### PR TITLE
Feature/javelin api key header support

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -96,13 +96,13 @@ impl MCPScannerCore {
         // Handle auth headers with minimal conversion for Javelin API key
         if let Some(auth_headers) = &request.auth_headers {
             let mut headers = auth_headers.clone();
-            
+
             // If we have x-javelin-api-key, add the formats that work with Javelin MCP
             if let Some(api_key) = auth_headers.get("x-javelin-api-key") {
                 headers.insert("x-javelin-apikey".to_string(), api_key.clone());
                 headers.insert("authorization".to_string(), format!("Bearer {}", api_key));
             }
-            
+
             builder = builder.auth_headers(Some(headers));
         }
 
@@ -393,7 +393,7 @@ mod tests {
         };
 
         let options = core.parse_scan_options(&request); // No conversion for test
-        // These will use default values from config
+                                                         // These will use default values from config
         assert!(options.timeout > 0);
         assert!(options.http_timeout > 0);
         assert!(!options.detailed); // Default is false

--- a/src/core.rs
+++ b/src/core.rs
@@ -99,8 +99,16 @@ impl MCPScannerCore {
 
             // If we have x-javelin-api-key, add the formats that work with Javelin MCP
             if let Some(api_key) = auth_headers.get("x-javelin-api-key") {
-                headers.insert("x-javelin-apikey".to_string(), api_key.clone());
-                headers.insert("authorization".to_string(), format!("Bearer {}", api_key));
+                // Only proceed if the API key is not empty
+                if !api_key.trim().is_empty() {
+                    // Add x-javelin-apikey format
+                    headers.insert("x-javelin-apikey".to_string(), api_key.clone());
+
+                    // Only add authorization header if one doesn't already exist
+                    if !headers.contains_key("authorization") {
+                        headers.insert("authorization".to_string(), format!("Bearer {}", api_key));
+                    }
+                }
             }
 
             builder = builder.auth_headers(Some(headers));

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,12 +4,13 @@ use crate::core::{
 };
 use axum::{
     extract::State,
-    http::{Method, StatusCode},
+    http::{HeaderMap, Method, StatusCode},
     response::Json,
     routing::{get, post},
     Router,
 };
 use serde_json::{json, Value};
+use std::collections::HashMap;
 use std::sync::Arc;
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::trace::TraceLayer;
@@ -190,8 +191,27 @@ async fn api_docs() -> Json<Value> {
 
 async fn scan_endpoint(
     State(state): State<ServerState>,
-    Json(request): Json<ScanRequest>,
+    headers: HeaderMap,
+    Json(mut request): Json<ScanRequest>,
 ) -> Result<Json<ScanResponse>, (StatusCode, Json<Value>)> {
+    // Extract Javelin API key from headers and add to auth_headers if not present
+    if let Some(api_key) = headers.get("x-javelin-apikey").and_then(|h| h.to_str().ok()) {
+        debug!("Extracted Javelin API key from X-Javelin-Apikey header");
+        
+        // Initialize auth_headers if it doesn't exist
+        if request.auth_headers.is_none() {
+            request.auth_headers = Some(HashMap::new());
+        }
+        
+        // Add the API key to auth_headers if not already present
+        if let Some(ref mut auth_headers) = request.auth_headers {
+            if !auth_headers.contains_key("x-javelin-api-key") {
+                auth_headers.insert("x-javelin-api-key".to_string(), api_key.to_string());
+                debug!("Added API key to auth_headers for conversion");
+            }
+        }
+    }
+
     // Input validation
     if request.url.is_empty() {
         return Err((
@@ -259,8 +279,20 @@ async fn scan_endpoint(
 
 async fn validate_endpoint(
     State(state): State<ServerState>,
-    Json(request): Json<ScanRequest>,
+    headers: HeaderMap,
+    Json(mut request): Json<ScanRequest>,
 ) -> Result<Json<ValidationResponse>, (StatusCode, Json<Value>)> {
+    // Extract Javelin API key from headers and add to auth_headers if not present
+    if let Some(api_key) = headers.get("x-javelin-apikey").and_then(|h| h.to_str().ok()) {
+        if request.auth_headers.is_none() {
+            request.auth_headers = Some(HashMap::new());
+        }
+        if let Some(ref mut auth_headers) = request.auth_headers {
+            if !auth_headers.contains_key("x-javelin-api-key") {
+                auth_headers.insert("x-javelin-api-key".to_string(), api_key.to_string());
+            }
+        }
+    }
     debug!("Received validation request");
 
     let response = state.core.validate_config(&request);
@@ -289,8 +321,22 @@ async fn validate_endpoint(
 
 async fn batch_scan_endpoint(
     State(state): State<ServerState>,
-    Json(request): Json<BatchScanRequest>,
+    headers: HeaderMap,
+    Json(mut request): Json<BatchScanRequest>,
 ) -> Result<Json<BatchScanResponse>, (StatusCode, Json<Value>)> {
+    // Extract Javelin API key from headers and add to batch scan options
+    if let Some(api_key) = headers.get("x-javelin-apikey").and_then(|h| h.to_str().ok()) {
+        if let Some(ref mut options) = request.options {
+            if options.auth_headers.is_none() {
+                options.auth_headers = Some(HashMap::new());
+            }
+            if let Some(ref mut auth_headers) = options.auth_headers {
+                if !auth_headers.contains_key("x-javelin-api-key") {
+                    auth_headers.insert("x-javelin-api-key".to_string(), api_key.to_string());
+                }
+            }
+        }
+    }
     if request.urls.is_empty() {
         return Err((
             StatusCode::BAD_REQUEST,

--- a/src/server.rs
+++ b/src/server.rs
@@ -195,14 +195,17 @@ async fn scan_endpoint(
     Json(mut request): Json<ScanRequest>,
 ) -> Result<Json<ScanResponse>, (StatusCode, Json<Value>)> {
     // Extract Javelin API key from headers and add to auth_headers if not present
-    if let Some(api_key) = headers.get("x-javelin-apikey").and_then(|h| h.to_str().ok()) {
+    if let Some(api_key) = headers
+        .get("x-javelin-apikey")
+        .and_then(|h| h.to_str().ok())
+    {
         debug!("Extracted Javelin API key from X-Javelin-Apikey header");
-        
+
         // Initialize auth_headers if it doesn't exist
         if request.auth_headers.is_none() {
             request.auth_headers = Some(HashMap::new());
         }
-        
+
         // Add the API key to auth_headers if not already present
         if let Some(ref mut auth_headers) = request.auth_headers {
             if !auth_headers.contains_key("x-javelin-api-key") {
@@ -283,7 +286,10 @@ async fn validate_endpoint(
     Json(mut request): Json<ScanRequest>,
 ) -> Result<Json<ValidationResponse>, (StatusCode, Json<Value>)> {
     // Extract Javelin API key from headers and add to auth_headers if not present
-    if let Some(api_key) = headers.get("x-javelin-apikey").and_then(|h| h.to_str().ok()) {
+    if let Some(api_key) = headers
+        .get("x-javelin-apikey")
+        .and_then(|h| h.to_str().ok())
+    {
         if request.auth_headers.is_none() {
             request.auth_headers = Some(HashMap::new());
         }
@@ -325,7 +331,10 @@ async fn batch_scan_endpoint(
     Json(mut request): Json<BatchScanRequest>,
 ) -> Result<Json<BatchScanResponse>, (StatusCode, Json<Value>)> {
     // Extract Javelin API key from headers and add to batch scan options
-    if let Some(api_key) = headers.get("x-javelin-apikey").and_then(|h| h.to_str().ok()) {
+    if let Some(api_key) = headers
+        .get("x-javelin-apikey")
+        .and_then(|h| h.to_str().ok())
+    {
         if let Some(ref mut options) = request.options {
             if options.auth_headers.is_none() {
                 options.auth_headers = Some(HashMap::new());

--- a/src/server.rs
+++ b/src/server.rs
@@ -93,6 +93,34 @@ impl MCPScannerServer {
     }
 }
 
+/// Helper function to extract Javelin API key from headers and add to auth_headers
+fn extract_and_add_api_key(
+    headers: &HeaderMap,
+    auth_headers: &mut Option<HashMap<String, String>>,
+) {
+    if let Some(api_key) = headers
+        .get("x-javelin-apikey")
+        .and_then(|h| h.to_str().ok())
+        .filter(|key| !key.trim().is_empty())
+    // Filter out empty keys
+    {
+        debug!("Extracted Javelin API key from X-Javelin-Apikey header");
+
+        // Initialize auth_headers if it doesn't exist
+        if auth_headers.is_none() {
+            *auth_headers = Some(HashMap::new());
+        }
+
+        // Add the API key to auth_headers if not already present
+        if let Some(ref mut headers_map) = auth_headers {
+            if !headers_map.contains_key("x-javelin-api-key") {
+                headers_map.insert("x-javelin-api-key".to_string(), api_key.to_string());
+                debug!("Added API key to auth_headers for conversion");
+            }
+        }
+    }
+}
+
 async fn health_check() -> Json<Value> {
     Json(json!({
         "status": "healthy",
@@ -194,26 +222,8 @@ async fn scan_endpoint(
     headers: HeaderMap,
     Json(mut request): Json<ScanRequest>,
 ) -> Result<Json<ScanResponse>, (StatusCode, Json<Value>)> {
-    // Extract Javelin API key from headers and add to auth_headers if not present
-    if let Some(api_key) = headers
-        .get("x-javelin-apikey")
-        .and_then(|h| h.to_str().ok())
-    {
-        debug!("Extracted Javelin API key from X-Javelin-Apikey header");
-
-        // Initialize auth_headers if it doesn't exist
-        if request.auth_headers.is_none() {
-            request.auth_headers = Some(HashMap::new());
-        }
-
-        // Add the API key to auth_headers if not already present
-        if let Some(ref mut auth_headers) = request.auth_headers {
-            if !auth_headers.contains_key("x-javelin-api-key") {
-                auth_headers.insert("x-javelin-api-key".to_string(), api_key.to_string());
-                debug!("Added API key to auth_headers for conversion");
-            }
-        }
-    }
+    // Extract Javelin API key from headers using helper function
+    extract_and_add_api_key(&headers, &mut request.auth_headers);
 
     // Input validation
     if request.url.is_empty() {
@@ -285,20 +295,9 @@ async fn validate_endpoint(
     headers: HeaderMap,
     Json(mut request): Json<ScanRequest>,
 ) -> Result<Json<ValidationResponse>, (StatusCode, Json<Value>)> {
-    // Extract Javelin API key from headers and add to auth_headers if not present
-    if let Some(api_key) = headers
-        .get("x-javelin-apikey")
-        .and_then(|h| h.to_str().ok())
-    {
-        if request.auth_headers.is_none() {
-            request.auth_headers = Some(HashMap::new());
-        }
-        if let Some(ref mut auth_headers) = request.auth_headers {
-            if !auth_headers.contains_key("x-javelin-api-key") {
-                auth_headers.insert("x-javelin-api-key".to_string(), api_key.to_string());
-            }
-        }
-    }
+    // Extract Javelin API key from headers using helper function
+    extract_and_add_api_key(&headers, &mut request.auth_headers);
+
     debug!("Received validation request");
 
     let response = state.core.validate_config(&request);
@@ -330,28 +329,23 @@ async fn batch_scan_endpoint(
     headers: HeaderMap,
     Json(mut request): Json<BatchScanRequest>,
 ) -> Result<Json<BatchScanResponse>, (StatusCode, Json<Value>)> {
-    // Extract Javelin API key from headers and add to batch scan options
-    if let Some(api_key) = headers
-        .get("x-javelin-apikey")
-        .and_then(|h| h.to_str().ok())
-    {
-        if let Some(ref mut options) = request.options {
-            if options.auth_headers.is_none() {
-                options.auth_headers = Some(HashMap::new());
-            }
-            if let Some(ref mut auth_headers) = options.auth_headers {
-                if !auth_headers.contains_key("x-javelin-api-key") {
-                    auth_headers.insert("x-javelin-api-key".to_string(), api_key.to_string());
-                }
-            }
-        }
+    // Fix critical bug: Handle API key even when options is None
+    if request.options.is_none() {
+        // Create default options if they don't exist
+        request.options = Some(ScanRequest::default());
     }
+
+    // Extract Javelin API key from headers using helper function
+    if let Some(ref mut options) = request.options {
+        extract_and_add_api_key(&headers, &mut options.auth_headers);
+    }
+
     if request.urls.is_empty() {
         return Err((
             StatusCode::BAD_REQUEST,
             Json(json!({
                 "success": false,
-                "error": "URLs array is required",
+                "error": "At least one URL is required",
                 "timestamp": chrono::Utc::now().to_rfc3339()
             })),
         ));
@@ -364,14 +358,19 @@ async fn batch_scan_endpoint(
 
     let response = state.core.batch_scan(request).await;
 
-    if !response.success {
-        error!(
-            "Batch scan failed: {} successful, {} failed",
-            response.successful, response.failed
-        );
+    if response.success {
+        Ok(Json(response))
+    } else {
+        error!("Batch scan failed");
+        Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "success": false,
+                "error": "Batch scan failed",
+                "timestamp": response.timestamp
+            })),
+        ))
     }
-
-    Ok(Json(response))
 }
 
 // Tests removed for now - would need axum-test dependency


### PR DESCRIPTION
Extract X-Javelin-Apikey from HTTP headers in scan endpoints
Convert x-javelin-api-key to multiple header formats for MCP compatibility
Support both header-based and body-based API key authentication