### PR TITLE
fix: Include config.yaml in Docker container for environment variable…

### DIFF
--- a/Deploy-Dockerfile
+++ b/Deploy-Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Akhil Raj"
 WORKDIR /app
 COPY target/release/ramparts /app/
 COPY rules /app/rules
+COPY config.yaml /app/
 
 EXPOSE 8080
 


### PR DESCRIPTION
… interpolation

- Add COPY config.yaml /app/ to Deploy-Dockerfile
- Fixes production issue where config.yaml was missing from container
- Enables proper environment variable interpolation for LLM configuration
- Resolves 401 authentication errors due to hardcoded fallback values

Without this fix:
- Container runs without config.yaml
- Falls back to ScannerConfig::default() with hardcoded values
- Environment variables (LLM_MODEL, LLM_URL, LLM_API_KEY) ignored
- Results in Azure OpenAI key used with standard OpenAI endpoint

With this fix:
- Container includes config.yaml with ${VAR:-default} syntax
- Environment variables properly expanded at runtime
- Enables seamless provider switching (Azure ↔ OpenAI ↔ others)
- Production-ready configuration management