### PR TITLE
Scanning the local mcpconfig

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ramparts"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 authors = ["Sharath Rajasekar <sharath@getjavelin.com>"]
 description = "A CLI tool for scanning Model Context Protocol (MCP) servers"


### PR DESCRIPTION
Add scan-config command for IDE MCP server discovery
Summary
Automatically discover and scan MCP servers configured in popular IDEs without manually specifying URLs.
Changes
New command: ramparts scan-config
Multi-IDE support: Cursor, VS Code, Neovim, Helix configuration files
Auto-discovery: Scans ~/.cursor/mcp.json, ~/.vscode/mcp.json, etc.
Configuration merging: Global + per-server settings with proper precedence