### PR TITLE
fix: STDIO server detection for Cursor/Windsurf/Gemini configs

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1104,6 +1104,10 @@ impl MCPConfigManager {
 
             // Windsurf
             paths.push((
+                home_dir.join(".windsurf").join("mcp.json"),
+                MCPClient::Windsurf,
+            ));
+            paths.push((
                 home_dir
                     .join(".codeium")
                     .join("windsurf")
@@ -1374,11 +1378,32 @@ impl MCPConfigManager {
                     }
                 }
                 // Claude Code uses .claude.json
-                if filename == ".claude.json" {
+                else if filename == ".claude.json" {
                     if let Ok(cursor_config) = serde_json::from_str::<CursorMCPConfig>(&content) {
                         debug!("Parsed as Claude Code configuration format");
                         return Ok(Self::convert_cursor_config(cursor_config));
                     }
+                }
+                // Claude mcp.json files use Cursor format
+                else if filename == "mcp.json" {
+                    if let Ok(cursor_config) = serde_json::from_str::<CursorMCPConfig>(&content) {
+                        debug!("Parsed as Claude MCP configuration format");
+                        return Ok(Self::convert_cursor_config(cursor_config));
+                    }
+                }
+            }
+            Some(MCPClient::Windsurf) => {
+                // Windsurf uses Cursor-compatible format
+                if let Ok(cursor_config) = serde_json::from_str::<CursorMCPConfig>(&content) {
+                    debug!("Parsed as Windsurf MCP configuration format");
+                    return Ok(Self::convert_cursor_config(cursor_config));
+                }
+            }
+            Some(MCPClient::Gemini) => {
+                // Gemini uses Cursor-compatible format
+                if let Ok(cursor_config) = serde_json::from_str::<CursorMCPConfig>(&content) {
+                    debug!("Parsed as Gemini MCP configuration format");
+                    return Ok(Self::convert_cursor_config(cursor_config));
                 }
             }
             Some(MCPClient::VSCode) => {
@@ -1439,10 +1464,21 @@ impl MCPConfigManager {
             mcp_servers
                 .into_iter()
                 .filter_map(|(name, server_config)| {
-                    // Use explicit URL first, then build from transport config
-                    let url = if let Some(url) = server_config.url {
-                        url
+                    // Use explicit URL first, then build from transport config, then handle STDIO servers
+                    if let Some(url) = server_config.url {
+                        // HTTP server with explicit URL
+                        Some(MCPServerConfig {
+                            name: Some(name),
+                            url: Some(url),
+                            command: None,
+                            args: None,
+                            env: None,
+                            description: server_config.description,
+                            auth_headers: server_config.headers,
+                            options: None,
+                        })
                     } else if let Some(transport) = &server_config.transport {
+                        // HTTP server with transport configuration
                         let host = transport.host.as_deref().unwrap_or("localhost");
                         let port = transport.port.unwrap_or(8080);
                         #[allow(clippy::match_same_arms)]
@@ -1451,22 +1487,34 @@ impl MCPConfigManager {
                             Some("https") => "https",
                             _ => "http",
                         };
-                        format!("{scheme}://{host}:{port}")
+                        let url = format!("{scheme}://{host}:{port}");
+
+                        Some(MCPServerConfig {
+                            name: Some(name),
+                            url: Some(url),
+                            command: None,
+                            args: None,
+                            env: None,
+                            description: server_config.description,
+                            auth_headers: server_config.headers,
+                            options: None,
+                        })
+                    } else if server_config.command.is_some() {
+                        // STDIO server with command configuration
+                        Some(MCPServerConfig {
+                            name: Some(name.clone()),
+                            url: None, // STDIO servers don't use URLs
+                            command: server_config.command,
+                            args: server_config.args,
+                            env: server_config.env,
+                            description: server_config.description,
+                            auth_headers: server_config.headers,
+                            options: None,
+                        })
                     } else {
                         // Skip servers without proper configuration
-                        return None;
-                    };
-
-                    Some(MCPServerConfig {
-                        name: Some(name),
-                        url: Some(url),
-                        command: None,
-                        args: None,
-                        env: None,
-                        description: server_config.description,
-                        auth_headers: server_config.headers, // Now supports auth headers at server level
-                        options: None, // Could be extended to convert any server-specific options
-                    })
+                        None
+                    }
                 })
                 .collect()
         });
@@ -1528,27 +1576,34 @@ impl MCPConfigManager {
             mcp_servers
                 .into_iter()
                 .filter_map(|(name, server_config)| {
-                    // Use explicit URL if provided, otherwise build from command
-                    let url = if let Some(url) = server_config.url {
-                        url
+                    if let Some(url) = server_config.url {
+                        // HTTP server with explicit URL
+                        Some(MCPServerConfig {
+                            name: Some(name),
+                            url: Some(url),
+                            command: None,
+                            args: None,
+                            env: server_config.env,
+                            description: None, // VS Code settings don't typically include descriptions
+                            auth_headers: None,
+                            options: None,
+                        })
                     } else if server_config.command.is_some() {
-                        // For command-based servers, create a placeholder URL
-                        format!("stdio://{name}")
+                        // STDIO server with command configuration
+                        Some(MCPServerConfig {
+                            name: Some(name),
+                            url: None, // STDIO servers don't use URLs
+                            command: server_config.command,
+                            args: server_config.args,
+                            env: server_config.env,
+                            description: None, // VS Code settings don't typically include descriptions
+                            auth_headers: None,
+                            options: None,
+                        })
                     } else {
-                        // Skip servers without explicit configuration
-                        return None;
-                    };
-
-                    Some(MCPServerConfig {
-                        name: Some(name),
-                        url: Some(url),
-                        command: None,
-                        args: None,
-                        env: None,
-                        description: None, // VS Code settings don't typically include descriptions
-                        auth_headers: None,
-                        options: None,
-                    })
+                        // Skip servers without proper configuration
+                        None
+                    }
                 })
                 .collect()
         });
@@ -1566,27 +1621,34 @@ impl MCPConfigManager {
             servers
                 .into_iter()
                 .filter_map(|(name, server_config)| {
-                    // Use explicit URL if provided, otherwise build from command
-                    let url = if let Some(url) = server_config.url {
-                        url
+                    if let Some(url) = server_config.url {
+                        // HTTP server with explicit URL
+                        Some(MCPServerConfig {
+                            name: Some(name),
+                            url: Some(url),
+                            command: None,
+                            args: None,
+                            env: server_config.env,
+                            description: None, // VS Code MCP format doesn't include descriptions
+                            auth_headers: server_config.headers,
+                            options: None,
+                        })
                     } else if server_config.command.is_some() {
-                        // For command-based servers, create a placeholder URL
-                        format!("stdio://{name}")
+                        // STDIO server with command configuration
+                        Some(MCPServerConfig {
+                            name: Some(name),
+                            url: None, // STDIO servers don't use URLs
+                            command: server_config.command,
+                            args: server_config.args,
+                            env: server_config.env,
+                            description: None, // VS Code MCP format doesn't include descriptions
+                            auth_headers: server_config.headers,
+                            options: None,
+                        })
                     } else {
-                        // Skip servers without explicit configuration
-                        return None;
-                    };
-
-                    Some(MCPServerConfig {
-                        name: Some(name),
-                        url: Some(url),
-                        command: None,
-                        args: None,
-                        env: None,
-                        description: None, // VS Code MCP format doesn't include descriptions
-                        auth_headers: server_config.headers,
-                        options: None,
-                    })
+                        // Skip servers without proper configuration
+                        None
+                    }
                 })
                 .collect()
         });

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1159,70 +1159,6 @@ fn print_multi_server_text(results: &[ScanResult]) {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::{error_utils, format_status, Timer};
-    use anyhow::anyhow;
-
-    #[test]
-    fn test_timer_functionality() {
-        let timer = Timer::start();
-        std::thread::sleep(std::time::Duration::from_millis(10));
-        let elapsed = timer.elapsed_ms();
-
-        assert!(elapsed >= 10);
-        println!("Timer elapsed: {elapsed}ms");
-    }
-
-    #[test]
-    fn test_error_utils() {
-        // Test format_error
-        let error_msg = error_utils::format_error("Test operation", "Something went wrong");
-        assert_eq!(error_msg, "Test operation failed: Something went wrong");
-
-        // Test wrap_error with success
-        let result: Result<i32, anyhow::Error> = Ok(42);
-        let wrapped = error_utils::wrap_error(result, "Test context");
-        assert!(wrapped.is_ok());
-        assert_eq!(wrapped.unwrap(), 42);
-
-        // Test wrap_error with failure
-        let result: Result<i32, anyhow::Error> = Err(anyhow!("Original error"));
-        let wrapped = error_utils::wrap_error(result, "Test context");
-        assert!(wrapped.is_err());
-        let error_msg = wrapped.unwrap_err().to_string();
-        assert!(error_msg.contains("Test context"));
-        assert!(error_msg.contains("Original error"));
-    }
-
-    // TODO: Add test for track_performance when async closure type inference is resolved
-
-    #[test]
-    fn test_format_status() {
-        use crate::types::ScanStatus;
-
-        let success = format_status(&ScanStatus::Success);
-        assert!(success.contains("SUCCESS"));
-
-        let failed = format_status(&ScanStatus::Failed("Test error".to_string()));
-        assert!(failed.contains("FAILED"));
-        assert!(failed.contains("Test error"));
-
-        let timeout = format_status(&ScanStatus::Timeout);
-        assert!(timeout.contains("TIMEOUT"));
-
-        let connection_error = format_status(&ScanStatus::ConnectionError(
-            "Connection failed".to_string(),
-        ));
-        assert!(connection_error.contains("CONNECTION ERROR"));
-        assert!(connection_error.contains("Connection failed"));
-
-        let auth_error = format_status(&ScanStatus::AuthenticationError("Auth failed".to_string()));
-        assert!(auth_error.contains("AUTHENTICATION ERROR"));
-        assert!(auth_error.contains("Auth failed"));
-    }
-}
-
 /// Generate a detailed markdown report from scan results
 #[allow(clippy::too_many_lines)]
 pub fn generate_markdown_report(results: &[ScanResult]) -> Result<String> {
@@ -1602,4 +1538,68 @@ pub fn write_markdown_report(results: &[ScanResult]) -> Result<String> {
         .map_err(|e| anyhow!("Failed to write report to {}: {}", filename, e))?;
 
     Ok(filename)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{error_utils, format_status, Timer};
+    use anyhow::anyhow;
+
+    #[test]
+    fn test_timer_functionality() {
+        let timer = Timer::start();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let elapsed = timer.elapsed_ms();
+
+        assert!(elapsed >= 10);
+        println!("Timer elapsed: {elapsed}ms");
+    }
+
+    #[test]
+    fn test_error_utils() {
+        // Test format_error
+        let error_msg = error_utils::format_error("Test operation", "Something went wrong");
+        assert_eq!(error_msg, "Test operation failed: Something went wrong");
+
+        // Test wrap_error with success
+        let result: Result<i32, anyhow::Error> = Ok(42);
+        let wrapped = error_utils::wrap_error(result, "Test context");
+        assert!(wrapped.is_ok());
+        assert_eq!(wrapped.unwrap(), 42);
+
+        // Test wrap_error with failure
+        let result: Result<i32, anyhow::Error> = Err(anyhow!("Original error"));
+        let wrapped = error_utils::wrap_error(result, "Test context");
+        assert!(wrapped.is_err());
+        let error_msg = wrapped.unwrap_err().to_string();
+        assert!(error_msg.contains("Test context"));
+        assert!(error_msg.contains("Original error"));
+    }
+
+    // TODO: Add test for track_performance when async closure type inference is resolved
+
+    #[test]
+    fn test_format_status() {
+        use crate::types::ScanStatus;
+
+        let success = format_status(&ScanStatus::Success);
+        assert!(success.contains("SUCCESS"));
+
+        let failed = format_status(&ScanStatus::Failed("Test error".to_string()));
+        assert!(failed.contains("FAILED"));
+        assert!(failed.contains("Test error"));
+
+        let timeout = format_status(&ScanStatus::Timeout);
+        assert!(timeout.contains("TIMEOUT"));
+
+        let connection_error = format_status(&ScanStatus::ConnectionError(
+            "Connection failed".to_string(),
+        ));
+        assert!(connection_error.contains("CONNECTION ERROR"));
+        assert!(connection_error.contains("Connection failed"));
+
+        let auth_error = format_status(&ScanStatus::AuthenticationError("Auth failed".to_string()));
+        assert!(auth_error.contains("AUTHENTICATION ERROR"));
+        assert!(auth_error.contains("Auth failed"));
+    }
 }


### PR DESCRIPTION
- Add STDIO server support to convert_cursor_config()
- Fix VS Code converters creating deprecated stdio: URLs
- Add Windsurf path detection to config loader