### PR TITLE
feat: MCP returnPrompts mode - expose LLM requests without execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -102,22 +113,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -131,6 +142,9 @@ name = "arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "array-bytes"
@@ -239,7 +253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.4.5",
  "axum-macros",
  "bytes",
  "futures-util",
@@ -249,7 +263,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
@@ -261,7 +275,41 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
+dependencies = [
+ "axum-core 0.5.2",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -276,6 +324,26 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
+dependencies = [
+ "bytes",
+ "futures-core",
  "http",
  "http-body",
  "http-body-util",
@@ -433,11 +501,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
-name = "cc"
-version = "1.2.31"
+name = "bzip2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a42d84bb6b69d3a8b3eaacf0d88f179e1929695e1ad012b6cf64d9caaa5fd2"
+checksum = "bea8dcd42434048e4f7a304411d9273a411f647446c1234a65ce0554923f4cff"
 dependencies = [
+ "libbz2-rs-sys",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
+dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -469,10 +548,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "4.5.42"
+name = "cipher"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed87a9d530bb41a67537289bafcac159cb3ee28460e0a4571123d2a778a6a882"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50fd97c9dc2399518aa331917ac6f274280ec5eb34e555dd291899745c48ec6f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -480,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.42"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f4f3f3c77c94aff3c7e9aac9a2ca1974a5adf392a8bb751e827d6d127ab966"
+checksum = "c35b5830294e1fa0462034af85cc95225a4cb07092c088c55bda3147cfcd8f65"
 dependencies = [
  "anstream",
  "anstyle",
@@ -579,6 +668,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,7 +756,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli 0.31.1",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "log",
  "pulley-interpreter",
  "regalloc2",
@@ -819,12 +914,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a79c4acb1fd5fa3d9304be4c76e031c54d2e92d172a393e24b19a14fe8532fe9"
+checksum = "d6b136475da5ef7b6ac596c0e956e37bad51b85b987ff3d5e230e964936736b2"
 dependencies = [
- "darling_core 0.21.0",
- "darling_macro 0.21.0",
+ "darling_core 0.21.1",
+ "darling_macro 0.21.1",
 ]
 
 [[package]]
@@ -843,9 +938,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74875de90daf30eb59609910b84d4d368103aaec4c924824c6799b28f77d6a1d"
+checksum = "b44ad32f92b75fb438b04b68547e521a548be8acc339a6dacc4a7121488f53e6"
 dependencies = [
  "fnv",
  "ident_case",
@@ -868,11 +963,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79f8e61677d5df9167cd85265f8e5f64b215cdea3fb55eebc3e622e44c7a146"
+checksum = "2b5be8a7a562d315a5b92a630c30cec6bcf663e6673f00fbb69cca66a6f521b9"
 dependencies = [
- "darling_core 0.21.0",
+ "darling_core 0.21.1",
  "quote",
  "syn 2.0.104",
 ]
@@ -882,6 +977,12 @@ name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
+name = "deflate64"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
 
 [[package]]
 name = "der"
@@ -915,6 +1016,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1096,6 +1208,17 @@ checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+dependencies = [
+ "crc32fast",
+ "libz-rs-sys",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1334,9 +1457,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash",
  "serde",
@@ -1673,8 +1796,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "serde",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1730,6 +1862,16 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jobserver"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1789,10 +1931,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "libbz2-rs-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
+
+[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "liblzma"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0791ab7e08ccc8e0ce893f6906eb2703ed8739d8e89b57c0714e71bad09024c8"
+dependencies = [
+ "liblzma-sys",
+]
+
+[[package]]
+name = "liblzma-sys"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b9596486f6d60c3bbe644c0e1be1aa6ccc472ad630fe8927b456973d7cb736"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "libm"
@@ -1808,6 +1976,15 @@ checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags",
  "libc",
+]
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "172a788537a2221661b480fee8dc5f96c580eb34fa88764d3205dc356c7e4221"
+dependencies = [
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1866,18 +2043,18 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "logos"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6f536c1af4c7cc81edf73da1f8029896e7e1e16a219ef09b184e76a296f3db"
+checksum = "ff472f899b4ec2d99161c51f60ff7075eeb3097069a36050d8037a6325eb8154"
 dependencies = [
  "logos-derive",
 ]
 
 [[package]]
 name = "logos-codegen"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189bbfd0b61330abea797e5e9276408f2edbe4f822d7ad08685d67419aafb34e"
+checksum = "192a3a2b90b0c05b27a0b2c43eecdb7c415e29243acc3f89cc8247a5b693045c"
 dependencies = [
  "beef",
  "fnv",
@@ -1891,9 +2068,9 @@ dependencies = [
 
 [[package]]
 name = "logos-derive"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebfe8e1a19049ddbfccbd14ac834b215e11b85b90bab0c2dba7c7b92fb5d5cba"
+checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
 dependencies = [
  "logos-codegen",
 ]
@@ -1933,6 +2110,12 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
@@ -2140,7 +2323,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "crc32fast",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "indexmap 2.10.0",
  "memchr",
 ]
@@ -2259,6 +2442,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2351,6 +2544,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "postcard"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2376,6 +2575,12 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppmd-rust"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c834641d8ad1b348c9ee86dec3b9840d805acd5f24daa5f90c788951a52ff59b"
 
 [[package]]
 name = "ppv-lite86"
@@ -2619,7 +2824,7 @@ name = "ramparts"
 version = "0.7.0"
 dependencies = [
  "anyhow",
- "axum",
+ "axum 0.7.9",
  "chrono",
  "clap",
  "colored",
@@ -2632,6 +2837,7 @@ dependencies = [
  "rand 0.8.5",
  "reqwest",
  "rmcp",
+ "schemars",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2641,6 +2847,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-test",
+ "tower 0.4.13",
  "tower-http 0.5.2",
  "tracing",
  "tracing-subscriber",
@@ -2755,7 +2962,7 @@ checksum = "5216b1837de2149f8bc8e6d5f88a9326b63b8c836ed58ce4a0a29ec736a59734"
 dependencies = [
  "allocator-api2",
  "bumpalo",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "log",
  "rustc-hash 2.1.1",
  "smallvec",
@@ -2835,7 +3042,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower",
+ "tower 0.5.2",
  "tower-http 0.6.6",
  "tower-service",
  "url",
@@ -2876,13 +3083,18 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f0d0d5493be0d181a62db489eab7838669b81885972ca00ceca893cf6ac2883"
 dependencies = [
+ "axum 0.8.4",
  "base64 0.22.1",
+ "bytes",
  "chrono",
  "futures",
  "http",
+ "http-body",
+ "http-body-util",
  "paste",
  "pin-project-lite",
  "process-wrap",
+ "rand 0.9.2",
  "reqwest",
  "rmcp-macros",
  "schemars",
@@ -2893,7 +3105,9 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tower-service",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -2902,7 +3116,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4aebc912b8fa7d54999adc4e45601d1d95fe458f97eb0a1277eddcd6382cf4b1"
 dependencies = [
- "darling 0.21.0",
+ "darling 0.21.1",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -3068,9 +3282,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -3284,10 +3498,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "slab"
-version = "0.4.10"
+name = "simd-adler32"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -3766,6 +3986,17 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
@@ -3810,7 +4041,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
@@ -4181,7 +4412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b51cb03afce7964bbfce46602d6cb358726f36430b6ba084ac6020d8ce5bc102"
 dependencies = [
  "bitflags",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "indexmap 2.10.0",
  "semver",
  "serde",
@@ -4210,7 +4441,7 @@ dependencies = [
  "bumpalo",
  "cc",
  "cfg-if",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "indexmap 2.10.0",
  "libc",
  "log",
@@ -4819,9 +5050,9 @@ dependencies = [
 
 [[package]]
 name = "yara-x"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad19e8ae5b6542e06cdf9ffd62690231b7b9b14ae717a8d94b772713d04beefb"
+checksum = "7721a29d854afd9e3c8550652c841223331d07d1803c0ac33ca749a50de6b757"
 dependencies = [
  "aho-corasick",
  "annotate-snippets",
@@ -4879,13 +5110,14 @@ dependencies = [
  "yara-x-macros",
  "yara-x-parser",
  "yara-x-proto",
+ "zip",
 ]
 
 [[package]]
 name = "yara-x-macros"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88535b229ed05a4fce90def2b855fbec9c82463b02ec64db2312ea0702ed9288"
+checksum = "109381e0ca8acc458e2b1a7defba3186b60adde06711ee6733a3f71e1772cc9b"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -4895,9 +5127,9 @@ dependencies = [
 
 [[package]]
 name = "yara-x-parser"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f5eea847933138566f4905487f8ef0d7a335d129852e96877ef3890b08178ce"
+checksum = "95b396a3763c0f818535ee4eab5962069ee98da536d071a8268a6561fdfa0ea6"
 dependencies = [
  "ascii_tree",
  "bitflags",
@@ -4913,9 +5145,9 @@ dependencies = [
 
 [[package]]
 name = "yara-x-proto"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a70cba12d8c2ec2c4fc0113cd1924d3de49dde57ab0784ca293d9287cb7e34d9"
+checksum = "9486aaebceda13d8069f6bdcc1d3011a82b0ca9d62dfe759fffbe46a45d68740"
 dependencies = [
  "protobuf",
  "protobuf-codegen",
@@ -4991,6 +5223,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "zerotrie"
@@ -5005,9 +5251,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -5023,4 +5269,77 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "zip"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aed4ac33e8eb078c89e6cbb1d5c4c7703ec6d299fc3e7c3695af8f8b423468b"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "deflate64",
+ "flate2",
+ "getrandom 0.3.3",
+ "hmac",
+ "indexmap 2.10.0",
+ "liblzma",
+ "memchr",
+ "pbkdf2",
+ "ppmd-rust",
+ "sha1",
+ "time",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "626bd9fa9734751fc50d6060752170984d7053f5a39061f524cda68023d4db8a"
+
+[[package]]
+name = "zopfli"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.15+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
+schemars = "1"
 
 # Logging
 tracing = "0.1"
@@ -80,13 +81,33 @@ spinners = "4.1.1"
 # Web framework for microservice
 axum = { version = "0.7", features = ["macros"] }
 tower-http = { version = "0.5", features = ["cors", "trace"] }
+tower = "0.4"
 
 # JSON-RPC handling for microservice
 jsonrpc-core = "18.0"
 yara-x = { version = "1.4", optional = true }
 
 # Official Rust MCP SDK
-rmcp = { version = "0.3.2", features = ["client", "reqwest", "transport-child-process", "transport-streamable-http-client", "transport-sse-client", "transport-worker"] }
+# Official Rust MCP SDK (client + server)
+# Enable server + macros and server stdio transport for MCP server implementation
+rmcp = { version = "0.3.2", features = [
+    "client",
+    "server",
+    "macros",
+    "schemars",
+    "reqwest",
+    # client transports already used by scanner
+    "transport-child-process",
+    "transport-streamable-http-client",
+    "transport-sse-client",
+    "transport-worker",
+    # server transports for MCP server (starting with stdio)
+    "transport-io",
+    # add SSE and streamable HTTP server transports
+    "transport-sse-server",
+    "transport-streamable-http-server",
+    "transport-streamable-http-server-session"
+] }
 
 # Random number generation for request IDs
 rand = "0.8"

--- a/MCP-Dockerfile
+++ b/MCP-Dockerfile
@@ -1,0 +1,36 @@
+FROM rustlang/rust:nightly-slim AS builder
+
+WORKDIR /app
+
+# Cache deps and build
+COPY Cargo.toml Cargo.lock* ./
+COPY src ./src
+COPY rules ./rules
+COPY assets ./assets
+COPY build.rs ./
+
+RUN cargo build --release
+
+FROM ubuntu:24.04
+
+# Install Docker CLI only (will use host Docker daemon via socket)
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    curl \
+    gnupg \
+    lsb-release \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
+    && apt-get update \
+    && apt-get install -y docker-ce-cli \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY --from=builder /app/target/release/ramparts /app/
+COPY --from=builder /app/rules /app/rules
+
+# Default: run as MCP stdio server (MCP Toolkit/hosts connect over stdio)
+ENTRYPOINT ["/app/ramparts", "mcp-stdio"]
+
+

--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ ramparts scan-config --report
 
 > **💡 Did you know you can start Ramparts as a server?** Run `ramparts server` to get a REST API for continuous monitoring and CI/CD integration. See 📚 **[Ramparts Server Mode](docs/api.md)** 
 
+### Run as an MCP server (stdio)
+
+```bash
+ramparts mcp-stdio
+```
+
+When publishing to Docker MCP Toolkit, configure the container command to `ramparts mcp-stdio` so the toolkit connects via stdio. Use `MCP-Dockerfile` to make this the default.
+
 ## Example Output
 
 **Single server scan:**

--- a/docs/latest-formats.md
+++ b/docs/latest-formats.md
@@ -216,6 +216,16 @@ For command-line MCP servers:
 }
 ```
 
+### Containerized Servers (Docker MCP Toolkit)
+For servers running inside containers (e.g., Docker MCP Toolkit):
+```json
+{
+    "image": "ghcr.io/getjavelin/ramparts:latest",
+    "command": ["/app/ramparts", "mcp-stdio"],
+    "description": "Ramparts MCP server over stdio"
+}
+```
+
 ### HTTP Servers
 For HTTP-based MCP servers:
 ```json

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -162,6 +162,19 @@ ramparts scan "stdio:npx:mcp-server-commands"
 ramparts scan "stdio:python3:/path/to/server.py:--port:8080"
 ```
 
+### MCP stdio server exits immediately
+**Issue:**
+```bash
+Error: ConnectionClosed("initialized request")
+```
+
+**Cause:**
+- The MCP stdio server expects an MCP client to speak JSON-RPC over stdin/stdout. When run directly in a terminal, no `initialize` request is sent.
+
+**Fix:**
+- Run `ramparts mcp-stdio` under an MCP host (e.g., Docker MCP Toolkit, Cursor, Claude Desktop).
+- For local testing, use an MCP inspector or a small client that spawns the binary and sends `initialize`.
+
 **Issue: Environment variable issues**
 ```bash
 error: Missing required environment variables

--- a/src/core.rs
+++ b/src/core.rs
@@ -14,6 +14,8 @@ pub struct ScanRequest {
     pub detailed: Option<bool>,
     pub format: Option<String>,
     pub auth_headers: Option<HashMap<String, String>>,
+    /// If true, do not call the LLM; return prompts instead
+    pub return_prompts: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -115,6 +117,10 @@ impl MCPScannerCore {
             }
 
             builder = builder.auth_headers(Some(headers));
+        }
+
+        if let Some(rp) = request.return_prompts {
+            builder = builder.return_prompts(rp);
         }
 
         builder.build()
@@ -223,6 +229,7 @@ mod tests {
                 "Authorization".to_string(),
                 "Bearer token".to_string(),
             )])),
+            return_prompts: Some(false),
         };
 
         assert_eq!(request.url, "http://example.com");
@@ -287,6 +294,7 @@ mod tests {
             detailed: Some(false),
             format: Some("text".to_string()),
             auth_headers: None,
+            return_prompts: Some(false),
         };
 
         let request = BatchScanRequest {
@@ -414,6 +422,7 @@ mod tests {
                 "Authorization".to_string(),
                 "Bearer token".to_string(),
             )])),
+            return_prompts: Some(false),
         };
 
         let options = core.parse_scan_options(&request); // No conversion for test
@@ -434,6 +443,7 @@ mod tests {
             detailed: None,
             format: None,
             auth_headers: None,
+            return_prompts: None,
         };
 
         let options = core.parse_scan_options(&request); // No conversion for test

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -1,0 +1,216 @@
+use std::sync::Arc;
+
+use crate::core::{MCPScannerCore, ScanRequest};
+use crate::scanner::MCPScanner;
+use crate::types::ScanConfigBuilder;
+use rmcp::handler::server::tool::Parameters;
+use rmcp::schemars::JsonSchema;
+use rmcp::{
+    handler::server::router::tool::ToolRouter,
+    model::{CallToolResult, Content, ServerCapabilities, ServerInfo},
+    tool, tool_handler, tool_router,
+    transport::{
+        io::stdio,
+        sse_server::SseServer,
+        streamable_http_server::{
+            session::local::LocalSessionManager, tower::StreamableHttpService,
+            StreamableHttpServerConfig,
+        },
+    },
+    ErrorData, ServiceExt,
+};
+use serde::Deserialize;
+use std::future::Future;
+use tokio::sync::Mutex;
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+struct ScanParams {
+    url: String,
+    #[serde(default)]
+    detailed: bool,
+    #[serde(default)]
+    auth_headers: Option<std::collections::HashMap<String, String>>,
+    #[serde(default)]
+    format: Option<String>,
+    #[serde(default)]
+    timeout: Option<u64>,
+    #[serde(default, rename = "httpTimeout")]
+    http_timeout: Option<u64>,
+    /// If true, do not call the LLM; return prompts instead
+    #[serde(default, rename = "returnPrompts")]
+    return_prompts: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+struct ScanConfigParams {
+    #[serde(default)]
+    detailed: Option<bool>,
+    #[serde(default)]
+    auth_headers: Option<std::collections::HashMap<String, String>>,
+    #[serde(default)]
+    format: Option<String>,
+    #[serde(default)]
+    timeout: Option<u64>,
+    #[serde(default, rename = "httpTimeout")]
+    http_timeout: Option<u64>,
+    /// If true, do not call the LLM; return prompts instead
+    #[serde(default, rename = "returnPrompts")]
+    return_prompts: Option<bool>,
+}
+
+/// Minimal MCP server that exposes basic tools. Extend to integrate scanner endpoints as tools.
+#[derive(Clone)]
+pub struct RampartsMcpServer {
+    tool_router: ToolRouter<Self>,
+    counter: Arc<Mutex<i32>>,
+    core: Arc<MCPScannerCore>,
+}
+
+#[tool_router]
+impl RampartsMcpServer {
+    pub fn new() -> Self {
+        let core = MCPScannerCore::new().expect("core init");
+        Self {
+            tool_router: Self::tool_router(),
+            counter: Arc::new(Mutex::new(0)),
+            core: Arc::new(core),
+        }
+    }
+
+    #[tool(description = "Healthcheck for the Ramparts MCP server")]
+    async fn health(&self) -> Result<CallToolResult, ErrorData> {
+        Ok(CallToolResult::success(vec![Content::text("ok")]))
+    }
+
+    #[tool(description = "Increment an internal counter and return its value")]
+    async fn increment_counter(&self) -> Result<CallToolResult, ErrorData> {
+        let mut guard = self.counter.lock().await;
+        *guard += 1;
+        Ok(CallToolResult::success(vec![Content::text(
+            guard.to_string(),
+        )]))
+    }
+
+    #[tool(
+        name = "scan",
+        description = "Scan an MCP server URL and return security findings as JSON"
+    )]
+    async fn scan(&self, params: Parameters<ScanParams>) -> Result<CallToolResult, ErrorData> {
+        let p = params.0;
+        let request = ScanRequest {
+            url: p.url,
+            timeout: p.timeout,
+            http_timeout: p.http_timeout,
+            detailed: Some(p.detailed),
+            format: p.format,
+            auth_headers: p.auth_headers,
+            // Default to returning prompts (no LLM call) for MCP tool flow
+            return_prompts: Some(p.return_prompts.unwrap_or(true)),
+        };
+
+        let resp = self.core.scan(request).await;
+        if let Some(result) = resp.result {
+            let json = serde_json::to_string(&result)
+                .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+            Ok(CallToolResult::success(vec![Content::text(json)]))
+        } else {
+            Err(ErrorData::invalid_request(
+                resp.error.unwrap_or_else(|| "scan failed".to_string()),
+                None,
+            ))
+        }
+    }
+
+    // New: scan-config tool
+    #[tool(
+        name = "scan-config",
+        description = "Scan MCP servers from IDE configuration files and return results as JSON"
+    )]
+    async fn scan_config(
+        &self,
+        params: Parameters<ScanConfigParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let p = params.0;
+        let mut builder = ScanConfigBuilder::new();
+        if let Some(d) = p.detailed {
+            builder = builder.detailed(d);
+        }
+        if let Some(fmt) = p.format {
+            builder = builder.format(fmt);
+        }
+        if let Some(t) = p.timeout {
+            builder = builder.timeout(t);
+        }
+        if let Some(ht) = p.http_timeout {
+            builder = builder.http_timeout(ht);
+        }
+        if let Some(headers) = p.auth_headers {
+            builder = builder.auth_headers(Some(headers));
+        }
+        // Default to returning prompts (no LLM call) for MCP tool flow
+        builder = builder.return_prompts(p.return_prompts.unwrap_or(true));
+
+        let options = builder.build();
+        let scanner = MCPScanner::with_timeout(options.http_timeout)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let results = scanner
+            .scan_config_by_ide(options)
+            .await
+            .map_err(|e| ErrorData::invalid_request(e.to_string(), None))?;
+        let json = serde_json::to_string(&results)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+}
+
+#[tool_handler]
+impl rmcp::ServerHandler for RampartsMcpServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            instructions: Some("Ramparts MCP server".into()),
+            capabilities: ServerCapabilities::builder().enable_tools().build(),
+            ..Default::default()
+        }
+    }
+}
+
+/// Run the MCP server over stdio transport.
+pub async fn run_stdio_server() -> Result<(), Box<dyn std::error::Error>> {
+    let handler = RampartsMcpServer::new();
+    let service = handler.serve(stdio()).await?;
+    service.waiting().await?;
+    Ok(())
+}
+
+/// Run the MCP server over SSE transport (HTTP SSE endpoint)
+pub async fn run_sse_server(host: &str, port: u16) -> Result<(), Box<dyn std::error::Error>> {
+    let bind: std::net::SocketAddr = format!("{host}:{port}").parse()?;
+    let sse = SseServer::serve(bind).await?;
+    let _ct = sse.with_service(RampartsMcpServer::new);
+    // Keep the server alive until process exit
+    futures_util::future::pending::<()>().await;
+    Ok(())
+}
+
+/// Run the MCP server over streamable HTTP transport using a Tower service (Axum-compatible)
+pub async fn run_streamable_http_server(
+    host: &str,
+    port: u16,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use axum::routing::any_service;
+    use axum::Router;
+    use tower::ServiceBuilder;
+
+    let bind: std::net::SocketAddr = format!("{host}:{port}").parse()?;
+    let service: StreamableHttpService<RampartsMcpServer, LocalSessionManager> =
+        StreamableHttpService::new(
+            || Ok(RampartsMcpServer::new()),
+            std::sync::Arc::new(LocalSessionManager::default()),
+            StreamableHttpServerConfig::default(),
+        );
+
+    let app = Router::new().route("/", any_service(ServiceBuilder::new().service(service)));
+    let listener = tokio::net::TcpListener::bind(bind).await?;
+    axum::serve(listener, app).await?;
+    Ok(())
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -67,6 +67,8 @@ pub struct ScanConfigBuilder {
     detailed: bool,
     format: String,
     auth_headers: Option<HashMap<String, String>>,
+    // When true, do not call the LLM; instead, return the prompts that would be used
+    return_prompts: bool,
 }
 
 impl Default for ScanConfigBuilder {
@@ -77,6 +79,7 @@ impl Default for ScanConfigBuilder {
             detailed: false,
             format: "text".to_string(),
             auth_headers: None,
+            return_prompts: false,
         }
     }
 }
@@ -111,6 +114,11 @@ impl ScanConfigBuilder {
         self
     }
 
+    pub fn return_prompts(mut self, return_prompts: bool) -> Self {
+        self.return_prompts = return_prompts;
+        self
+    }
+
     pub fn build(self) -> ScanOptions {
         ScanOptions {
             timeout: self.timeout,
@@ -118,6 +126,7 @@ impl ScanConfigBuilder {
             detailed: self.detailed,
             format: self.format,
             auth_headers: self.auth_headers,
+            return_prompts: self.return_prompts,
         }
     }
 }
@@ -153,6 +162,8 @@ pub struct ScanOptions {
     pub detailed: bool,
     pub format: String,
     pub auth_headers: Option<HashMap<String, String>>,
+    /// When true, do not call the LLM; instead, return prompts to the caller
+    pub return_prompts: bool,
 }
 
 impl Default for ScanOptions {
@@ -163,6 +174,7 @@ impl Default for ScanOptions {
             detailed: false,
             format: "text".to_string(),
             auth_headers: None,
+            return_prompts: false,
         }
     }
 }
@@ -184,6 +196,28 @@ pub struct ScanResult {
     /// IDE source that provided this server configuration
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ide_source: Option<String>,
+    /// If set, LLM calls were deferred and these are the prompts per batch
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub llm_prompts: Option<Vec<LlmPrompt>>,
+}
+
+/// Exported prompt bundle for deferring LLM calls to the caller
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LlmPrompt {
+    /// One of: "tool", "prompt", "resource"
+    pub target_type: String,
+    /// Zero-based batch index
+    pub batch_index: usize,
+    /// The full prompt text that would be sent to the LLM
+    pub prompt: String,
+    /// Full request body that Ramparts would send to the LLM API (OpenAI-compatible)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_body: Option<serde_json::Value>,
+    /// The LLM endpoint that would be used (if configured)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+    /// Names of items included in this batch (tool names, prompt names, or resource names)
+    pub item_names: Vec<String>,
 }
 
 /// Scan status enumeration
@@ -211,6 +245,7 @@ impl ScanResult {
             yara_results: Vec::new(),
             errors: Vec::new(),
             ide_source: None,
+            llm_prompts: None,
         }
     }
 
@@ -353,6 +388,7 @@ mod tests {
             detailed: false,
             format: "json".to_string(),
             auth_headers: None,
+            return_prompts: false,
         };
 
         let result = config_utils::validate_scan_config(&options);
@@ -367,6 +403,7 @@ mod tests {
             detailed: false,
             format: "json".to_string(),
             auth_headers: None,
+            return_prompts: false,
         };
 
         let result = config_utils::validate_scan_config(&options);
@@ -385,6 +422,7 @@ mod tests {
             detailed: false,
             format: "json".to_string(),
             auth_headers: None,
+            return_prompts: false,
         };
 
         let result = config_utils::validate_scan_config(&options);
@@ -403,6 +441,7 @@ mod tests {
             detailed: false,
             format: "json".to_string(),
             auth_headers: None,
+            return_prompts: false,
         };
 
         let result = config_utils::validate_scan_config(&options);


### PR DESCRIPTION
<img width="1161" height="663" alt="Screenshot 2025-08-10 at 10 10 55 AM" src="https://github.com/user-attachments/assets/6fe949b7-084e-41fb-999a-06dc823e5f63" />
<img width="425" height="703" alt="Screenshot 2025-08-10 at 10 12 56 AM" src="https://github.com/user-attachments/assets/c6b4fa23-bbdb-40b9-b73f-7e7cb0fe6ace" />
                                                                                                                                                                                              ```
'returnPrompts' parameter in 'scan' and 'scan-config' operations. When set to 'true', Ramparts will now return a detailed 'llm_prompts' array, including the full OpenAI-compatible request body and target endpoint, instead of executing the LLM call.

New MCP Server Modes:  run Ramparts as an MCP server over standard I/O (stdio), Server-Sent Events (SSE), and streamable HTTP, significantly enhancing its integration possibilities within the MCP ecosystem.
```
