### PR TITLE
fix: scan UX bugs + VSCode parser fallthrough (closes #85)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2729,6 +2729,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rmcp",
+ "rustls",
  "schemars",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,13 @@ rmcp = { version = "1.5", features = [
 # Random number generation for request IDs
 rand = "0.9"
 
+# Pulled in transitively via reqwest 0.13 / hyper-rustls; we declare it
+# directly so we can install the process-wide CryptoProvider explicitly at
+# startup. Without an explicit install, rustls 0.23 + aws-lc-rs auto-init
+# fails on some environments (notably some macOS configurations) and
+# `reqwest::Client::builder().build()` returns an opaque `"builder error"`.
+rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs"] }
+
 # Bring in common as path dependency
 ramparts-common = { path = "common" }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1439,6 +1439,22 @@ impl MCPConfigManager {
         }
     }
 
+    /// Returns `true` only when the parsed `MCPConfig` actually contains at
+    /// least one server.
+    ///
+    /// Several IDE config schemas have all fields `Option`-wrapped, so a JSON
+    /// document keyed differently than expected (e.g., a Claude-Desktop-style
+    /// `{"mcpServers": ...}` file at a VS Code path) parses as a syntactically
+    /// valid but empty `MCPConfig`. Without this gate, the early-return in
+    /// `load_config_from_path` swallows that case and the caller's fallback
+    /// chain never runs. See ramparts#85.
+    fn config_has_servers(config: &MCPConfig) -> bool {
+        config
+            .servers
+            .as_ref()
+            .is_some_and(|servers| !servers.is_empty())
+    }
+
     /// Load configuration from a specific IDE config path
     pub fn load_config_from_path(path: &Path) -> Result<MCPConfig> {
         if !path.exists() {
@@ -1505,52 +1521,81 @@ impl MCPConfigManager {
                 // VS Code settings.json may contain MCP configuration
                 if filename == "settings.json" {
                     if let Ok(vscode_config) = serde_json::from_str::<VSCodeSettings>(&content) {
-                        debug!("Parsed as VS Code settings configuration format");
-                        return Ok(Self::convert_vscode_config(vscode_config));
+                        let parsed = Self::convert_vscode_config(vscode_config);
+                        if Self::config_has_servers(&parsed) {
+                            debug!("Parsed as VS Code settings configuration format");
+                            return Ok(parsed);
+                        }
                     }
                 }
                 // VS Code mcp.json uses the new format
                 else if filename == "mcp.json" {
                     if let Ok(vscode_mcp_config) = serde_json::from_str::<VSCodeMCPConfig>(&content)
                     {
-                        debug!("Parsed as VS Code MCP configuration format");
-                        return Ok(Self::convert_vscode_mcp_config(vscode_mcp_config));
+                        let parsed = Self::convert_vscode_mcp_config(vscode_mcp_config);
+                        if Self::config_has_servers(&parsed) {
+                            debug!("Parsed as VS Code MCP configuration format");
+                            return Ok(parsed);
+                        }
                     }
                 }
             }
             _ => {}
         }
 
-        // Try parsing as standard format
-        match serde_json::from_str::<MCPConfig>(&content) {
-            Ok(config) => Ok(config),
-            Err(e) => {
-                // Try fallback parsing for different formats
-                if let Some(config) =
-                    Self::try_parse_cursor_compatible_config(&content, "Cursor MCP (fallback)")
-                {
-                    Ok(config)
-                } else if let Ok(claude_config) =
-                    serde_json::from_str::<ClaudeDesktopConfig>(&content)
-                {
-                    debug!("Parsed as Claude Desktop configuration format (fallback)");
-                    Ok(Self::convert_claude_desktop_config(claude_config))
-                } else if let Ok(vscode_config) = serde_json::from_str::<VSCodeSettings>(&content) {
-                    debug!("Parsed as VS Code settings configuration format (fallback)");
-                    Ok(Self::convert_vscode_config(vscode_config))
-                } else if let Ok(vscode_mcp_config) =
-                    serde_json::from_str::<VSCodeMCPConfig>(&content)
-                {
-                    debug!("Parsed as VS Code MCP configuration format (fallback)");
-                    Ok(Self::convert_vscode_mcp_config(vscode_mcp_config))
-                } else {
-                    Err(anyhow!(
-                        "Failed to parse IDE config file {}: {}",
-                        path.display(),
-                        e
-                    ))
-                }
+        // Fallback chain. Used when client detection didn't match (or matched
+        // VS Code but the schema-specific parsers produced an empty config —
+        // e.g., a Claude-Desktop-style `{"mcpServers": ...}` saved at a VS
+        // Code path). The first parser to yield a non-empty config wins.
+        let mcp_config_parse = serde_json::from_str::<MCPConfig>(&content);
+        if let Ok(ref config) = mcp_config_parse {
+            if Self::config_has_servers(config) {
+                return Ok(config.clone());
             }
+        }
+
+        if let Some(config) =
+            Self::try_parse_cursor_compatible_config(&content, "Cursor MCP (fallback)")
+        {
+            if Self::config_has_servers(&config) {
+                return Ok(config);
+            }
+        }
+
+        if let Ok(claude_config) = serde_json::from_str::<ClaudeDesktopConfig>(&content) {
+            let parsed = Self::convert_claude_desktop_config(claude_config);
+            if Self::config_has_servers(&parsed) {
+                debug!("Parsed as Claude Desktop configuration format (fallback)");
+                return Ok(parsed);
+            }
+        }
+
+        if let Ok(vscode_config) = serde_json::from_str::<VSCodeSettings>(&content) {
+            let parsed = Self::convert_vscode_config(vscode_config);
+            if Self::config_has_servers(&parsed) {
+                debug!("Parsed as VS Code settings configuration format (fallback)");
+                return Ok(parsed);
+            }
+        }
+
+        if let Ok(vscode_mcp_config) = serde_json::from_str::<VSCodeMCPConfig>(&content) {
+            let parsed = Self::convert_vscode_mcp_config(vscode_mcp_config);
+            if Self::config_has_servers(&parsed) {
+                debug!("Parsed as VS Code MCP configuration format (fallback)");
+                return Ok(parsed);
+            }
+        }
+
+        // Nothing yielded a non-empty config. If at least one parser succeeded
+        // syntactically, return that empty config so the caller still sees a
+        // "0 servers" entry; otherwise surface the original parse error.
+        match mcp_config_parse {
+            Ok(config) => Ok(config),
+            Err(e) => Err(anyhow!(
+                "Failed to parse IDE config file {}: {}",
+                path.display(),
+                e
+            )),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -271,19 +271,25 @@ fn determine_log_level(cli: &Cli, scanner_config: &ScannerConfig) -> Level {
     }
 }
 
-/// Creates an MCP scanner instance if needed for the given command
+/// Creates an MCP scanner instance if needed for the given command.
+///
+/// The CLI's `--http-timeout` flag (when present) takes precedence over the
+/// config-file value here so the scanner's HTTP client is constructed with
+/// the same timeout that ends up in `ScanOptions::http_timeout`.
 fn create_scanner_if_needed(cli: &Cli, scanner_config: &ScannerConfig) -> Option<MCPScanner> {
-    match &cli.command {
-        Commands::Scan { .. } | Commands::ScanConfig { .. } => {
-            match MCPScanner::with_timeout(scanner_config.scanner.http_timeout) {
-                Ok(scanner) => Some(scanner),
-                Err(e) => {
-                    error!("Failed to create scanner: {}", e);
-                    std::process::exit(1);
-                }
-            }
+    let http_timeout_override = match &cli.command {
+        Commands::Scan { http_timeout, .. } | Commands::ScanConfig { http_timeout, .. } => {
+            *http_timeout
         }
-        _ => None,
+        _ => return None,
+    };
+    let http_timeout = http_timeout_override.unwrap_or(scanner_config.scanner.http_timeout);
+    match MCPScanner::with_timeout(http_timeout) {
+        Ok(scanner) => Some(scanner),
+        Err(e) => {
+            error!("Failed to create scanner: {}", e);
+            std::process::exit(1);
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,6 +114,14 @@ enum Commands {
         /// Generate a detailed markdown report with timestamp (`scan_YYYYMMDD_HHMMSS.md`)
         #[arg(long)]
         report: bool,
+
+        /// Overall scan timeout in seconds. Overrides `scanner.scan_timeout` from config.yaml.
+        #[arg(long, value_name = "SECONDS")]
+        timeout: Option<u64>,
+
+        /// Per-HTTP-request timeout in seconds. Overrides `scanner.http_timeout` from config.yaml.
+        #[arg(long, value_name = "SECONDS")]
+        http_timeout: Option<u64>,
     },
 
     /// Scan MCP servers from IDE configuration files (~/.cursor/mcp.json, ~/.codeium/windsurf/mcp_config.json)
@@ -129,6 +137,14 @@ enum Commands {
         /// Generate a detailed markdown report with timestamp (`scan_YYYYMMDD_HHMMSS.md`)
         #[arg(long)]
         report: bool,
+
+        /// Overall per-server scan timeout in seconds. Overrides `scanner.scan_timeout` from config.yaml.
+        #[arg(long, value_name = "SECONDS")]
+        timeout: Option<u64>,
+
+        /// Per-HTTP-request timeout in seconds. Overrides `scanner.http_timeout` from config.yaml.
+        #[arg(long, value_name = "SECONDS")]
+        http_timeout: Option<u64>,
     },
 
     /// Generate a default config.yaml file
@@ -283,13 +299,38 @@ async fn execute_command(
             auth_headers,
             format,
             report,
-        } => handle_scan_command(url, auth_headers, format, report, &scanner_config, scanner).await,
+            timeout,
+            http_timeout,
+        } => {
+            handle_scan_command(
+                url,
+                auth_headers,
+                format,
+                report,
+                timeout,
+                http_timeout,
+                &scanner_config,
+                scanner,
+            )
+            .await
+        }
         Commands::ScanConfig {
             auth_headers,
             format,
             report,
+            timeout,
+            http_timeout,
         } => {
-            handle_scan_config_command(auth_headers, format, report, &scanner_config, scanner).await
+            handle_scan_config_command(
+                auth_headers,
+                format,
+                report,
+                timeout,
+                http_timeout,
+                &scanner_config,
+                scanner,
+            )
+            .await
         }
         Commands::InitConfig { force } => {
             handle_init_config_command(force);
@@ -303,17 +344,26 @@ async fn execute_command(
 }
 
 /// Handles the scan command for a single URL
+#[allow(clippy::too_many_arguments)]
 async fn handle_scan_command(
     url: String,
     auth_headers: Vec<String>,
     format: Option<String>,
     report: bool,
+    timeout: Option<u64>,
+    http_timeout: Option<u64>,
     scanner_config: &ScannerConfig,
     scanner: Option<MCPScanner>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let auth_headers_map = parse_auth_headers(&auth_headers);
     let output_format = format.unwrap_or(scanner_config.scanner.format.clone());
-    let options = build_scan_options(scanner_config, &output_format, auth_headers_map);
+    let options = build_scan_options(
+        scanner_config,
+        &output_format,
+        auth_headers_map,
+        timeout,
+        http_timeout,
+    );
 
     validate_scan_config(&options);
 
@@ -350,16 +400,25 @@ async fn handle_scan_command(
 }
 
 /// Handles the scan-config command for IDE configurations
+#[allow(clippy::too_many_arguments)]
 async fn handle_scan_config_command(
     auth_headers: Vec<String>,
     format: Option<String>,
     report: bool,
+    timeout: Option<u64>,
+    http_timeout: Option<u64>,
     scanner_config: &ScannerConfig,
     scanner: Option<MCPScanner>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let auth_headers_map = parse_auth_headers(&auth_headers);
     let output_format = format.unwrap_or(scanner_config.scanner.format.clone());
-    let options = build_scan_options(scanner_config, &output_format, auth_headers_map);
+    let options = build_scan_options(
+        scanner_config,
+        &output_format,
+        auth_headers_map,
+        timeout,
+        http_timeout,
+    );
 
     validate_scan_config(&options);
 
@@ -458,15 +517,20 @@ async fn handle_mcp_http_command(
     mcp_server::run_streamable_http_server(&host, port).await
 }
 
-/// Builds scan options from configuration and parameters
+/// Builds scan options from configuration and parameters.
+///
+/// `timeout_override` and `http_timeout_override` come from CLI flags and, when
+/// `Some`, take precedence over the values in `scanner_config`.
 fn build_scan_options(
     scanner_config: &ScannerConfig,
     output_format: &str,
     auth_headers_map: Option<std::collections::HashMap<String, String>>,
+    timeout_override: Option<u64>,
+    http_timeout_override: Option<u64>,
 ) -> ScanOptions {
     ScanConfigBuilder::new()
-        .timeout(scanner_config.scanner.scan_timeout)
-        .http_timeout(scanner_config.scanner.http_timeout)
+        .timeout(timeout_override.unwrap_or(scanner_config.scanner.scan_timeout))
+        .http_timeout(http_timeout_override.unwrap_or(scanner_config.scanner.http_timeout))
         .detailed(scanner_config.scanner.detailed)
         .format(output_format.to_string())
         .auth_headers(auth_headers_map)

--- a/src/main.rs
+++ b/src/main.rs
@@ -191,6 +191,15 @@ enum Commands {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Install the aws-lc-rs CryptoProvider as the process-wide default for
+    // rustls 0.23. reqwest 0.13's `rustls` feature relies on a default
+    // provider being available before any HTTPS client is built; in some
+    // environments the implicit auto-init races or fails, surfacing as the
+    // opaque `reqwest::Error("builder error")` from `Client::builder().build()`.
+    // Doing this explicitly and ignoring the `Err` (returned only when
+    // something else already installed a provider) makes startup deterministic.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     let cli = Cli::parse();
     // Do not print banner when running as stdio MCP server to avoid corrupting JSON-RPC stdout
     if !matches!(cli.command, Commands::McpStdio) {

--- a/src/mcp_client.rs
+++ b/src/mcp_client.rs
@@ -110,7 +110,12 @@ impl McpClient {
             .default_headers(headers)
             .timeout(std::time::Duration::from_secs(self.http_timeout_secs))
             .build()
-            .map_err(|e| anyhow!("Failed to build HTTP client: {}", e))
+            .map_err(|e| {
+                anyhow!(
+                    "Failed to build HTTP client: {}",
+                    crate::utils::error_utils::format_error_chain(&e)
+                )
+            })
     }
 
     /// Try to connect using streamable HTTP transport

--- a/src/mcp_client.rs
+++ b/src/mcp_client.rs
@@ -23,6 +23,11 @@ use tokio::process::Command;
 use tokio::sync::Mutex;
 use tracing::{debug, warn};
 
+/// Default per-HTTP-request timeout when none is provided. Kept identical to
+/// the previous hardcoded value so existing behavior doesn't change for
+/// callers that haven't started forwarding the configured `http_timeout`.
+const DEFAULT_HTTP_TIMEOUT_SECS: u64 = 30;
+
 /// MCP client using the official Rust MCP SDK with full transport support
 #[derive(Clone)]
 pub struct McpClient {
@@ -30,6 +35,9 @@ pub struct McpClient {
     services: Arc<Mutex<HashMap<String, RunningService<RoleClient, ()>>>>,
     /// Tool cache with TTL support
     tool_cache: ToolCache,
+    /// Per-HTTP-request timeout applied to every reqwest client this McpClient
+    /// builds. Sourced from `ScanOptions::http_timeout`.
+    http_timeout_secs: u64,
 }
 
 #[allow(dead_code)] // Future feature - will be used when cache is integrated
@@ -38,6 +46,16 @@ impl McpClient {
         Self {
             services: Arc::new(Mutex::new(HashMap::new())),
             tool_cache: ToolCache::default(), // 1 hour default TTL
+            http_timeout_secs: DEFAULT_HTTP_TIMEOUT_SECS,
+        }
+    }
+
+    /// Create a new MCP client with the given per-HTTP-request timeout.
+    pub fn with_http_timeout(http_timeout_secs: u64) -> Self {
+        Self {
+            services: Arc::new(Mutex::new(HashMap::new())),
+            tool_cache: ToolCache::default(),
+            http_timeout_secs,
         }
     }
 
@@ -46,6 +64,7 @@ impl McpClient {
         Self {
             services: Arc::new(Mutex::new(HashMap::new())),
             tool_cache: ToolCache::new(cache_ttl_seconds),
+            http_timeout_secs: DEFAULT_HTTP_TIMEOUT_SECS,
         }
     }
 
@@ -89,7 +108,7 @@ impl McpClient {
 
         HttpClient::builder()
             .default_headers(headers)
-            .timeout(std::time::Duration::from_secs(30))
+            .timeout(std::time::Duration::from_secs(self.http_timeout_secs))
             .build()
             .map_err(|e| anyhow!("Failed to build HTTP client: {}", e))
     }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -9,7 +9,9 @@ use crate::types::{
     LlmPrompt, MCPPrompt, MCPResource, MCPServerInfo, MCPTool, ScanOptions, ScanResult, ScanStatus,
     YaraScanResult,
 };
-use crate::utils::{error_utils, performance::track_performance, Timer};
+use crate::utils::{
+    error_utils, error_utils::format_error_chain, performance::track_performance, Timer,
+};
 use anyhow::{anyhow, Result};
 use reqwest::Client;
 use std::collections::HashMap;
@@ -927,7 +929,7 @@ impl MCPScanner {
             .timeout(Duration::from_secs(http_timeout))
             .user_agent(protocol::USER_AGENT)
             .build()
-            .map_err(|e| anyhow!("Failed to create HTTP client: {}", e))?;
+            .map_err(|e| anyhow!("Failed to create HTTP client: {}", format_error_chain(&e)))?;
 
         // Set up middleware chain with dynamic YARA capabilities
         let mut middleware_chain = ScannerChain::new();

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -966,13 +966,16 @@ impl MCPScanner {
 
     /// Scan a single MCP server
     pub async fn scan_single(&self, url: &str, options: ScanOptions) -> Result<ScanResult> {
+        let scan_timer = Timer::start();
         let mut result = ScanResult::new(url.to_string());
 
         debug!("Scanning {}", url);
 
         // Check if this is a STDIO URL and route appropriately
         if url.starts_with("stdio:") {
-            return self.scan_stdio_url(url, options).await;
+            let mut stdio_result = self.scan_stdio_url(url, options).await?;
+            stdio_result.response_time_ms = scan_timer.elapsed_ms();
+            return Ok(stdio_result);
         }
 
         // Normalize URL with error context for HTTP URLs
@@ -1163,7 +1166,7 @@ impl MCPScanner {
                     // Update result with any post-scan changes
                     result.yara_results.clone_from(&scan_data.yara_results);
 
-                    result.response_time_ms = Timer::start().elapsed_ms(); // Track actual scan time
+                    result.response_time_ms = scan_timer.elapsed_ms();
                     debug!("Scan completed in {}ms", result.response_time_ms);
                 }
             }
@@ -1198,9 +1201,13 @@ impl MCPScanner {
             Vec::new()
         };
 
-        // Create a temporary server config for the STDIO URL
+        // Create a temporary server config for the STDIO URL. Leaving `name`
+        // unset is intentional: the synthetic `STDIO-<command>` placeholder
+        // pollutes `to_display_url` output with a useless suffix. We restore
+        // the original `stdio_url` on the result below so the user sees the
+        // exact string they typed.
         let server_config = MCPServerConfig {
-            name: Some(format!("STDIO-{command}")),
+            name: None,
             url: None,
             command: Some(command.to_string()),
             args: Some(args),
@@ -1210,8 +1217,9 @@ impl MCPScanner {
             options: None,
         };
 
-        // Use the existing STDIO server scanning method
-        self.scan_stdio_server(&server_config, options).await
+        let mut result = self.scan_stdio_server(&server_config, options).await?;
+        result.url = stdio_url.to_string();
+        Ok(result)
     }
 
     /// Scan a STDIO MCP server using subprocess transport
@@ -1220,6 +1228,7 @@ impl MCPScanner {
         server_config: &MCPServerConfig,
         options: ScanOptions,
     ) -> Result<ScanResult> {
+        let scan_timer = Timer::start();
         let command = server_config
             .command
             .as_ref()
@@ -1338,6 +1347,7 @@ impl MCPScanner {
             }
         }
 
+        result.response_time_ms = scan_timer.elapsed_ms();
         Ok(result)
     }
 

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1252,9 +1252,7 @@ impl MCPScanner {
                     .mcp_client
                     .connect_subprocess(command, args, server_config.env.as_ref())
                     .await
-                    .map_err(|e| {
-                        anyhow!("Failed to connect to STDIO server {}: {}", command, e)
-                    })?;
+                    .map_err(|e| anyhow!("Failed to connect to STDIO server {}: {}", command, e))?;
                 let scan_data = self.perform_scan_with_session(&session, &options).await?;
                 Ok::<_, anyhow::Error>((session, scan_data))
             })

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -960,7 +960,7 @@ impl MCPScanner {
             client,
             http_timeout,
             middleware_chain,
-            mcp_client: McpClient::new(),
+            mcp_client: McpClient::with_http_timeout(http_timeout),
         })
     }
 
@@ -1242,21 +1242,35 @@ impl MCPScanner {
 
         let mut result = ScanResult::new(display_url.clone());
 
-        // Connect to the STDIO server using the MCP client
-        let session = self
-            .mcp_client
-            .connect_subprocess(command, args, server_config.env.as_ref())
-            .await
-            .map_err(|e| anyhow!("Failed to connect to STDIO server {}: {}", command, e))?;
-
-        // Perform the same MCP scanning pattern as HTTP servers
+        // Wrap the entire connect-and-scan pipeline in `options.timeout` so a
+        // hung subprocess (no MCP handshake response, deadlocked tool, etc.)
+        // can't make the CLI hang forever — same overall budget the HTTP path
+        // gets in `scan_single`.
         let scan_result = track_performance("STDIO MCP server scan", || async {
-            self.perform_scan_with_session(&session, &options).await
+            match timeout(Duration::from_secs(options.timeout), async {
+                let session = self
+                    .mcp_client
+                    .connect_subprocess(command, args, server_config.env.as_ref())
+                    .await
+                    .map_err(|e| {
+                        anyhow!("Failed to connect to STDIO server {}: {}", command, e)
+                    })?;
+                let scan_data = self.perform_scan_with_session(&session, &options).await?;
+                Ok::<_, anyhow::Error>((session, scan_data))
+            })
+            .await
+            {
+                Ok(inner) => inner,
+                Err(_) => Err(anyhow!(
+                    "STDIO scan operation timed out after {}s",
+                    options.timeout
+                )),
+            }
         })
         .await;
 
         match scan_result {
-            Ok(mut scan_data) => {
+            Ok((session, mut scan_data)) => {
                 // Apply the same middleware chain as HTTP scanning
                 self.middleware_chain.run_pre_scan(&mut scan_data);
 
@@ -2076,7 +2090,7 @@ impl Clone for MCPScanner {
             client: self.client.clone(),
             http_timeout: self.http_timeout,
             middleware_chain: self.middleware_chain.clone(),
-            mcp_client: McpClient::new(),
+            mcp_client: self.mcp_client.clone(),
         }
     }
 }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -971,11 +971,10 @@ impl MCPScanner {
 
         debug!("Scanning {}", url);
 
-        // Check if this is a STDIO URL and route appropriately
+        // STDIO URLs route through `scan_stdio_url` -> `scan_stdio_server`,
+        // which sets `response_time_ms` itself. Don't overwrite it here.
         if url.starts_with("stdio:") {
-            let mut stdio_result = self.scan_stdio_url(url, options).await?;
-            stdio_result.response_time_ms = scan_timer.elapsed_ms();
-            return Ok(stdio_result);
+            return self.scan_stdio_url(url, options).await;
         }
 
         // Normalize URL with error context for HTTP URLs
@@ -1166,8 +1165,7 @@ impl MCPScanner {
                     // Update result with any post-scan changes
                     result.yara_results.clone_from(&scan_data.yara_results);
 
-                    result.response_time_ms = scan_timer.elapsed_ms();
-                    debug!("Scan completed in {}ms", result.response_time_ms);
+                    debug!("Scan completed in {}ms", scan_timer.elapsed_ms());
                 }
             }
             Err(e) => {
@@ -1177,6 +1175,9 @@ impl MCPScanner {
             }
         }
 
+        // Record total scan duration on both the success and failure paths so
+        // failed scans no longer report `0ms`.
+        result.response_time_ms = scan_timer.elapsed_ms();
         Ok(result)
     }
 

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -8,6 +8,7 @@ use anyhow::{anyhow, Result};
 use reqwest::Client;
 use serde_json::{json, Value};
 use spinners::{Spinner, Spinners};
+use std::io::IsTerminal;
 use tracing::{debug, error};
 
 /// Trait for items that can be batch scanned for security issues
@@ -782,11 +783,15 @@ Example valid response: [{\"tool_name\": \"example\", \"found_issue\": true, \"i
             );
         }
 
-        // Start spinner with text after animation
-        let mut sp = Spinner::new(
-            Spinners::Dots9,
-            "Scanning for security vulnerabilities...(this may take a while)".into(),
-        );
+        // Start spinner only when stdout is an interactive terminal. In CI,
+        // pipelines, or any redirected output the animation re-prints
+        // hundreds of frames per scan, drowning the actual results.
+        let mut sp = std::io::stdout().is_terminal().then(|| {
+            Spinner::new(
+                Spinners::Dots9,
+                "Scanning for security vulnerabilities...(this may take a while)".into(),
+            )
+        });
 
         debug!("📡 Sending LLM API request to: {}", endpoint);
 
@@ -801,7 +806,9 @@ Example valid response: [{\"tool_name\": \"example\", \"found_issue\": true, \"i
         {
             Ok(resp) => resp,
             Err(e) => {
-                sp.stop();
+                if let Some(s) = sp.as_mut() {
+                    s.stop();
+                }
                 error!("🚨 LLM API Request Failed:");
                 error!("   Endpoint: {}", endpoint);
                 error!("   Error: {}", e);
@@ -821,7 +828,9 @@ Example valid response: [{\"tool_name\": \"example\", \"found_issue\": true, \"i
         };
 
         // Stop spinner
-        sp.stop();
+        if let Some(s) = sp.as_mut() {
+            s.stop();
+        }
 
         let status = response.status();
         debug!("📥 LLM API Response Status: {}", status);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -42,6 +42,23 @@ pub mod error_utils {
         format!("{operation} failed: {details}")
     }
 
+    /// Render the full `std::error::Error` source chain as a single string.
+    ///
+    /// Some libraries (notably reqwest) print very terse `Display`
+    /// representations like `"builder error"` while the actual diagnosis lives
+    /// in the underlying `source()`. Walking the chain surfaces those causes
+    /// when a user reports an error.
+    pub fn format_error_chain<E: std::error::Error + ?Sized>(err: &E) -> String {
+        let mut out = err.to_string();
+        let mut source = err.source();
+        while let Some(s) = source {
+            out.push_str(": ");
+            out.push_str(&s.to_string());
+            source = s.source();
+        }
+        out
+    }
+
     /// Wrap an error with context
     /// Wraps an error with additional context information
     #[allow(dead_code)] // Used in tests and for error context enhancement


### PR DESCRIPTION
## Summary

Five small UX/correctness fixes surfaced by smoke-testing the rmcp 1.5 migration in #102 plus a real-world bug report.

> **Base branch:** stacked on top of #102 — review/merge that one first.

### 1. `response_time_ms` was always `0ms`
`src/scanner.rs` called `Timer::start().elapsed_ms()` *after* the scan finished, so it always measured the time to construct a Timer (~0ms). Visible in every terminal output, every JSON dump, and the markdown report. Fixed by starting the timer at the top of `scan_single` and `scan_stdio_server` and reading it before returning. Verified: `Response Time: 11946ms` on a real scan, and `5002ms` on a forced timeout (failed scans now also report duration).

### 2. Spinner spam in non-TTY output
`SecurityScanner` always created a `spinners::Spinner` regardless of whether stdout was a terminal. With output piped to `tail`, `head`, a file, or CI logs, the animation re-printed hundreds of frames per scan, drowning the actual results. Fixed by gating spinner construction on `std::io::IsTerminal::is_terminal(&stdout())`.

### 3. No `--timeout` / `--http-timeout` flags on `scan` / `scan-config`
Users had to edit `~/.config/ramparts/config.yaml` to bound a one-off scan. Added `--timeout <SECONDS>` and `--http-timeout <SECONDS>` flags on both subcommands; CLI values override config.yaml.

### 4. stdio URL display mangled
`ramparts scan stdio:npx:-y:@modelcontextprotocol/server-everything` rendered as `URL: stdio:npx[STDIO-npx]` because `scan_stdio_url` synthesized a placeholder server name. Fixed by leaving `name` unset on the synthetic config and restoring the user's original `stdio_url` string on `result.url`.

### 5. VSCode parser swallows non-VSCode formats at vscode paths — closes #85
A `.vscode/mcp.json` containing a Claude-Desktop-style `{"mcpServers": {...}}` document silently parsed as a valid-but-empty `VSCodeMCPConfig`, so `scan-config` reported `0 servers` and dropped the file. Root cause: every IDE schema has `Option`-wrapped top-level fields, so an off-schema document deserializes into an empty struct, and the per-client early-return blocked the multi-format fallback chain. Fixed by introducing `config_has_servers` and gating every "I parsed it, return" branch on a non-empty result. The first parser that yields a non-empty config wins. Verified with the reporter's exact JSON: now resolves to `grafana [STDIO]: stdio:docker[grafana]`.

## Test plan

- [x] `cargo build --all-features` clean
- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] `cargo test --all-features` — 93/93 passed
- [x] Smoke test stdio (everything server) — URL preserved, Response Time real, no spinner spam piped
- [x] Smoke test failed HTTP timeout — reports `Response Time: 5002ms`
- [x] Smoke test #85 — `.vscode/mcp.json` with Claude-Desktop-style content finds the server
- [x] `ramparts scan --help` shows new flags
- [ ] CI green
