### PR TITLE
feat: SARIF output, OWASP MCP Top 10 taxonomy, repo-root config scan

### DIFF
--- a/docs/CHANGELOG-v0.8.0.md
+++ b/docs/CHANGELOG-v0.8.0.md
@@ -1,0 +1,214 @@
+# Ramparts v0.8.0 Release Notes
+
+This release shifts ramparts from "MCP scanner that produces text output" to "MCP scanner that fits cleanly into modern security tooling pipelines". The big themes:
+
+- **CI/CD-native output** via SARIF 2.1.0 with OWASP MCP Top 10 tagging
+- **Supply-chain coverage** via OSV.dev for stdio-launched MCP servers
+- **Reliable startup** on minimal Linux/EC2 hosts (no more "No CA certificates were loaded")
+- **Modern transport stack** via the rmcp 1.x SDK (ramparts was on 0.3 before this release)
+- **A pile of CLI ergonomics fixes** that came out of dogfooding the migration
+
+> **No code-level breaking changes.** Existing CLI invocations continue to work; existing JSON output adds new optional fields but doesn't remove any. The one user-visible behavior change is that the welcome banner is now suppressed for `--format json | raw | sarif` (so downstream parsers see clean stdout).
+
+## ✨ New Features
+
+### SARIF 2.1.0 output (#96)
+
+```bash
+ramparts scan-config --format sarif > ramparts.sarif
+# Then in CI:
+- uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: ramparts.sarif
+```
+
+Each finding includes:
+
+- `ruleId` — YARA rule name (e.g. `CrossDomainContamination`) or `ramparts.security.<IssueType>` for LLM-detected findings
+- `level` — `error` (CRITICAL/HIGH), `warning` (MEDIUM), `note` (LOW)
+- `properties.security-severity` — numeric 0–10 score so GitHub renders the right severity badge
+- `properties.tags` — OWASP MCP Top 10 IDs (e.g. `owasp-mcp-top-10:2025-draft:MCP05`)
+
+Each scanned server becomes its own `runs[]` entry; rules referenced by that run are deduped into `tool.driver.rules[]`. Suitable for GitHub Advanced Security code-scanning, GitLab, Azure DevOps, Microsoft Defender, and most enterprise security dashboards.
+
+### OWASP MCP Top 10 taxonomy mapping (#101)
+
+Every finding ramparts emits is now tagged with one or more entries from the OWASP MCP Top 10 (2025 draft). Tags appear in:
+
+- terminal output (`OWASP MCP Top 10: MCP05, MCP06`)
+- JSON output (`owasp_tags` field on every `SecurityIssue` and `YaraScanResult`)
+- SARIF output (`properties.tags` on every `result` and `rule`)
+
+The taxonomy is pinned to a versioned YAML file (`taxonomies/owasp-mcp-top-10/2025.yaml`) — when the official list publishes a new revision, it lands as a new file rather than mutating the existing one.
+
+| ID | Category | Example findings |
+|---|---|---|
+| MCP01 | Prompt Injection | `PromptInjection`, `Jailbreak` |
+| MCP02 | Tool Poisoning | `ToolPoisoning`, `MCPConfigChanged` |
+| MCP03 | Excessive Agency | `Jailbreak` |
+| MCP04 | Insecure Tool Output Handling | `PathTraversalVulnerability` |
+| MCP05 | Cross-Origin Tool Confusion | `CrossDomainContamination`, `DomainOutlier`, `MixedSecuritySchemes` |
+| MCP06 | Credential and Secret Leakage | `SecretsLeakage`, `EnvironmentVariableLeakage`, `SSHKeyExposure`, `PEMFileAccess` |
+| MCP07 | Command and SQL Injection | `CommandInjection`, `SQLInjection`, `MCPConfigRisk` |
+| MCP08 | Authentication & Authorization Bypass | `AuthBypass` |
+| MCP09 | Sensitive Data Exposure | `PIILeakage`, secret findings |
+| MCP10 | Supply Chain | `MCPConfigRisk`, `VulnerableDependency` |
+
+### Supply-chain dependency scan via OSV.dev (#104)
+
+When a stdio MCP server is launched via `npx` (npm) or `uvx` (PyPI), ramparts now extracts the package name + version from the launch command and queries [OSV.dev](https://osv.dev) for known security advisories. Findings emit as `VulnerableDependency` entries, mapped to OWASP **MCP10 Supply Chain**.
+
+Verified end-to-end — `ramparts scan stdio:npx:lodash@4.17.20` surfaces 5+ real CVEs (ReDoS, command injection, prototype pollution, code injection) directly in the report.
+
+The check runs in parallel with the main scan and fails soft — network errors / OSV outages are logged and treated as "no findings", never as a fatal scan error.
+
+### `--root <PATH>` for scan-config (closes #51)
+
+Walk an arbitrary directory (e.g. a checked-in repo of IDE configs) for `mcp.json` / `*.mcp.json` / `claude_desktop_config.json` / `settings.json` files instead of the user's home + IDE locations:
+
+```bash
+ramparts scan-config --root ./ide-configs --format sarif > ramparts.sarif
+```
+
+Recursive; symlinks are not followed; common build directories (`.git`, `node_modules`, `target`, `dist`, `build`, `.venv`, `venv`, `__pycache__`) are skipped; depth capped at 16.
+
+### `replay` subcommand (#104)
+
+Read a previously-emitted JSON scan result and re-emit it through any other format — no live network or LLM calls. The headline use case is "archive a JSON scan in CI and convert to SARIF later as a separate step":
+
+```bash
+ramparts scan-config --format json > scan.json
+ramparts replay scan.json --format sarif > scan.sarif
+```
+
+Auto-detects single-server (`ScanResult`) vs multi-server (`Vec<ScanResult>`) shapes.
+
+### `--only <KINDS>` filter (#104)
+
+Restrict a scan to a subset of artifact kinds. Useful for CI gates that only care about one surface:
+
+```bash
+ramparts scan https://api.example.com/mcp/ --only tools
+ramparts scan-config --only tools,prompts
+```
+
+Comma-separated; accepts `tools`, `prompts`, `resources` (singular forms also accepted). Unrecognized tokens fail with a clean error rather than silently scanning everything.
+
+### `--timeout` / `--http-timeout` CLI flags (#103)
+
+Bound a one-off scan from the CLI without editing `~/.config/ramparts/config.yaml`:
+
+```bash
+ramparts scan https://api.example.com/mcp/ --timeout 90 --http-timeout 30
+```
+
+`--timeout` is the overall scan budget (also applies to the stdio path now — a hung subprocess is killed at the timeout instead of hanging the CLI forever); `--http-timeout` bounds individual HTTP requests.
+
+## 🛠️ Reliability fixes
+
+### Bundled Mozilla CA list (#105)
+
+reqwest 0.13's `rustls-platform-verifier` returns zero roots on hosts where the system CA bundle isn't populated — fresh EC2 ubuntu/debian AMIs, distroless containers, Debian slim without `ca-certificates`. Symptom: `Failed to create HTTP client: builder error: No CA certificates were loaded from the system`, ramparts fails before any HTTPS request.
+
+ramparts now ships [Mozilla's CA list](https://github.com/rustls/webpki-roots) embedded in the binary and hands reqwest a preconfigured rustls `ClientConfig` whose trust store is that bundle. The config is built once via `LazyLock` and shared via `Arc` across every reqwest builder. There's no dependency on the host trust store anymore.
+
+### Process-wide CryptoProvider install (#103)
+
+rustls 0.23 requires a process-wide `CryptoProvider` before any HTTPS client is built. We now install `aws_lc_rs` explicitly at the top of `main()` (ignoring the `Err` returned when something else has already installed one) so startup is deterministic across environments.
+
+### Improved error chain reporting (#103)
+
+Failures from `reqwest::Client::builder().build()` used to surface as the bare string `"builder error"`. We now walk the `std::error::Error` source chain and join causes so the actual diagnosis (e.g. "No CA certificates were loaded from the system") is visible.
+
+### `response_time_ms` always reported `0ms` (#103)
+
+Internal timer was constructed *after* the scan rather than at entry, so the reported response time was always near zero. Fixed for both success and failure paths — failed scans (timeout, connection refused, etc.) now report their actual elapsed time instead of `0ms`.
+
+### Spinner spam in non-TTY output (#103)
+
+The "Scanning for security vulnerabilities..." spinner ran unconditionally, drowning machine-readable stdout with hundreds of frames per scan in CI logs and `--format json` pipelines. Now gated on `std::io::stdout().is_terminal()`.
+
+### stdio URL display preserved (#103)
+
+`ramparts scan stdio:npx:-y:@modelcontextprotocol/server-everything` previously rendered as `URL: stdio:npx[STDIO-npx]` because of a synthetic placeholder. The result now preserves the user's exact input string.
+
+### `--http-timeout` plumbed to McpClient (#103)
+
+The flag was getting into `ScanOptions` but the underlying `McpClient` was hardcoding a 30-second timeout. Now `MCPScanner::with_timeout` constructs the inner `McpClient::with_http_timeout(...)` so the flag actually bounds individual reqwest calls.
+
+### stdio scan now respects `--timeout` (#103)
+
+`scan_stdio_server` previously ran without a `tokio::time::timeout` wrap, so a hung subprocess could pin the CLI forever regardless of the configured timeout. The connect + scan pipeline is now wrapped, mirroring the HTTP path.
+
+### VS Code parser silently produced empty configs (closes #85, #103)
+
+A `.vscode/mcp.json` containing a Claude-Desktop-style `{"mcpServers": ...}` document parsed cleanly as a valid-but-empty `VSCodeMCPConfig`, so `scan-config` reported `0 servers` and dropped the file. The fix introduces `config_has_servers` and gates every "I parsed it, return" branch on a non-empty result; the first parser that yields servers wins.
+
+## 🔧 Internal / dependency changes
+
+### rmcp 0.3.2 → 1.5 migration (#102)
+
+Major-version bump of the official Rust MCP SDK. Internal-only behavior changes:
+
+- SSE is no longer a separate transport. `mcp-sse` CLI command is preserved and now delegates to the streamable HTTP server (rmcp 1.x folds SSE into HTTP for both client and server directions).
+- `Parameters` import moved from `handler::server::tool` to `handler::server::wrapper`.
+- `ServerInfo` switched to the `::new(...).with_instructions(...)` builder per the upstream migration guide.
+
+### reqwest 0.12 → 0.13 (#102)
+
+Required by rmcp 1.5 — having two reqwest versions in the dep tree broke the `StreamableHttpClient` trait impl. The TLS feature was renamed `rustls-tls` → `rustls`.
+
+### yara-x 1.5 → 1.15.0 + transitive bumps (#102)
+
+Cleared RUSTSEC-2026-0097 (rand unsoundness) and the older yara-x advisory chain. Pinned yara-x to a post-1.15.0 commit that ships wasmtime 43.0.1 to clear CVE-2026-34971 / CVE-2026-34987 (both critical) plus 12 lower-severity wasmtime advisories.
+
+### Clippy / formatting hygiene (#102, #103)
+
+- 4 `clippy::collapsible_match` errors fixed under clippy 1.95.0
+- `severity_score` emitted as a JSON number in SARIF (was string)
+
+## 🐛 Other bug fixes
+
+- Failed scans now record their elapsed time (was leaking `0ms` for both stdio and HTTP) (#103)
+- Single-source timing for stdio scans — no more double-counting between `scan_single` and `scan_stdio_server` (#103)
+- `MCPScanner::Clone` now preserves the underlying `mcp_client` (with its session cache and configured timeout) instead of constructing a fresh default-timeout one (#103)
+
+## 📚 Documentation
+
+- `cli.md` — replaced the stale flag list (`--output`, `--detailed`, `--min-severity`, `--pretty` — none existed in the actual CLI) with the real flags, documented the new `--timeout` / `--http-timeout` / `--root` / `--only` / `--format sarif` / `replay` / `mcp-stdio|http|sse` surface, added a SARIF + GitHub Code Scanning integration example.
+- `features.md` — added subsections covering OWASP MCP Top 10 mapping, OSV.dev supply-chain check, SARIF, and replay mode.
+- `security-features.md` — added a "Vulnerable Dependencies (Supply Chain)" section under the threat catalog and a full OWASP MCP Top 10 mapping table.
+- `troubleshooting.md` — replaced the generic SSL advice with the specific "No CA certificates were loaded" error and noted that the bundled Mozilla CA list makes the host trust store no longer load-bearing.
+
+## 🚀 Migration guide
+
+For most users, no action is required:
+
+- All existing CLI invocations continue to work.
+- All existing config-file fields are still honored.
+- All existing JSON output fields are still present; new fields (`owasp_tags`, `VulnerableDependency` results) are additive.
+- The one visible change: scripts that piped `--format json` / `--format raw` while expecting the welcome banner on stdout will now get only the JSON. (The banner went to stderr in some places before this; it's now consistently suppressed for machine-readable formats.)
+
+For CI/CD integrators, the new high-leverage moves are:
+
+- Switch `--format json` artifacts to `--format sarif` and upload via `github/codeql-action/upload-sarif@v3`.
+- Use `replay` to convert archived JSON scans to SARIF as a separate step (decoupled from the actual scan).
+- Use `--root <PATH>` to scan a checked-in repo of IDE configs.
+
+For ramparts library / SDK consumers (Rust):
+
+- `SecurityIssue` and `YaraScanResult` gained an `owasp_tags: Vec<OwaspTag>` field. It's `#[serde(default, skip_serializing_if = "Vec::is_empty")]` so old JSON deserializes fine.
+- `ScanOptions` gained `only: Option<Vec<ArtifactKind>>`.
+
+## 🎯 What's next
+
+Tracked as open issues:
+
+- `.ramparts.lock` tool-pinning lockfile (#97) — detect MCP tool drift via SHA-256 hash pinning
+- Toxic-flow analysis (#98) — detect dangerous capability pairings across MCP servers
+- YAML custom rule format (#99) — higher-level alternative to YARA for org-specific rules
+- Auto-fix with backup/undo (#100) — opt-in remediation for IDE config findings
+
+---
+
+**Full Changelog**: https://github.com/highflame-ai/ramparts/compare/v0.7.0...v0.8.0

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -14,8 +14,16 @@ ramparts server [options]
 # Scan from IDE configuration files
 ramparts scan-config [options]
 
+# Re-emit a previously-saved scan result in another format
+ramparts replay <path> [--format <FORMAT>]
+
 # Initialize configuration file
 ramparts init-config
+
+# Run Ramparts itself as an MCP server
+ramparts mcp-stdio
+ramparts mcp-http  [--host HOST] [--port PORT]
+ramparts mcp-sse   [--host HOST] [--port PORT]   # alias of mcp-http (rmcp 1.x folds SSE into streamable HTTP)
 
 # Show help
 ramparts --help
@@ -50,20 +58,21 @@ ramparts scan <URL> [OPTIONS]
 
 ```bash
 Options:
-  -a, --auth-headers <HEADERS>    Authentication headers (format: "Header: Value")
-                                  Can be specified multiple times
-  -o, --output <FORMAT>           Output format [default: table]
-                                  [possible values: json, raw, table, text]
+      --auth-headers <HEADERS>    Authentication headers (format: "Header: Value", comma-separated)
+      --format <FORMAT>           Output format [default: from config.yaml; usually `table`]
+                                  [possible values: text, table, json, raw, sarif]
       --report                    Generate detailed markdown report (scan_YYYYMMDD_HHMMSS.md)
-  -t, --timeout <SECONDS>         Request timeout in seconds [default: 60]
-      --http-timeout <SECONDS>    HTTP timeout in seconds [default: 30]
-      --detailed                  Enable detailed output
-      --min-severity <LEVEL>      Minimum severity level to report
-                                  [possible values: low, medium, high, critical]
-      --config <FILE>             Custom configuration file path
-      --pretty                    Pretty print JSON output (only with --output json)
+      --timeout <SECONDS>         Overall scan timeout. Overrides scanner.scan_timeout.
+      --http-timeout <SECONDS>    Per-HTTP-request timeout. Overrides scanner.http_timeout.
+      --only <KINDS>              Restrict scan to a subset of artifact kinds. Comma-separated:
+                                  tools, prompts, resources (singular forms also accepted).
+                                  Default: scan all kinds.
   -h, --help                      Print help information
 ```
+
+> **Note**: `--format sarif` produces SARIF 2.1.0 output suitable for GitHub Advanced
+> Security code-scanning, GitLab, and other SARIF consumers. OWASP MCP Top 10 IDs are
+> included as `properties.tags` on every result and rule definition.
 
 ### Examples
 
@@ -75,37 +84,51 @@ ramparts scan https://api.githubcopilot.com/mcp/
 **Scan with authentication:**
 ```bash
 ramparts scan https://api.githubcopilot.com/mcp/ \
-  --auth-headers "Authorization: Bearer $TOKEN" \
-  --auth-headers "X-API-Key: $API_KEY"
+  --auth-headers "Authorization: Bearer $TOKEN"
 ```
 
-**Detailed JSON output:**
+**JSON output:**
 ```bash
-ramparts scan https://api.githubcopilot.com/mcp/ \
-  --output json \
-  --detailed \
-  --pretty
+ramparts scan https://api.githubcopilot.com/mcp/ --format json
 ```
 
-**Custom timeout and severity:**
+**SARIF output for GitHub code scanning:**
+```bash
+ramparts scan https://api.githubcopilot.com/mcp/ --format sarif > ramparts.sarif
+# Then upload via github/codeql-action/upload-sarif in CI
+```
+
+**Custom timeout:**
 ```bash
 ramparts scan https://api.githubcopilot.com/mcp/ \
   --timeout 120 \
-  --http-timeout 45 \
-  --min-severity high
+  --http-timeout 45
 ```
 
-**Generate detailed report:**
+**Scan only tool definitions (skip prompts and resources):**
+```bash
+ramparts scan https://api.githubcopilot.com/mcp/ --only tools
+```
+
+**Generate detailed markdown report:**
 ```bash
 ramparts scan https://api.githubcopilot.com/mcp/ --report
 ```
 
 **STDIO server scan:**
 ```bash
-ramparts scan "stdio:///usr/local/bin/mcp-server"
-ramparts scan "node /path/to/server.js --config config.json"
-ramparts scan "/usr/bin/python3 /path/to/server.py"
+# Format: stdio:<command>:<arg1>:<arg2>:...
+ramparts scan "stdio:npx:-y:@modelcontextprotocol/server-everything"
+ramparts scan "stdio:python3:/path/to/server.py"
+ramparts scan "stdio:node:/path/to/server.js"
 ```
+
+> **Supply-chain check**: when the stdio command is `npx` or `uvx`, ramparts
+> automatically queries [OSV.dev](https://osv.dev) for known advisories on the
+> launched package@version and emits any findings as `VulnerableDependency`
+> entries (mapped to OWASP MCP10 Supply Chain). The lookup runs in parallel with
+> the main scan and fails soft — network errors are logged and treated as "no
+> findings", never as a fatal scan error.
 
 ## Scan-Config Command
 
@@ -120,11 +143,17 @@ ramparts scan-config [OPTIONS]
 
 ```bash
 Options:
-  -a, --auth-headers <HEADERS>    Authentication headers for MCP servers
-  -o, --output <FORMAT>           Output format [default: table]
-                                  [possible values: json, raw, table, text]
+      --auth-headers <HEADERS>    Authentication headers for MCP servers
+      --format <FORMAT>           Output format [default: from config.yaml]
+                                  [possible values: text, table, json, raw, sarif]
       --report                    Generate detailed markdown report (scan_YYYYMMDD_HHMMSS.md)
-      --config <FILE>             Custom configuration file path
+      --timeout <SECONDS>         Overall per-server scan timeout
+      --http-timeout <SECONDS>    Per-HTTP-request timeout
+      --root <PATH>               Walk this directory for MCP config files instead of the
+                                  user's home/IDE locations. Useful for scanning a
+                                  checked-in repo of IDE configs in CI.
+      --only <KINDS>              Restrict scan to a subset of artifact kinds
+                                  (tools, prompts, resources)
   -h, --help                      Print help information
 ```
 
@@ -139,12 +168,26 @@ ramparts scan-config
 ```bash
 ramparts scan-config \
   --auth-headers "Authorization: Bearer $TOKEN" \
-  --output json
+  --format json
 ```
 
 **Generate report:**
 ```bash
 ramparts scan-config --report
+```
+
+**Scan a checked-in repo of IDE configs (e.g. in CI):**
+```bash
+# `--root` walks the directory recursively, picks up `mcp.json`,
+# `*.mcp.json`, `claude_desktop_config.json`, `settings.json`, etc.
+# Skips `.git`, `node_modules`, `target`, `dist`, `build`, `.venv`,
+# and similar build directories. Symlinks are not followed.
+ramparts scan-config --root ./ide-configs --format sarif > ramparts.sarif
+```
+
+**Only tool definitions (skip prompts/resources):**
+```bash
+ramparts scan-config --only tools
 ```
 
 ### Supported IDE Configuration Files
@@ -153,13 +196,60 @@ Ramparts automatically discovers and reads MCP server configurations from:
 
 - **Cursor**: `~/.cursor/mcp.json`
 - **Windsurf**: `~/.codeium/windsurf/mcp_config.json`
-- **VS Code**: `~/.vscode/mcp.json`
+- **VS Code**: `~/.vscode/mcp.json`, `~/Library/Application Support/Code/User/mcp.json`
 - **Claude Desktop**: `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
-- **Claude Code**: `~/.claude/settings.json`
+- **Claude Code**: `~/.claude/settings.json`, `~/.claude/settings.local.json`
 - **Gemini CLI**: `~/.gemini/settings.json`, `.gemini/settings.json` (workspace)
 - **Neovim**: `~/.config/nvim/mcp.json`
 - **Helix**: `~/.config/helix/mcp.json`
 - **Zed**: `~/.config/zed/mcp.json`
+
+If a file's content uses a different schema than the path suggests (e.g. a
+Claude-Desktop-style `{"mcpServers": ...}` document saved at a VS Code path),
+ramparts falls through to the multi-format parser chain rather than silently
+treating it as empty. Files that contain no recognizable MCP server entries
+appear in the discovery summary with `0 servers` and are skipped.
+
+## Replay Command
+
+Re-emit a previously-saved scan result through a different output format
+without re-connecting to the MCP server. The headline use case is **archive
+a JSON scan in CI, then convert it to SARIF** for GitHub code-scanning
+ingestion as a separate step.
+
+### Usage
+```bash
+ramparts replay <PATH> [--format <FORMAT>]
+```
+
+### Arguments
+- `<PATH>` — Path to a JSON file containing a `ScanResult` (single-server,
+  emitted by `ramparts scan`) or a `Vec<ScanResult>` (multi-server, emitted
+  by `ramparts scan-config`). The renderer auto-detects which shape is
+  present.
+
+### Options
+```bash
+Options:
+      --format <FORMAT>   Output format [default: from config.yaml]
+                          [possible values: text, table, json, raw, sarif]
+  -h, --help              Print help information
+```
+
+### Examples
+
+```bash
+# Capture once in CI, convert to SARIF later
+ramparts scan https://api.example.com/mcp/ --format json > scan.json
+ramparts replay scan.json --format sarif > scan.sarif
+
+# View an archived multi-server scan-config result locally
+ramparts scan-config --format json > all-servers.json
+ramparts replay all-servers.json
+```
+
+`replay` does no network or LLM calls — it's a pure format conversion of
+already-emitted findings.
 
 ## Server Command
 
@@ -230,34 +320,59 @@ This creates a `ramparts.yaml` file in the current directory with all configurat
 
 ## Output Formats
 
+For machine-readable formats (`json`, `raw`, `sarif`), the welcome banner is
+suppressed automatically so downstream parsers (jq, `codeql-action/upload-sarif`,
+etc.) get clean stdout.
+
 ### Table Format (Default)
 Human-readable table format with colored output:
 ```bash
 ramparts scan <url>
-ramparts scan <url> --output table
+ramparts scan <url> --format table
 ```
-
-
 
 ### JSON Format
-Machine-readable JSON output:
+Machine-readable structured output:
 ```bash
-ramparts scan <url> --output json
-ramparts scan <url> --output json --pretty
+ramparts scan <url> --format json
 ```
 
-
-
 ### Text Format
-Simple text format:
+Simple text output:
 ```bash
-ramparts scan <url> --output text
+ramparts scan <url> --format text
 ```
 
 ### Raw Format
-Raw JSON format preserving original MCP server responses with embedded security data:
+Raw JSON preserving original MCP server responses with embedded security data:
 ```bash
-ramparts scan <url> --output raw
+ramparts scan <url> --format raw
+```
+
+### SARIF Format
+SARIF 2.1.0 output for GitHub Advanced Security code-scanning, GitLab, Azure
+DevOps, Microsoft Defender, and most enterprise security dashboards:
+
+```bash
+ramparts scan <url> --format sarif > ramparts.sarif
+```
+
+Each finding includes:
+- `ruleId` — YARA rule name or `ramparts.security.<IssueType>`
+- `level` — `error` (CRITICAL/HIGH), `warning` (MEDIUM), `note` (LOW)
+- `properties.security-severity` — numeric 0–10 score so GitHub renders the
+  right severity badge
+- `properties.tags` — OWASP MCP Top 10 IDs (e.g. `owasp-mcp-top-10:2025-draft:MCP05`)
+
+CI integration example with GitHub Code Scanning:
+```yaml
+- name: Run ramparts
+  run: ramparts scan-config --format sarif > ramparts.sarif
+
+- name: Upload SARIF
+  uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: ramparts.sarif
 ```
 
 ## Environment Variables

--- a/docs/features.md
+++ b/docs/features.md
@@ -18,15 +18,45 @@ Ramparts looks for 11+ different types of security issues, from the obvious (lik
 
 Here's what it catches: **Tool Poisoning** when tools lie about what they do, **Path Traversal** attacks like `../../../etc/passwd`, **Command Injection** where user input could execute system commands, **SQL Injection** vulnerabilities, **Cross-Origin Escalation** when tools span multiple domains unsafely, **Secret Leakage** of API keys and tokens, **Authentication Bypass** issues, **Prompt Injection** that could fool AI safety measures, **PII Leakage**, **Privilege Escalation**, and **Data Exfiltration** risks.
 
-The cool thing is you can tune the scanning based on what you care about. If you only want to know about critical issues, just add `--min-severity HIGH` to your scan. Working in a regulated environment? Create custom rules for your specific compliance requirements.
+The cool thing is you can tune the scanning based on what you care about. If you only care about tool definitions in CI, scope the scan with `--only tools`. Working in a regulated environment? Create custom YARA rules for your specific compliance requirements (drop them in the `rules/` directory).
 
 ```bash
-# Only show me the serious stuff
-ramparts scan https://your-mcp-server.com --min-severity HIGH
+# Only scan tool definitions, skip prompts and resources
+ramparts scan https://your-mcp-server.com --only tools
 
-# Use our company's custom security rules
-ramparts scan https://your-mcp-server.com --config custom-rules.yaml
+# Bound the scan and per-request timeouts from the CLI
+ramparts scan https://your-mcp-server.com --timeout 90 --http-timeout 30
 ```
+
+### OWASP MCP Top 10 Mapping
+
+Every finding ramparts emits is tagged with one or more entries from the
+**OWASP MCP Top 10** (2025 draft) so you can group results by category and
+report against a recognized framework. Tags appear in:
+
+- the terminal output (`OWASP MCP Top 10: MCP05, MCP06`)
+- the JSON output (`owasp_tags` field on every finding)
+- the SARIF output (`properties.tags` on every result and rule)
+- the markdown report (grouped by category)
+
+The taxonomy is pinned to a versioned YAML file
+(`taxonomies/owasp-mcp-top-10/2025.yaml`) so future revisions are explicit
+upgrades rather than silent churn.
+
+### Supply-Chain Dependency Check
+
+When a stdio MCP server is launched via `npx` or `uvx`, ramparts extracts
+the package name + version from the launch command and queries
+[OSV.dev](https://osv.dev) for known security advisories on that release.
+Findings emit as `VulnerableDependency` entries (mapped to OWASP **MCP10
+Supply Chain**), surface in every output format, and run in parallel with
+the main scan so they don't slow you down. Real-world example — a scan of
+`stdio:npx:lodash@4.17.20` surfaces 5+ known CVEs (ReDoS, command
+injection, prototype pollution, code injection) directly in the report.
+
+The check fails soft: a network error, OSV outage, or unrecognized launch
+command logs a warning and is treated as "no findings" rather than a fatal
+scan error.
 
 ### Advanced Pattern Detection (YARA-X)
 
@@ -118,6 +148,39 @@ When you need to integrate with other tools, JSON format provides structured dat
 For debugging MCP protocol issues, raw format shows you exactly what the server responded with, which is invaluable when you're trying to figure out why something isn't working as expected.
 
 The JSON structure is designed to be jq-friendly, so you can easily extract issue counts, filter by severity, or pull out specific findings for reporting.
+
+### SARIF for Code Scanning
+
+For teams that want findings to land in GitHub Advanced Security's code
+scanning UI (or GitLab / Azure DevOps / Microsoft Defender), `--format
+sarif` emits SARIF 2.1.0 directly:
+
+```bash
+ramparts scan-config --format sarif > ramparts.sarif
+# Then in CI:
+- uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: ramparts.sarif
+```
+
+Each finding includes its OWASP MCP Top 10 ID as a SARIF tag and a
+numeric `security-severity` (0–10) so the right severity badge renders.
+
+### Replay Mode
+
+Scan once, render many times. The `replay` subcommand reads a previously
+emitted JSON scan result and re-emits it in any other format — no live
+network or LLM calls. Handy when you want to:
+
+- archive a scan as JSON in CI and convert to SARIF later as a separate
+  step (so the SARIF upload doesn't block on a slow scan)
+- view an archived multi-server scan-config result locally as a tree
+- pipe an existing scan into a different consumer without rescanning
+
+```bash
+ramparts scan-config --format json > scan.json
+ramparts replay scan.json --format sarif > scan.sarif
+```
 
 
 

--- a/docs/security-features.md
+++ b/docs/security-features.md
@@ -120,6 +120,18 @@ Jailbreak attacks involve sophisticated attempts to bypass AI safety measures an
 
 Ramparts looks for patterns that suggest tools might be designed to enable jailbreaking, including tools that could be chained together to bypass restrictions, tools that seem designed to manipulate AI behavior, and tools that might provide pathways around safety measures.
 
+### Vulnerable Dependencies (Supply Chain)
+
+When a stdio MCP server is launched via `npx` (npm) or `uvx` (PyPI),
+ramparts extracts the package + version from the launch command and
+queries [OSV.dev](https://osv.dev) for known security advisories. Any
+findings are emitted as `VulnerableDependency` entries with full CVE/GHSA
+identifiers, summaries, and mapped CVSS severity. This catches the case
+where the MCP server itself is fine but it's running on a release of an
+underlying library with known CVEs (ReDoS, prototype pollution,
+arbitrary code execution, etc.). The check runs in parallel with the
+main scan and fails soft.
+
 ## How Ramparts Detects These Threats
 
 Ramparts uses a three-layer approach to catch these security issues:
@@ -136,6 +148,36 @@ Ramparts uses a three-layer approach to catch these security issues:
 This metadata makes it easy to prioritize security findings and understand their impact on your specific environment.
 
 **LLM-Powered Analysis** is where things get interesting. Ramparts uses AI models to understand the semantic meaning of tools and catch subtle issues that static analysis might miss. It can detect when a tool's description doesn't match its actual behavior, identify tools that might be designed to be deceptive, and spot complex attack patterns that require understanding context.
+
+## OWASP MCP Top 10 Mapping
+
+Every finding ramparts emits is tagged with one or more entries from the
+**OWASP MCP Top 10** so consumers (terminal output, JSON, SARIF, the
+markdown report) can group and prioritize results against a recognized
+framework. The taxonomy is pinned to a versioned YAML file
+(`taxonomies/owasp-mcp-top-10/2025.yaml`) — when the official list
+publishes a new revision, it lands as a new file rather than mutating
+the existing one, so previously-tagged findings stay interpretable.
+
+| ID | Category | Example ramparts findings |
+|---|---|---|
+| MCP01 | Prompt Injection | `PromptInjection`, `Jailbreak` |
+| MCP02 | Tool Poisoning | `ToolPoisoning`, `MCPConfigChanged` (baseline drift) |
+| MCP03 | Excessive Agency | `Jailbreak`, overscoped capabilities |
+| MCP04 | Insecure Tool Output Handling | `PathTraversalVulnerability` |
+| MCP05 | Cross-Origin Tool Confusion | `CrossDomainContamination`, `DomainOutlier`, `MixedSecuritySchemes` |
+| MCP06 | Credential and Secret Leakage | `SecretsLeakage`, `EnvironmentVariableLeakage`, `SSHKeyExposure`, `PEMFileAccess` |
+| MCP07 | Command and SQL Injection | `CommandInjection`, `SQLInjection`, `MCPConfigRisk` |
+| MCP08 | Authentication & Authorization Bypass | `AuthBypass` |
+| MCP09 | Sensitive Data Exposure | `PIILeakage`, secret findings |
+| MCP10 | Supply Chain | `MCPConfigRisk`, `VulnerableDependency` (OSV.dev) |
+
+Tags appear in:
+
+- **Terminal**: `OWASP MCP Top 10: MCP05, MCP06` after each finding
+- **JSON**: `owasp_tags` array on every `SecurityIssue` and `YaraScanResult`
+- **SARIF**: `properties.tags` on every `result` and `rule` definition
+  (e.g. `owasp-mcp-top-10:2025-draft:MCP05`)
 
 ## Severity Levels and What They Mean
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -66,36 +66,65 @@ xattr -d com.apple.quarantine /path/to/ramparts
 
 **Issue: Connection timeout**
 ```bash
-error: Connection timeout after 30 seconds
+error: Scan operation timed out
+# or
+error: STDIO scan operation timed out after 60s
 ```
 
 **Solutions:**
 ```bash
-# Increase timeout
+# Increase the overall scan budget and per-HTTP-request timeout
 ramparts scan <url> --timeout 120 --http-timeout 60
 
-# Check network connectivity
+# Check network connectivity directly
 curl -I <url>
 
-# Test with simple endpoint
-ramparts scan https://httpbin.org/json
+# Test against a known-good MCP endpoint
+ramparts scan "stdio:npx:-y:@modelcontextprotocol/server-everything"
 ```
 
-**Issue: SSL/TLS certificate errors**
+> **Note**: The `--timeout` flag bounds the *entire* scan (including LLM
+> security analysis); `--http-timeout` bounds individual HTTP requests
+> made during the scan. Both work for `scan` and `scan-config`, and both
+> apply to the stdio path too — a hung subprocess will be killed at
+> `--timeout` rather than hanging the CLI forever.
+
+**Issue: `Failed to create HTTP client: builder error`** (especially on a fresh
+EC2 instance, slim Linux image, or distroless container)
+
+This used to surface as the opaque `builder error: unexpected error: No CA
+certificates were loaded from the system` on hosts where
+`/etc/ssl/certs/ca-certificates.crt` is missing or empty (e.g. the
+`ca-certificates` package isn't installed). As of ramparts 0.7.0+ this is no
+longer reachable: ramparts ships [Mozilla's CA bundle](https://github.com/rustls/webpki-roots)
+embedded in the binary and hands reqwest a preconfigured rustls
+`ClientConfig` whose trust store is that bundle. There's no dependency on
+the host OS trust store anymore.
+
+If you're still seeing this on an older release:
 ```bash
-error: SSL certificate verify failed
+# Workaround until you upgrade
+sudo apt-get update && sudo apt-get install -y ca-certificates
+sudo update-ca-certificates
+
+# Or upgrade ramparts
+cargo install --force ramparts
+```
+
+**Issue: SSL/TLS certificate verification failure for a real host**
+```bash
+error: invalid peer certificate ...
 ```
 
 **Solutions:**
 ```bash
-# Update CA certificates (Ubuntu/Debian)
-sudo apt-get update && sudo apt-get install ca-certificates
+# Verify the certificate yourself first
+curl -I <url>
+openssl s_client -connect <host>:443 -servername <host> < /dev/null
 
-# Update CA certificates (macOS)
-brew install ca-certificates
-
-# For testing only (NOT recommended for production)
-export RUSTLS_VERIFY_CERT=false
+# If you're on a corporate network with MITM proxies, you'll need to
+# add the intermediate CA to the host trust store (ramparts uses the
+# embedded Mozilla bundle by default, which won't include private CAs).
 ```
 
 **Issue: HTTP 403 Forbidden**

--- a/src/config.rs
+++ b/src/config.rs
@@ -2328,6 +2328,101 @@ impl MCPConfigManager {
     pub fn has_config_files(&self) -> bool {
         self.config_paths.iter().any(|(path, _)| path.exists())
     }
+
+    /// Build a `MCPConfigManager` whose `config_paths` are discovered by
+    /// walking `root` for known MCP configuration filenames. Used by
+    /// `scan-config --root <PATH>` (see ramparts#51) to scan a checked-in
+    /// repository of IDE configs without relying on the user's home
+    /// directory state.
+    pub fn with_root(root: &Path) -> Self {
+        Self {
+            config_paths: Self::discover_config_paths_in_root(root),
+        }
+    }
+
+    /// Recursively walk `root` collecting paths whose filename matches a
+    /// known MCP config pattern. The directory walk skips a small set of
+    /// directories that never contain MCP configs (`.git`, `node_modules`,
+    /// `target`, `dist`, `build`) so a repo with thousands of files in
+    /// those directories doesn't pay for a full crawl.
+    fn discover_config_paths_in_root(root: &Path) -> Vec<(PathBuf, MCPClient)> {
+        const SKIP_DIRS: &[&str] = &[
+            ".git",
+            "node_modules",
+            "target",
+            "dist",
+            "build",
+            ".venv",
+            "venv",
+            "__pycache__",
+        ];
+        const CONFIG_FILENAMES: &[&str] = &[
+            "mcp.json",
+            "mcp_config.json",
+            "claude_desktop_config.json",
+            "settings.json",
+            "settings.local.json",
+            "managed-settings.json",
+        ];
+        const MAX_DEPTH: usize = 16;
+
+        fn walk(
+            dir: &Path,
+            depth: usize,
+            max_depth: usize,
+            skip_dirs: &[&str],
+            filenames: &[&str],
+            out: &mut Vec<(PathBuf, MCPClient)>,
+        ) {
+            if depth > max_depth {
+                return;
+            }
+            let Ok(entries) = std::fs::read_dir(dir) else {
+                return;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                let Ok(file_type) = entry.file_type() else {
+                    continue;
+                };
+                if file_type.is_symlink() {
+                    // Don't follow symlinks — avoids cycles and surprises
+                    // when scanning repos that link out to elsewhere.
+                    continue;
+                }
+                if file_type.is_dir() {
+                    if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                        if skip_dirs.contains(&name)
+                            || name.starts_with('.')
+                                && name != ".vscode"
+                                && name != ".cursor"
+                                && name != ".claude"
+                                && name != ".gemini"
+                                && name != ".windsurf"
+                                && name != ".codeium"
+                        {
+                            continue;
+                        }
+                    }
+                    walk(&path, depth + 1, max_depth, skip_dirs, filenames, out);
+                } else if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                    if filenames.contains(&name) || name.ends_with(".mcp.json") {
+                        let client =
+                            MCPConfigManager::detect_client(&path).unwrap_or(MCPClient::VSCode);
+                        out.push((path, client));
+                    }
+                }
+            }
+        }
+
+        let mut found = Vec::new();
+        if !root.exists() {
+            warn!("--root path does not exist: {}", root.display());
+            return found;
+        }
+        walk(root, 0, MAX_DEPTH, SKIP_DIRS, CONFIG_FILENAMES, &mut found);
+        found
+    }
 }
 
 #[cfg(test)]

--- a/src/core.rs
+++ b/src/core.rs
@@ -457,6 +457,7 @@ impl MCPScannerCore {
             format: "json".to_string(),
             auth_headers: auth_headers.clone(),
             return_prompts: false,
+            only: None,
         };
 
         let result = self.scanner.scan_single(url, scan_options).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,9 +13,11 @@ mod core;
 mod integration_tests;
 mod mcp_client;
 mod mcp_server;
+mod sarif;
 mod scanner;
 mod security;
 mod server;
+mod taxonomy;
 mod tls;
 
 mod types;
@@ -146,6 +148,13 @@ enum Commands {
         /// Per-HTTP-request timeout in seconds. Overrides `scanner.http_timeout` from config.yaml.
         #[arg(long, value_name = "SECONDS")]
         http_timeout: Option<u64>,
+
+        /// Walk this directory (e.g. a checked-in repo of IDE configs) for MCP
+        /// configuration files instead of looking at the user's home/IDE
+        /// locations. Recursive; symlinks are not followed; common build
+        /// directories like .git, node_modules, target are skipped.
+        #[arg(long, value_name = "PATH")]
+        root: Option<std::path::PathBuf>,
     },
 
     /// Generate a default config.yaml file
@@ -202,8 +211,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
     let cli = Cli::parse();
-    // Do not print banner when running as stdio MCP server to avoid corrupting JSON-RPC stdout
-    if !matches!(cli.command, Commands::McpStdio) {
+    // Do not print the banner when:
+    //   - running as stdio MCP server (would corrupt JSON-RPC stdout), or
+    //   - emitting a machine-readable scan format (json/raw/sarif), since
+    //     downstream tools like `jq`, GitHub code-scanning's SARIF
+    //     uploader, etc. parse our stdout and choke on free-form text.
+    if should_display_banner(&cli.command) {
         display_banner();
     }
 
@@ -215,6 +228,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     execute_command(cli, scanner_config, scanner).await?;
 
     Ok(())
+}
+
+/// Whether to print the welcome banner for the current command. Suppresses
+/// it for the stdio MCP server (would corrupt JSON-RPC framing) and for
+/// scan commands that produce machine-readable output.
+fn should_display_banner(command: &Commands) -> bool {
+    if matches!(command, Commands::McpStdio) {
+        return false;
+    }
+    let format = match command {
+        Commands::Scan { format, .. } | Commands::ScanConfig { format, .. } => format.as_deref(),
+        _ => None,
+    };
+    !matches!(
+        format.map(str::to_ascii_lowercase).as_deref(),
+        Some("json") | Some("raw") | Some("sarif")
+    )
 }
 
 /// Loads the scanner configuration, using defaults if loading fails
@@ -336,6 +366,7 @@ async fn execute_command(
             report,
             timeout,
             http_timeout,
+            root,
         } => {
             handle_scan_config_command(
                 auth_headers,
@@ -343,6 +374,7 @@ async fn execute_command(
                 report,
                 timeout,
                 http_timeout,
+                root,
                 &scanner_config,
                 scanner,
             )
@@ -423,6 +455,7 @@ async fn handle_scan_config_command(
     report: bool,
     timeout: Option<u64>,
     http_timeout: Option<u64>,
+    root: Option<std::path::PathBuf>,
     scanner_config: &ScannerConfig,
     scanner: Option<MCPScanner>,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -442,7 +475,12 @@ async fn handle_scan_config_command(
         .as_ref()
         .expect("Scanner should be initialized for scan-config command");
 
-    match scanner.scan_config_by_ide(options).await {
+    let scan_outcome = match root.as_deref() {
+        Some(root_path) => scanner.scan_config_in_root(root_path, options).await,
+        None => scanner.scan_config_by_ide(options).await,
+    };
+
+    match scan_outcome {
         Ok(results) => {
             utils::print_multi_server_results(
                 &results,

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod core;
 mod integration_tests;
 mod mcp_client;
 mod mcp_server;
+mod osv;
 mod sarif;
 mod scanner;
 mod security;
@@ -125,6 +126,13 @@ enum Commands {
         /// Per-HTTP-request timeout in seconds. Overrides `scanner.http_timeout` from config.yaml.
         #[arg(long, value_name = "SECONDS")]
         http_timeout: Option<u64>,
+
+        /// Restrict the scan to a subset of artifact kinds. Comma-separated:
+        /// `tools`, `prompts`, `resources` (singular forms also accepted).
+        /// When omitted, every kind is scanned. Useful for CI gates that
+        /// only care about one surface (`--only tools`).
+        #[arg(long, value_name = "KINDS")]
+        only: Option<String>,
     },
 
     /// Scan MCP servers from IDE configuration files (~/.cursor/mcp.json, ~/.codeium/windsurf/mcp_config.json)
@@ -155,6 +163,11 @@ enum Commands {
         /// directories like .git, node_modules, target are skipped.
         #[arg(long, value_name = "PATH")]
         root: Option<std::path::PathBuf>,
+
+        /// Restrict the scan to a subset of artifact kinds. Comma-separated:
+        /// `tools`, `prompts`, `resources` (singular forms also accepted).
+        #[arg(long, value_name = "KINDS")]
+        only: Option<String>,
     },
 
     /// Generate a default config.yaml file
@@ -197,6 +210,25 @@ enum Commands {
         #[arg(short, long, default_value = "8081")]
         port: u16,
     },
+
+    /// Replay a previously-saved scan result.
+    ///
+    /// Reads a `ramparts scan` / `scan-config` JSON output and re-emits it
+    /// through the requested format. Useful for: converting an archived JSON
+    /// scan into SARIF for code-scanning ingestion, viewing a CI artifact
+    /// locally, or chaining scan output into downstream tooling without
+    /// re-connecting to the MCP server. No live network or LLM calls.
+    Replay {
+        /// Path to a JSON file containing a `ScanResult` (single-server) or
+        /// `[ScanResult, ...]` (multi-server, as emitted by `scan-config`).
+        #[arg(value_name = "PATH")]
+        input: std::path::PathBuf,
+
+        /// Output format (json, raw, table, text, sarif). Defaults to the
+        /// configured scanner output format.
+        #[arg(long, value_name = "FORMAT")]
+        format: Option<String>,
+    },
 }
 
 #[tokio::main]
@@ -238,7 +270,9 @@ fn should_display_banner(command: &Commands) -> bool {
         return false;
     }
     let format = match command {
-        Commands::Scan { format, .. } | Commands::ScanConfig { format, .. } => format.as_deref(),
+        Commands::Scan { format, .. }
+        | Commands::ScanConfig { format, .. }
+        | Commands::Replay { format, .. } => format.as_deref(),
         _ => None,
     };
     !matches!(
@@ -347,6 +381,7 @@ async fn execute_command(
             report,
             timeout,
             http_timeout,
+            only,
         } => {
             handle_scan_command(
                 url,
@@ -355,6 +390,7 @@ async fn execute_command(
                 report,
                 timeout,
                 http_timeout,
+                only,
                 &scanner_config,
                 scanner,
             )
@@ -367,6 +403,7 @@ async fn execute_command(
             timeout,
             http_timeout,
             root,
+            only,
         } => {
             handle_scan_config_command(
                 auth_headers,
@@ -375,6 +412,7 @@ async fn execute_command(
                 timeout,
                 http_timeout,
                 root,
+                only,
                 &scanner_config,
                 scanner,
             )
@@ -388,7 +426,44 @@ async fn execute_command(
         Commands::McpStdio => handle_mcp_stdio_command().await,
         Commands::McpSse { host, port } => handle_mcp_sse_command(host, port).await,
         Commands::McpHttp { host, port } => handle_mcp_http_command(host, port).await,
+        Commands::Replay { input, format } => handle_replay_command(input, format, &scanner_config),
     }
+}
+
+/// Read a previously-emitted scan result JSON file and re-emit it through
+/// the requested format. Accepts both single-server (`ScanResult`) and
+/// multi-server (`Vec<ScanResult>`) shapes — sniffs which by attempting
+/// the array first, then falling back to a single object.
+fn handle_replay_command(
+    input: std::path::PathBuf,
+    format: Option<String>,
+    scanner_config: &ScannerConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let bytes = std::fs::read(&input).map_err(|e| {
+        Box::<dyn std::error::Error>::from(format!(
+            "Failed to read replay input {}: {e}",
+            input.display()
+        ))
+    })?;
+    let output_format = format.unwrap_or(scanner_config.scanner.format.clone());
+    // Try the multi-server shape first; the single-server shape fits inside
+    // a 1-element Vec for `print_multi_server_results` so we can route both
+    // through the same renderer below.
+    if let Ok(results) = serde_json::from_slice::<Vec<types::ScanResult>>(&bytes) {
+        utils::print_multi_server_results(
+            &results,
+            &output_format,
+            scanner_config.scanner.detailed,
+        );
+        return Ok(());
+    }
+    let result: types::ScanResult = serde_json::from_slice(&bytes).map_err(|e| {
+        Box::<dyn std::error::Error>::from(format!(
+            "Replay input is neither a `ScanResult` nor a `Vec<ScanResult>`: {e}"
+        ))
+    })?;
+    utils::print_result(&result, &output_format, scanner_config.scanner.detailed);
+    Ok(())
 }
 
 /// Handles the scan command for a single URL
@@ -400,17 +475,20 @@ async fn handle_scan_command(
     report: bool,
     timeout: Option<u64>,
     http_timeout: Option<u64>,
+    only: Option<String>,
     scanner_config: &ScannerConfig,
     scanner: Option<MCPScanner>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let auth_headers_map = parse_auth_headers(&auth_headers);
     let output_format = format.unwrap_or(scanner_config.scanner.format.clone());
+    let only_kinds = parse_only_filter(only)?;
     let options = build_scan_options(
         scanner_config,
         &output_format,
         auth_headers_map,
         timeout,
         http_timeout,
+        only_kinds,
     );
 
     validate_scan_config(&options);
@@ -456,17 +534,20 @@ async fn handle_scan_config_command(
     timeout: Option<u64>,
     http_timeout: Option<u64>,
     root: Option<std::path::PathBuf>,
+    only: Option<String>,
     scanner_config: &ScannerConfig,
     scanner: Option<MCPScanner>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let auth_headers_map = parse_auth_headers(&auth_headers);
     let output_format = format.unwrap_or(scanner_config.scanner.format.clone());
+    let only_kinds = parse_only_filter(only)?;
     let options = build_scan_options(
         scanner_config,
         &output_format,
         auth_headers_map,
         timeout,
         http_timeout,
+        only_kinds,
     );
 
     validate_scan_config(&options);
@@ -573,14 +654,17 @@ async fn handle_mcp_http_command(
 
 /// Builds scan options from configuration and parameters.
 ///
-/// `timeout_override` and `http_timeout_override` come from CLI flags and, when
-/// `Some`, take precedence over the values in `scanner_config`.
+/// CLI overrides (`timeout_override`, `http_timeout_override`, `only_kinds`)
+/// take precedence over the values in `scanner_config`. `only_kinds` is
+/// `None` when the user didn't pass `--only`; in that case every artifact
+/// kind is scanned.
 fn build_scan_options(
     scanner_config: &ScannerConfig,
     output_format: &str,
     auth_headers_map: Option<std::collections::HashMap<String, String>>,
     timeout_override: Option<u64>,
     http_timeout_override: Option<u64>,
+    only_kinds: Option<Vec<types::ArtifactKind>>,
 ) -> ScanOptions {
     ScanConfigBuilder::new()
         .timeout(timeout_override.unwrap_or(scanner_config.scanner.scan_timeout))
@@ -588,7 +672,30 @@ fn build_scan_options(
         .detailed(scanner_config.scanner.detailed)
         .format(output_format.to_string())
         .auth_headers(auth_headers_map)
+        .only(only_kinds)
         .build()
+}
+
+/// Parse the `--only` CLI value (e.g. `"tools,prompts"`) into the `Vec` shape
+/// `ScanOptions::only` expects, or surface a clean error when the value is
+/// malformed.
+fn parse_only_filter(
+    raw: Option<String>,
+) -> Result<Option<Vec<types::ArtifactKind>>, Box<dyn std::error::Error>> {
+    match raw {
+        None => Ok(None),
+        Some(s) => {
+            let kinds = types::ArtifactKind::parse_set(&s)
+                .map_err(|e| Box::<dyn std::error::Error>::from(e.to_string()))?;
+            // Empty string parses to empty vec; treat that as "no filter"
+            // rather than "scan nothing".
+            if kinds.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(kinds))
+            }
+        }
+    }
 }
 
 /// Validates scan configuration and exits on error

--- a/src/osv.rs
+++ b/src/osv.rs
@@ -1,0 +1,400 @@
+//! OSV.dev integration for stdio MCP servers' transitive dependencies.
+//!
+//! When ramparts scans a stdio MCP server launched via `npx` (npm) or
+//! `uvx` (PyPI), the scanner can extract the package name+version from
+//! the command/args and ask OSV.dev whether that release has known
+//! security advisories. Findings are surfaced through the existing YARA
+//! result type (`rule_name = "VulnerableDependency"`) so they propagate
+//! into terminal, JSON, markdown, and SARIF outputs without any new
+//! plumbing.
+//!
+//! This is an opportunistic, fail-soft check: an OSV query that times
+//! out, errors, or returns a non-200 status logs a warning and is
+//! treated as "no known vulns" rather than failing the whole scan.
+//! Downstream consumers should treat the absence of OSV findings as
+//! "we didn't see any" rather than "definitely clean".
+//!
+//! Supports two ecosystems today (covering the two most common stdio
+//! MCP server launch patterns); adding new ones is a matter of
+//! extending `parse_package_spec_from_command` and the ecosystem
+//! mapping in `query_osv`.
+
+use crate::types::{YaraRuleMetadata, YaraScanResult};
+use reqwest::Client;
+use serde::Deserialize;
+use std::time::Duration;
+use tracing::{debug, warn};
+
+const OSV_QUERY_URL: &str = "https://api.osv.dev/v1/query";
+const OSV_QUERY_TIMEOUT_SECS: u64 = 5;
+
+/// A parsed (ecosystem, name, version) triple ready to send to OSV.
+#[derive(Debug, Clone)]
+pub struct PackageSpec {
+    pub ecosystem: &'static str,
+    pub name: String,
+    pub version: Option<String>,
+}
+
+/// Parse a stdio MCP launch command into a `PackageSpec` suitable for an
+/// OSV query. Returns `None` when the command isn't a recognized package
+/// runner or the args don't yield a clean package reference. We only
+/// recognize the conservative subset we can parse without false positives:
+///
+/// - `npx [-y|--yes] [pkg@ver] [...rest]` → npm:pkg@ver
+/// - `uvx [--from pkg[==ver]] [pkg[==ver]] [...rest]` → PyPI:pkg@ver
+///
+/// Anything more exotic (custom scripts, shell pipelines, npx-with-multiple-
+/// packages) returns `None` so we don't emit false positives.
+pub fn parse_package_spec_from_command(command: &str, args: &[String]) -> Option<PackageSpec> {
+    match command {
+        "npx" => parse_npx(args),
+        "uvx" => parse_uvx(args),
+        _ => None,
+    }
+}
+
+fn parse_npx(args: &[String]) -> Option<PackageSpec> {
+    // First positional arg that doesn't start with `-` is the package.
+    let pkg_arg = args.iter().find(|a| !a.starts_with('-'))?;
+    let (name, version) = split_npm_spec(pkg_arg)?;
+    Some(PackageSpec {
+        ecosystem: "npm",
+        name,
+        version,
+    })
+}
+
+/// Split an npm package reference into (name, version). Handles scoped
+/// packages (`@scope/pkg`) where the leading `@` must NOT be parsed as a
+/// version separator.
+fn split_npm_spec(raw: &str) -> Option<(String, Option<String>)> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    // Scoped package: @scope/pkg[@ver]
+    if let Some(stripped) = raw.strip_prefix('@') {
+        let (scope, rest) = stripped.split_once('/')?;
+        if let Some((pkg, ver)) = rest.split_once('@') {
+            return Some((format!("@{scope}/{pkg}"), version_or_none(ver)));
+        }
+        return Some((format!("@{scope}/{rest}"), None));
+    }
+    if let Some((name, ver)) = raw.split_once('@') {
+        return Some((name.to_string(), version_or_none(ver)));
+    }
+    Some((raw.to_string(), None))
+}
+
+fn parse_uvx(args: &[String]) -> Option<PackageSpec> {
+    // `uvx --from pkg[==ver] cmd ...` or `uvx pkg[==ver] [...]`. Take the
+    // first non-flag token after a known flag, or the first non-flag token
+    // overall.
+    let mut iter = args.iter().peekable();
+    while let Some(arg) = iter.peek() {
+        if *arg == "--from" {
+            iter.next();
+            if let Some(spec) = iter.next() {
+                let (name, version) = split_pypi_spec(spec)?;
+                return Some(PackageSpec {
+                    ecosystem: "PyPI",
+                    name,
+                    version,
+                });
+            }
+            return None;
+        }
+        if arg.starts_with('-') {
+            iter.next();
+            continue;
+        }
+        break;
+    }
+    let pkg = iter.next()?;
+    let (name, version) = split_pypi_spec(pkg)?;
+    Some(PackageSpec {
+        ecosystem: "PyPI",
+        name,
+        version,
+    })
+}
+
+fn split_pypi_spec(raw: &str) -> Option<(String, Option<String>)> {
+    // PyPI version specifiers we care about: `pkg==1.2.3`, `pkg`. We leave
+    // looser specs (`pkg>=1.0`) alone because OSV needs an exact version
+    // to give a useful answer.
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    if let Some((name, ver)) = raw.split_once("==") {
+        return Some((name.to_string(), version_or_none(ver)));
+    }
+    Some((raw.to_string(), None))
+}
+
+fn version_or_none(s: &str) -> Option<String> {
+    let s = s.trim();
+    // npm/PyPI both treat "latest" as a tag rather than a real version. OSV
+    // can't resolve tags, so drop these and return the package alone — OSV
+    // will tell us "any known vulns at all", which is still useful info.
+    if s.is_empty() || s.eq_ignore_ascii_case("latest") {
+        None
+    } else {
+        Some(s.to_string())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct OsvQueryResponse {
+    #[serde(default)]
+    vulns: Vec<OsvVulnerability>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OsvVulnerability {
+    id: String,
+    #[serde(default)]
+    summary: Option<String>,
+    #[serde(default)]
+    details: Option<String>,
+    #[serde(default)]
+    severity: Vec<OsvSeverity>,
+    #[serde(default)]
+    aliases: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OsvSeverity {
+    #[serde(rename = "type")]
+    severity_type: String,
+    score: String,
+}
+
+/// Query OSV.dev for vulnerabilities affecting `spec`. Returns an empty
+/// `Vec` on any failure (network error, non-200 status, parse error) — the
+/// caller is responsible for treating "no findings" as "we didn't see any"
+/// rather than "definitely clean".
+///
+/// Takes `Client` by reference (cheap clones internally via `Arc`) and
+/// `PackageSpec` by value so callers can spawn the resulting future onto
+/// a `tokio::task` without lifetime gymnastics.
+pub async fn query_osv(client: Client, spec: PackageSpec) -> Vec<YaraScanResult> {
+    debug!(
+        "Querying OSV.dev for {}/{} ({:?})",
+        spec.ecosystem, spec.name, spec.version
+    );
+    let request_body = build_osv_request(&spec);
+    let response = match client
+        .post(OSV_QUERY_URL)
+        .timeout(Duration::from_secs(OSV_QUERY_TIMEOUT_SECS))
+        .json(&request_body)
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(
+                "OSV query failed for {}/{}: {}",
+                spec.ecosystem, spec.name, e
+            );
+            return Vec::new();
+        }
+    };
+    if !response.status().is_success() {
+        warn!(
+            "OSV returned {} for {}/{}",
+            response.status(),
+            spec.ecosystem,
+            spec.name
+        );
+        return Vec::new();
+    }
+    let body: OsvQueryResponse = match response.json().await {
+        Ok(b) => b,
+        Err(e) => {
+            warn!(
+                "Failed to parse OSV response for {}/{}: {}",
+                spec.ecosystem, spec.name, e
+            );
+            return Vec::new();
+        }
+    };
+
+    body.vulns
+        .into_iter()
+        .map(|v| osv_finding_to_yara_result(&spec, v))
+        .collect()
+}
+
+fn build_osv_request(spec: &PackageSpec) -> serde_json::Value {
+    let mut req = serde_json::json!({
+        "package": {
+            "name": spec.name,
+            "ecosystem": spec.ecosystem,
+        }
+    });
+    if let Some(version) = &spec.version {
+        req["version"] = serde_json::Value::String(version.clone());
+    }
+    req
+}
+
+fn osv_finding_to_yara_result(spec: &PackageSpec, vuln: OsvVulnerability) -> YaraScanResult {
+    let cvss = vuln
+        .severity
+        .iter()
+        .find(|s| s.severity_type.starts_with("CVSS"))
+        .map(|s| s.score.as_str())
+        .unwrap_or("unknown");
+    let severity = severity_label_for_cvss(cvss);
+    let summary = vuln
+        .summary
+        .as_deref()
+        .or(vuln.details.as_deref())
+        .unwrap_or("No summary provided by OSV");
+    let aliases = if vuln.aliases.is_empty() {
+        String::new()
+    } else {
+        format!(" (aliases: {})", vuln.aliases.join(", "))
+    };
+    let context = format!(
+        "{}/{} {}: {}{aliases}",
+        spec.ecosystem,
+        spec.name,
+        spec.version.as_deref().unwrap_or("(any version)"),
+        summary
+    );
+    YaraScanResult {
+        target_type: "dependency".to_string(),
+        target_name: format!(
+            "{}/{}@{}",
+            spec.ecosystem,
+            spec.name,
+            spec.version.as_deref().unwrap_or("?")
+        ),
+        rule_name: "VulnerableDependency".to_string(),
+        rule_file: Some("osv".to_string()),
+        matched_text: Some(vuln.id.clone()),
+        context,
+        rule_metadata: Some(YaraRuleMetadata {
+            name: Some("Vulnerable Dependency".to_string()),
+            author: Some("OSV.dev".to_string()),
+            date: None,
+            version: None,
+            description: Some(summary.to_string()),
+            severity: Some(severity.to_string()),
+            category: Some("supply-chain".to_string()),
+            confidence: Some("HIGH".to_string()),
+            tags: vec!["dependency".to_string(), "osv".to_string()],
+        }),
+        owasp_tags: crate::taxonomy::tags_for_yara_rule("VulnerableDependency"),
+        phase: Some("pre-scan".to_string()),
+        rules_executed: None,
+        security_issues_detected: None,
+        total_items_scanned: None,
+        total_matches: None,
+        status: Some("warning".to_string()),
+    }
+}
+
+/// Map a CVSS score string (e.g. "9.8", "CVSS:3.1/AV:N/...") to a coarse
+/// severity label aligned with the rest of ramparts' severity vocabulary.
+fn severity_label_for_cvss(score_text: &str) -> &'static str {
+    // Some OSV records put the full CVSS vector in `score`; others put just
+    // the numeric base score. Try to extract a leading float either way.
+    let numeric = score_text
+        .split('/')
+        .find_map(|part| part.parse::<f32>().ok());
+    match numeric {
+        Some(n) if n >= 9.0 => "CRITICAL",
+        Some(n) if n >= 7.0 => "HIGH",
+        Some(n) if n >= 4.0 => "MEDIUM",
+        Some(_) => "LOW",
+        None => "MEDIUM",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_plain_npx_pkg() {
+        let spec = parse_package_spec_from_command(
+            "npx",
+            &[
+                "-y".into(),
+                "@modelcontextprotocol/server-everything".into(),
+            ],
+        )
+        .expect("should parse");
+        assert_eq!(spec.ecosystem, "npm");
+        assert_eq!(spec.name, "@modelcontextprotocol/server-everything");
+        assert_eq!(spec.version, None);
+    }
+
+    #[test]
+    fn parses_npx_with_pinned_version() {
+        let spec = parse_package_spec_from_command("npx", &["lodash@4.17.21".into()])
+            .expect("should parse");
+        assert_eq!(spec.name, "lodash");
+        assert_eq!(spec.version, Some("4.17.21".into()));
+    }
+
+    #[test]
+    fn parses_npx_scoped_with_version() {
+        let spec = parse_package_spec_from_command("npx", &["@scope/pkg@1.2.3".into()])
+            .expect("should parse");
+        assert_eq!(spec.name, "@scope/pkg");
+        assert_eq!(spec.version, Some("1.2.3".into()));
+    }
+
+    #[test]
+    fn drops_latest_tag() {
+        let spec = parse_package_spec_from_command("npx", &["lodash@latest".into()])
+            .expect("should parse");
+        assert_eq!(spec.version, None);
+    }
+
+    #[test]
+    fn parses_uvx_with_from_flag() {
+        let spec = parse_package_spec_from_command(
+            "uvx",
+            &["--from".into(), "ruff==0.8.4".into(), "ruff".into()],
+        )
+        .expect("should parse");
+        assert_eq!(spec.ecosystem, "PyPI");
+        assert_eq!(spec.name, "ruff");
+        assert_eq!(spec.version, Some("0.8.4".into()));
+    }
+
+    #[test]
+    fn parses_uvx_positional() {
+        let spec = parse_package_spec_from_command("uvx", &["black".into()]).expect("should parse");
+        assert_eq!(spec.ecosystem, "PyPI");
+        assert_eq!(spec.name, "black");
+    }
+
+    #[test]
+    fn rejects_unrecognized_runner() {
+        assert!(parse_package_spec_from_command("python3", &["script.py".into()]).is_none());
+        assert!(
+            parse_package_spec_from_command("docker", &["run".into(), "image".into()]).is_none()
+        );
+    }
+
+    #[test]
+    fn cvss_severity_buckets() {
+        assert_eq!(severity_label_for_cvss("9.8"), "CRITICAL");
+        assert_eq!(severity_label_for_cvss("7.5"), "HIGH");
+        assert_eq!(severity_label_for_cvss("5.0"), "MEDIUM");
+        assert_eq!(severity_label_for_cvss("3.1"), "LOW");
+        assert_eq!(
+            severity_label_for_cvss("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"),
+            "MEDIUM"
+        );
+        assert_eq!(severity_label_for_cvss(""), "MEDIUM");
+    }
+}

--- a/src/sarif.rs
+++ b/src/sarif.rs
@@ -1,0 +1,313 @@
+//! SARIF 2.1.0 output for ramparts scan results.
+//!
+//! Emits a single SARIF log per `print_result` / `print_multi_server_results`
+//! call. We hand-build the JSON via `serde_json::Value` rather than defining
+//! ~30 nested types we'd only use for one-way emission. The shape conforms
+//! to SARIF 2.1.0 and uploads cleanly to GitHub Advanced Security via
+//! `github/codeql-action/upload-sarif`.
+//!
+//! See ramparts#96 for the design discussion. OWASP MCP Top 10 IDs (see
+//! ramparts#101) are emitted as `properties.tags` on each result so
+//! downstream consumers can filter by category.
+
+use crate::security::{SecurityIssue, SecurityIssueType};
+use crate::types::{ScanResult, YaraScanResult};
+use serde_json::{json, Map, Value};
+use std::collections::BTreeMap;
+
+const SARIF_SCHEMA_URI: &str =
+    "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json";
+const SARIF_VERSION: &str = "2.1.0";
+const TOOL_INFO_URI: &str = "https://github.com/highflame-ai/ramparts";
+
+/// Convert a single ScanResult into a SARIF log document. Useful for
+/// `ramparts scan <url> --format sarif`.
+pub fn scan_result_to_sarif(result: &ScanResult) -> Value {
+    sarif_log(std::slice::from_ref(result))
+}
+
+/// Convert a batch of ScanResults (one per scanned server) into a single
+/// SARIF log document. Each server becomes its own `runs[]` entry so
+/// findings stay attributed to their source.
+pub fn scan_results_to_sarif(results: &[ScanResult]) -> Value {
+    sarif_log(results)
+}
+
+fn sarif_log(results: &[ScanResult]) -> Value {
+    let runs: Vec<Value> = results.iter().map(build_run).collect();
+    json!({
+        "$schema": SARIF_SCHEMA_URI,
+        "version": SARIF_VERSION,
+        "runs": runs,
+    })
+}
+
+/// Build a single SARIF `run` for one scanned server. Collects the rule
+/// definitions actually referenced by this server's findings into
+/// `tool.driver.rules` and emits the findings in `results`.
+fn build_run(scan: &ScanResult) -> Value {
+    // Collect (ruleId -> rule definition) so the driver carries one entry per
+    // distinct rule we actually fired in this run. BTreeMap keeps the rule
+    // list deterministic.
+    let mut rules: BTreeMap<String, Value> = BTreeMap::new();
+    let mut sarif_results: Vec<Value> = Vec::new();
+
+    // Map YARA findings (and the in-process cross-origin scanner findings,
+    // which use the same type).
+    for yara in &scan.yara_results {
+        // Skip the synthetic summary rows — they aren't real findings.
+        if yara.target_type == "summary" {
+            continue;
+        }
+        let rule_id = yara.rule_name.clone();
+        rules
+            .entry(rule_id.clone())
+            .or_insert_with(|| build_rule_from_yara(yara));
+        sarif_results.push(build_result_from_yara(scan, yara));
+    }
+
+    // Map LLM-detected security issues across tools/prompts/resources.
+    if let Some(security) = &scan.security_issues {
+        for issue in &security.tool_issues {
+            let rule_id = security_issue_rule_id(issue.issue_type);
+            rules
+                .entry(rule_id.clone())
+                .or_insert_with(|| build_rule_from_security_issue(issue));
+            sarif_results.push(build_result_from_security_issue(scan, issue, "tool"));
+        }
+        for issue in &security.prompt_issues {
+            let rule_id = security_issue_rule_id(issue.issue_type);
+            rules
+                .entry(rule_id.clone())
+                .or_insert_with(|| build_rule_from_security_issue(issue));
+            sarif_results.push(build_result_from_security_issue(scan, issue, "prompt"));
+        }
+        for issue in &security.resource_issues {
+            let rule_id = security_issue_rule_id(issue.issue_type);
+            rules
+                .entry(rule_id.clone())
+                .or_insert_with(|| build_rule_from_security_issue(issue));
+            sarif_results.push(build_result_from_security_issue(scan, issue, "resource"));
+        }
+    }
+
+    json!({
+        "tool": {
+            "driver": {
+                "name": "ramparts",
+                "version": env!("CARGO_PKG_VERSION"),
+                "informationUri": TOOL_INFO_URI,
+                "rules": rules.into_values().collect::<Vec<_>>(),
+            }
+        },
+        "invocations": [{
+            "executionSuccessful": matches!(scan.status, crate::types::ScanStatus::Success),
+            "endTimeUtc": scan.timestamp.to_rfc3339(),
+        }],
+        "originalUriBaseIds": {
+            "MCP_SERVER": { "uri": scan.url }
+        },
+        "results": sarif_results,
+    })
+}
+
+fn build_rule_from_yara(yara: &YaraScanResult) -> Value {
+    let mut rule = Map::new();
+    rule.insert("id".into(), Value::String(yara.rule_name.clone()));
+    rule.insert("name".into(), Value::String(yara.rule_name.clone()));
+
+    if let Some(meta) = &yara.rule_metadata {
+        if let Some(name) = meta.name.as_ref() {
+            rule.insert("shortDescription".into(), json!({ "text": name }));
+        }
+        if let Some(desc) = meta.description.as_ref() {
+            rule.insert("fullDescription".into(), json!({ "text": desc }));
+        }
+        if let Some(sev) = meta.severity.as_ref() {
+            let mut props = Map::new();
+            props.insert("severity".into(), Value::String(sev.clone()));
+            props.insert(
+                "security-severity".into(),
+                Value::String(severity_score(sev).to_string()),
+            );
+            if !yara.owasp_tags.is_empty() {
+                props.insert("tags".into(), owasp_tags_value(&yara.owasp_tags));
+            }
+            rule.insert("properties".into(), Value::Object(props));
+        }
+    } else if !yara.owasp_tags.is_empty() {
+        rule.insert(
+            "properties".into(),
+            json!({ "tags": owasp_tags_value(&yara.owasp_tags) }),
+        );
+    }
+
+    Value::Object(rule)
+}
+
+fn build_result_from_yara(scan: &ScanResult, yara: &YaraScanResult) -> Value {
+    let severity = yara
+        .rule_metadata
+        .as_ref()
+        .and_then(|m| m.severity.as_deref())
+        .unwrap_or("MEDIUM");
+    let level = severity_to_sarif_level(severity);
+
+    let message = yara
+        .matched_text
+        .as_ref()
+        .map(|t| format!("{}: {}", yara.context, t))
+        .unwrap_or_else(|| yara.context.clone());
+
+    let mut props = Map::new();
+    props.insert(
+        "security-severity".into(),
+        Value::String(severity_score(severity).to_string()),
+    );
+    if !yara.owasp_tags.is_empty() {
+        props.insert("tags".into(), owasp_tags_value(&yara.owasp_tags));
+    }
+    props.insert(
+        "target".into(),
+        json!({
+            "type": yara.target_type,
+            "name": yara.target_name,
+        }),
+    );
+
+    json!({
+        "ruleId": yara.rule_name,
+        "level": level,
+        "message": { "text": message },
+        "locations": [logical_location(&scan.url, &yara.target_name)],
+        "properties": Value::Object(props),
+    })
+}
+
+fn build_rule_from_security_issue(issue: &SecurityIssue) -> Value {
+    let id = security_issue_rule_id(issue.issue_type);
+    let mut props = Map::new();
+    props.insert("severity".into(), Value::String(issue.severity.clone()));
+    props.insert(
+        "security-severity".into(),
+        Value::String(severity_score(&issue.severity).to_string()),
+    );
+    if !issue.owasp_tags.is_empty() {
+        props.insert("tags".into(), owasp_tags_value(&issue.owasp_tags));
+    }
+    json!({
+        "id": id,
+        "name": format!("{:?}", issue.issue_type),
+        "shortDescription": { "text": issue.message },
+        "fullDescription": { "text": issue.description },
+        "properties": Value::Object(props),
+    })
+}
+
+fn build_result_from_security_issue(
+    scan: &ScanResult,
+    issue: &SecurityIssue,
+    target_kind: &str,
+) -> Value {
+    let target_name = issue
+        .tool_name
+        .clone()
+        .or_else(|| issue.prompt_name.clone())
+        .or_else(|| issue.resource_uri.clone())
+        .unwrap_or_else(|| target_kind.to_string());
+
+    let mut props = Map::new();
+    props.insert(
+        "security-severity".into(),
+        Value::String(severity_score(&issue.severity).to_string()),
+    );
+    if !issue.owasp_tags.is_empty() {
+        props.insert("tags".into(), owasp_tags_value(&issue.owasp_tags));
+    }
+    props.insert(
+        "target".into(),
+        json!({ "type": target_kind, "name": target_name.clone() }),
+    );
+
+    let level = severity_to_sarif_level(&issue.severity);
+
+    json!({
+        "ruleId": security_issue_rule_id(issue.issue_type),
+        "level": level,
+        "message": { "text": issue.message },
+        "locations": [logical_location(&scan.url, &target_name)],
+        "properties": Value::Object(props),
+    })
+}
+
+fn logical_location(server_url: &str, target_name: &str) -> Value {
+    json!({
+        "logicalLocations": [{
+            "name": target_name,
+            "fullyQualifiedName": format!("{server_url}::{target_name}"),
+            "kind": "function"
+        }]
+    })
+}
+
+fn owasp_tags_value(tags: &[crate::taxonomy::OwaspTag]) -> Value {
+    Value::Array(
+        tags.iter()
+            .map(|t| Value::String(format!("owasp-mcp-top-10:{}:{}", t.version, t.id)))
+            .collect(),
+    )
+}
+
+fn security_issue_rule_id(t: SecurityIssueType) -> String {
+    format!("ramparts.security.{t:?}")
+}
+
+/// Map ramparts severity (CRITICAL/HIGH/MEDIUM/LOW) to a SARIF `level` value
+/// (`error`, `warning`, `note`). SARIF doesn't have a CRITICAL level so we
+/// fold it into `error`.
+fn severity_to_sarif_level(sev: &str) -> &'static str {
+    match sev.to_ascii_uppercase().as_str() {
+        "CRITICAL" | "HIGH" => "error",
+        "MEDIUM" => "warning",
+        _ => "note",
+    }
+}
+
+/// Map ramparts severity to a numeric `security-severity` (CVSS-like 0–10)
+/// so GitHub code-scanning renders the right severity badge.
+fn severity_score(sev: &str) -> f32 {
+    match sev.to_ascii_uppercase().as_str() {
+        "CRITICAL" => 9.5,
+        "HIGH" => 7.5,
+        "MEDIUM" => 5.0,
+        "LOW" => 3.0,
+        _ => 1.0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::ScanResult;
+
+    #[test]
+    fn empty_result_produces_valid_sarif_structure() {
+        let result = ScanResult::new("http://localhost:3000".to_string());
+        let log = scan_result_to_sarif(&result);
+        assert_eq!(log["version"], "2.1.0");
+        assert!(log["runs"].is_array());
+        assert_eq!(log["runs"].as_array().unwrap().len(), 1);
+        let run = &log["runs"][0];
+        assert_eq!(run["tool"]["driver"]["name"], "ramparts");
+        assert!(run["results"].is_array());
+    }
+
+    #[test]
+    fn severity_mapping_covers_all_levels() {
+        assert_eq!(severity_to_sarif_level("CRITICAL"), "error");
+        assert_eq!(severity_to_sarif_level("HIGH"), "error");
+        assert_eq!(severity_to_sarif_level("MEDIUM"), "warning");
+        assert_eq!(severity_to_sarif_level("LOW"), "note");
+        assert_eq!(severity_to_sarif_level("unknown"), "note");
+    }
+}

--- a/src/sarif.rs
+++ b/src/sarif.rs
@@ -126,10 +126,7 @@ fn build_rule_from_yara(yara: &YaraScanResult) -> Value {
         if let Some(sev) = meta.severity.as_ref() {
             let mut props = Map::new();
             props.insert("severity".into(), Value::String(sev.clone()));
-            props.insert(
-                "security-severity".into(),
-                Value::String(severity_score(sev).to_string()),
-            );
+            props.insert("security-severity".into(), severity_score_value(sev));
             if !yara.owasp_tags.is_empty() {
                 props.insert("tags".into(), owasp_tags_value(&yara.owasp_tags));
             }
@@ -160,10 +157,7 @@ fn build_result_from_yara(scan: &ScanResult, yara: &YaraScanResult) -> Value {
         .unwrap_or_else(|| yara.context.clone());
 
     let mut props = Map::new();
-    props.insert(
-        "security-severity".into(),
-        Value::String(severity_score(severity).to_string()),
-    );
+    props.insert("security-severity".into(), severity_score_value(severity));
     if !yara.owasp_tags.is_empty() {
         props.insert("tags".into(), owasp_tags_value(&yara.owasp_tags));
     }
@@ -179,18 +173,25 @@ fn build_result_from_yara(scan: &ScanResult, yara: &YaraScanResult) -> Value {
         "ruleId": yara.rule_name,
         "level": level,
         "message": { "text": message },
-        "locations": [logical_location(&scan.url, &yara.target_name)],
+        "locations": [logical_location(&scan.url, &yara.target_name, &yara.target_type)],
         "properties": Value::Object(props),
     })
 }
 
 fn build_rule_from_security_issue(issue: &SecurityIssue) -> Value {
+    // Multiple findings of the same SecurityIssueType collapse to the same
+    // `ruleId` and therefore share this single rule definition. Use the
+    // class-generic message from `SecurityIssueType::default_message` rather
+    // than `issue.message`/`issue.description`, which describe a specific
+    // finding and would otherwise leak into the shared rule definition
+    // depending only on which finding was processed first.
     let id = security_issue_rule_id(issue.issue_type);
+    let generic_description = issue.issue_type.default_message();
     let mut props = Map::new();
     props.insert("severity".into(), Value::String(issue.severity.clone()));
     props.insert(
         "security-severity".into(),
-        Value::String(severity_score(&issue.severity).to_string()),
+        severity_score_value(&issue.severity),
     );
     if !issue.owasp_tags.is_empty() {
         props.insert("tags".into(), owasp_tags_value(&issue.owasp_tags));
@@ -198,8 +199,8 @@ fn build_rule_from_security_issue(issue: &SecurityIssue) -> Value {
     json!({
         "id": id,
         "name": format!("{:?}", issue.issue_type),
-        "shortDescription": { "text": issue.message },
-        "fullDescription": { "text": issue.description },
+        "shortDescription": { "text": generic_description },
+        "fullDescription": { "text": generic_description },
         "properties": Value::Object(props),
     })
 }
@@ -219,7 +220,7 @@ fn build_result_from_security_issue(
     let mut props = Map::new();
     props.insert(
         "security-severity".into(),
-        Value::String(severity_score(&issue.severity).to_string()),
+        severity_score_value(&issue.severity),
     );
     if !issue.owasp_tags.is_empty() {
         props.insert("tags".into(), owasp_tags_value(&issue.owasp_tags));
@@ -235,19 +236,48 @@ fn build_result_from_security_issue(
         "ruleId": security_issue_rule_id(issue.issue_type),
         "level": level,
         "message": { "text": issue.message },
-        "locations": [logical_location(&scan.url, &target_name)],
+        "locations": [logical_location(&scan.url, &target_name, target_kind)],
         "properties": Value::Object(props),
     })
 }
 
-fn logical_location(server_url: &str, target_name: &str) -> Value {
+/// Build a SARIF `location` whose `kind` reflects what kind of MCP entity
+/// produced the finding. Per the SARIF 2.1.0 logical-location `kind` enum,
+/// `resource` is the literal match for an MCP resource; `function` fits an
+/// MCP tool (callable, takes args, returns output); `member` is the closest
+/// option for prompts (no first-class SARIF kind exists for templated
+/// strings). Unknown target types fall back to `function` rather than being
+/// dropped entirely so consumers always get a `kind` field.
+fn logical_location(server_url: &str, target_name: &str, target_kind: &str) -> Value {
+    let kind = match target_kind {
+        "tool" => "function",
+        "resource" => "resource",
+        "prompt" => "member",
+        // Cross-origin scanner targets ("domain-analysis", "outlier-analysis",
+        // "scheme-analysis") and the YARA pre-scan target_type "server" are
+        // structural, not callable; SARIF doesn't have a perfect kind for
+        // them, so we use "module" as the closest neutral container kind.
+        "server" | "domain-analysis" | "outlier-analysis" | "scheme-analysis" => "module",
+        _ => "function",
+    };
     json!({
         "logicalLocations": [{
             "name": target_name,
             "fullyQualifiedName": format!("{server_url}::{target_name}"),
-            "kind": "function"
+            "kind": kind
         }]
     })
+}
+
+/// Render a numeric `security-severity` (0.0–10.0) as a JSON number.
+/// GitHub Code Scanning accepts both string and number forms but their
+/// SARIF spec annotation calls it a floating point number, so we emit the
+/// stricter form.
+fn severity_score_value(sev: &str) -> Value {
+    let score = severity_score(sev);
+    serde_json::Number::from_f64(f64::from(score))
+        .map(Value::Number)
+        .unwrap_or_else(|| Value::String(score.to_string()))
 }
 
 fn owasp_tags_value(tags: &[crate::taxonomy::OwaspTag]) -> Value {

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1248,6 +1248,18 @@ impl MCPScanner {
 
         let mut result = ScanResult::new(display_url.clone());
 
+        // Kick off a parallel OSV.dev lookup for this server's launch package
+        // (e.g. `npx -y @scope/pkg@1.2.3` -> npm:@scope/pkg@1.2.3). We don't
+        // wait on it inline — the future is awaited after the scan body so
+        // the OSV roundtrip overlaps with the actual MCP handshake + tool
+        // enumeration. Returns an empty Vec when no recognizable package
+        // spec can be parsed from the command (e.g. raw `python3 script.py`).
+        let osv_findings_future =
+            crate::osv::parse_package_spec_from_command(command, args).map(|spec| {
+                debug!("Launching OSV lookup for {}/{}", spec.ecosystem, spec.name);
+                crate::osv::query_osv(self.client.clone(), spec)
+            });
+
         // Wrap the entire connect-and-scan pipeline in `options.timeout` so a
         // hung subprocess (no MCP handshake response, deadlocked tool, etc.)
         // can't make the CLI hang forever — same overall budget the HTTP path
@@ -1272,6 +1284,15 @@ impl MCPScanner {
             }
         })
         .await;
+
+        // Drain the OSV future (no-op if no spec was parseable). Findings
+        // append to result.yara_results regardless of whether the main scan
+        // succeeded — supply-chain risks are real even if the server is
+        // unreachable right now.
+        let osv_findings = match osv_findings_future {
+            Some(fut) => fut.await,
+            None => Vec::new(),
+        };
 
         match scan_result {
             Ok((session, mut scan_data)) => {
@@ -1364,6 +1385,18 @@ impl MCPScanner {
                 result.add_error(format!("STDIO scan failed: {e}"));
                 warn!("STDIO scan failed for {}: {}", display_url, e);
             }
+        }
+
+        // Append OSV supply-chain findings (if any) regardless of the main
+        // scan's success: a failed handshake doesn't make the dependency
+        // any less vulnerable.
+        if !osv_findings.is_empty() {
+            debug!(
+                "OSV reported {} vulnerability finding(s) for {}",
+                osv_findings.len(),
+                display_url
+            );
+            result.yara_results.extend(osv_findings);
         }
 
         result.response_time_ms = scan_timer.elapsed_ms();
@@ -1950,6 +1983,10 @@ impl MCPScanner {
         // Store fetch errors in scan_data for later inclusion in final result
         scan_data.fetch_errors = fetch_errors;
 
+        // Apply --only filter: drop categories the user didn't ask for so
+        // they don't appear in security analysis or output.
+        Self::apply_only_filter(&mut scan_data, options);
+
         // Clean up the session to prevent session deletion errors
         if let Err(e) = self.mcp_client.cleanup_session(&session).await {
             warn!("Failed to clean up MCP session: {}", e);
@@ -1958,11 +1995,30 @@ impl MCPScanner {
         Ok(scan_data)
     }
 
+    /// Drop tools / resources / prompts from `scan_data` based on
+    /// `ScanOptions::only`. When `only` is `None`, no-op. When it's `Some`,
+    /// any artifact kind not in the list is cleared so downstream YARA, LLM,
+    /// and cross-origin steps see nothing for it.
+    fn apply_only_filter(scan_data: &mut ScanData, options: &ScanOptions) {
+        let Some(kinds) = options.only.as_ref() else {
+            return;
+        };
+        if !kinds.contains(&crate::types::ArtifactKind::Tools) {
+            scan_data.tools.clear();
+        }
+        if !kinds.contains(&crate::types::ArtifactKind::Resources) {
+            scan_data.resources.clear();
+        }
+        if !kinds.contains(&crate::types::ArtifactKind::Prompts) {
+            scan_data.prompts.clear();
+        }
+    }
+
     /// Perform scan with an existing MCP session (for STDIO transport)
     async fn perform_scan_with_session(
         &self,
         session: &crate::types::MCPSession,
-        _options: &ScanOptions,
+        options: &ScanOptions,
     ) -> Result<ScanData> {
         let mut scan_data = ScanData::new();
 
@@ -2066,6 +2122,9 @@ impl MCPScanner {
 
         // Store fetch errors in scan_data for later inclusion in final result
         scan_data.fetch_errors = fetch_errors;
+
+        // Apply --only filter (same as the HTTP path).
+        Self::apply_only_filter(&mut scan_data, options);
 
         // Clean up the session to prevent session deletion errors
         if let Err(e) = self.mcp_client.cleanup_session(session).await {

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -670,6 +670,7 @@ impl YaraScanner {
             matched_text: None,
             context: generate_context_message(T::item_type(), &match_info.rule_name),
             rule_metadata: match_info.metadata.clone(),
+            owasp_tags: crate::taxonomy::tags_for_yara_rule(&match_info.rule_name),
             phase: None,
             rules_executed: None,
             security_issues_detected: None,
@@ -757,6 +758,7 @@ impl Scanner for YaraScanner {
                         stats.pre_scan_count, total_items
                     ),
                     rule_metadata: None,
+                    owasp_tags: Vec::new(),
                     phase: Some("pre-scan".to_string()),
                     rules_executed: if stats.pre_scan_rules.is_empty() {
                         None
@@ -860,6 +862,7 @@ impl Scanner for YaraScanner {
                         stats.post_scan_count, total_items
                     ),
                     rule_metadata: None,
+                    owasp_tags: Vec::new(),
                     phase: Some("post-scan".to_string()),
                     rules_executed: if stats.post_scan_rules.is_empty() {
                         None
@@ -1368,10 +1371,28 @@ impl MCPScanner {
     }
 
     /// Scan MCP servers from IDE configuration files
-    /// Scan configuration files grouped by IDE  
+    /// Scan configuration files grouped by IDE
     pub async fn scan_config_by_ide(&self, options: ScanOptions) -> Result<Vec<ScanResult>> {
-        let config_manager = MCPConfigManager::new();
+        self.scan_config_by_ide_inner(MCPConfigManager::new(), options)
+            .await
+    }
 
+    /// Scan MCP servers discovered by walking a user-supplied root directory
+    /// (e.g. a checked-in repo of IDE configs). See ramparts#51.
+    pub async fn scan_config_in_root(
+        &self,
+        root: &Path,
+        options: ScanOptions,
+    ) -> Result<Vec<ScanResult>> {
+        self.scan_config_by_ide_inner(MCPConfigManager::with_root(root), options)
+            .await
+    }
+
+    async fn scan_config_by_ide_inner(
+        &self,
+        config_manager: MCPConfigManager,
+        options: ScanOptions,
+    ) -> Result<Vec<ScanResult>> {
         if !config_manager.has_config_files() {
             return Err(anyhow!("No MCP IDE configuration files found"));
         }
@@ -1514,6 +1535,7 @@ impl MCPScanner {
                             matched_text: None,
                             context: generate_context_message("server", &m.rule_name),
                             rule_metadata: m.metadata.clone(),
+                            owasp_tags: crate::taxonomy::tags_for_yara_rule(&m.rule_name),
                             phase: Some("pre-config".to_string()),
                             rules_executed: None,
                             security_issues_detected: None,
@@ -1554,6 +1576,7 @@ impl MCPScanner {
                                 confidence: Some("MEDIUM".to_string()),
                                 tags: vec!["baseline".to_string()],
                             }),
+                            owasp_tags: crate::taxonomy::tags_for_yara_rule("MCPConfigChanged"),
                             phase: Some("pre-config".to_string()),
                             rules_executed: None,
                             security_issues_detected: None,

--- a/src/security/cross_origin_scanner.rs
+++ b/src/security/cross_origin_scanner.rs
@@ -283,6 +283,7 @@ impl CrossOriginScanner {
                     analysis.unique_root_domains.len()
                 ),
                 rule_metadata: Some(metadata.clone()),
+                owasp_tags: crate::taxonomy::tags_for_yara_rule("CrossDomainContamination"),
                 phase: Some(match self.phase {
                     ScanPhase::PreScan => "pre-scan".to_string(),
                     ScanPhase::PostScan => "post-scan".to_string(),
@@ -306,6 +307,7 @@ impl CrossOriginScanner {
                     matched_text: Some(outlier.clone()),
                     context: "Tool or resource using different domain than majority".to_string(),
                     rule_metadata: Some(metadata.clone()),
+                    owasp_tags: crate::taxonomy::tags_for_yara_rule("DomainOutlier"),
                     phase: Some(match self.phase {
                         ScanPhase::PreScan => "pre-scan".to_string(),
                         ScanPhase::PostScan => "post-scan".to_string(),
@@ -346,6 +348,7 @@ impl CrossOriginScanner {
                     "Tools or resources use both secure (HTTPS) and insecure (HTTP) connections"
                         .to_string(),
                 rule_metadata: Some(metadata.clone()),
+                owasp_tags: crate::taxonomy::tags_for_yara_rule("MixedSecuritySchemes"),
                 phase: Some(match self.phase {
                     ScanPhase::PreScan => "pre-scan".to_string(),
                     ScanPhase::PostScan => "post-scan".to_string(),

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -149,7 +149,11 @@ impl SecurityIssueType {
         }
     }
 
-    fn default_message(self) -> &'static str {
+    /// Generic, finding-independent description of this issue class.
+    /// Used both as the prefix for `SecurityIssue::message` and as the
+    /// `shortDescription` for the SARIF rule definition (which must be
+    /// generic because multiple findings share the same `ruleId`).
+    pub fn default_message(self) -> &'static str {
         match self {
             SecurityIssueType::ToolPoisoning => "Tool with destructive or malicious intent",
             SecurityIssueType::SQLInjection => "Tool allowing SQL injection attacks",

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -174,6 +174,12 @@ pub struct SecurityIssue {
     pub details: Option<String>,
     pub severity: String,
     pub message: String,
+    /// OWASP MCP Top 10 categories this issue maps to. Derived from
+    /// `issue_type` via `taxonomy::tags_for_security_issue`. Always populated
+    /// at construction (every `SecurityIssueType` has at least one entry —
+    /// enforced by a unit test in `taxonomy.rs`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub owasp_tags: Vec<crate::taxonomy::OwaspTag>,
 }
 
 impl SecurityIssue {
@@ -188,6 +194,7 @@ impl SecurityIssue {
             details: None,
             severity: issue_type.default_severity().to_string(),
             message,
+            owasp_tags: crate::taxonomy::tags_for_security_issue(issue_type),
         }
     }
 }

--- a/src/taxonomy.rs
+++ b/src/taxonomy.rs
@@ -1,0 +1,159 @@
+//! OWASP MCP Top 10 taxonomy mapping.
+//!
+//! Tags ramparts findings with their OWASP MCP Top 10 category so consumers
+//! (terminal output, JSON, SARIF, the markdown report) can group and
+//! prioritize findings against a recognized framework.
+//!
+//! The taxonomy itself lives in `taxonomies/owasp-mcp-top-10/<version>.yaml`.
+//! Mappings from finding identifiers to taxonomy IDs are intentionally kept
+//! in code (rather than per-rule YAML metadata) for now so we have one file
+//! to audit when the OWASP list is refreshed. See ramparts#101.
+//!
+//! When the OWASP MCP Top 10 publishes a stable revision, add a new YAML
+//! file with the new version key and update the constants below; we never
+//! mutate published mappings in place so existing tagged findings remain
+//! interpretable.
+
+use crate::security::SecurityIssueType;
+use serde::{Deserialize, Serialize};
+
+/// The current taxonomy version Ramparts emits. Bumped explicitly when we
+/// adopt a new OWASP MCP Top 10 revision so consumers can treat the change
+/// as a deliberate upgrade.
+pub const CURRENT_TAXONOMY_VERSION: &str = "2025-draft";
+
+/// A reference to a single OWASP MCP Top 10 entry. Designed to be cheap to
+/// clone and friendly to serde so it can be embedded directly in finding
+/// types and propagate into JSON / SARIF / markdown outputs without any
+/// extra plumbing. We use `String` rather than `&'static str` so the type
+/// implements `Deserialize` (consumers may round-trip our JSON output back
+/// through serde); the strings are short and the per-finding clone cost is
+/// negligible relative to the rest of a scan.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OwaspTag {
+    pub id: String,
+    pub version: String,
+}
+
+impl OwaspTag {
+    pub fn new(id: &'static str) -> Self {
+        Self {
+            id: id.to_string(),
+            version: CURRENT_TAXONOMY_VERSION.to_string(),
+        }
+    }
+}
+
+/// Map an LLM-detected `SecurityIssueType` to the OWASP MCP Top 10 entries
+/// it belongs to. A single issue can map to multiple categories; e.g.
+/// `SecretsLeakage` is both credential leakage (MCP06) and a sensitive-data
+/// exposure (MCP09).
+pub fn tags_for_security_issue(issue: SecurityIssueType) -> Vec<OwaspTag> {
+    use SecurityIssueType::*;
+    match issue {
+        ToolPoisoning => vec![OwaspTag::new("MCP02"), OwaspTag::new("MCP03")],
+        SQLInjection | CommandInjection => vec![OwaspTag::new("MCP07")],
+        PathTraversal => vec![OwaspTag::new("MCP04")],
+        AuthBypass => vec![OwaspTag::new("MCP08")],
+        PromptInjection => vec![OwaspTag::new("MCP01")],
+        Jailbreak => vec![OwaspTag::new("MCP01"), OwaspTag::new("MCP03")],
+        PIILeakage => vec![OwaspTag::new("MCP09")],
+        SecretsLeakage => vec![OwaspTag::new("MCP06"), OwaspTag::new("MCP09")],
+    }
+}
+
+/// Map a YARA rule name (the value returned by yara-x's `Rule::identifier`)
+/// to OWASP MCP Top 10 entries. Rule names not listed here are returned as
+/// an empty Vec rather than an error — better to have a finding without
+/// taxonomy tags than to drop the finding because we forgot to map a new
+/// rule. Untagged findings are also useful telemetry: they tell us which
+/// rules need taxonomy entries added.
+pub fn tags_for_yara_rule(rule_name: &str) -> Vec<OwaspTag> {
+    match rule_name {
+        // secrets_leakage.yar
+        "SecretsLeakage" | "EnvironmentVariableLeakage" => {
+            vec![OwaspTag::new("MCP06"), OwaspTag::new("MCP09")]
+        }
+        "SSHKeyExposure" | "PEMFileAccess" => vec![OwaspTag::new("MCP06")],
+
+        // command_injection.yar
+        "CommandInjection" => vec![OwaspTag::new("MCP07")],
+
+        // sql_injection.yar
+        "SQLInjection" => vec![OwaspTag::new("MCP07")],
+
+        // path_traversal.yar
+        "PathTraversalVulnerability" => vec![OwaspTag::new("MCP04")],
+
+        // mcp_config_risk.yar
+        "MCPConfigRisk" => vec![OwaspTag::new("MCP10"), OwaspTag::new("MCP07")],
+
+        // Synthetic rule emitted by the baseline-diff check when a previously
+        // approved server's command/args/env fingerprint changes.
+        "MCPConfigChanged" => vec![OwaspTag::new("MCP02")],
+
+        // cross_origin_escalation.yar + the in-process cross-origin scanner
+        "CrossOriginEscalation"
+        | "CrossDomainContamination"
+        | "DomainOutlier"
+        | "MixedSecuritySchemes" => vec![OwaspTag::new("MCP05")],
+
+        _ => Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_security_issue_type_has_at_least_one_tag() {
+        use SecurityIssueType::*;
+        let all = [
+            ToolPoisoning,
+            SQLInjection,
+            CommandInjection,
+            PathTraversal,
+            AuthBypass,
+            PromptInjection,
+            Jailbreak,
+            PIILeakage,
+            SecretsLeakage,
+        ];
+        for issue in all {
+            assert!(
+                !tags_for_security_issue(issue).is_empty(),
+                "SecurityIssueType::{issue:?} has no OWASP tags — every \
+                 detection class should map to at least one Top 10 entry"
+            );
+        }
+    }
+
+    #[test]
+    fn known_yara_rules_have_tags() {
+        for name in [
+            "SecretsLeakage",
+            "EnvironmentVariableLeakage",
+            "SSHKeyExposure",
+            "PEMFileAccess",
+            "CommandInjection",
+            "SQLInjection",
+            "PathTraversalVulnerability",
+            "MCPConfigRisk",
+            "CrossOriginEscalation",
+            "CrossDomainContamination",
+            "DomainOutlier",
+            "MixedSecuritySchemes",
+        ] {
+            assert!(
+                !tags_for_yara_rule(name).is_empty(),
+                "YARA rule {name} should be tagged"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_yara_rule_returns_empty_not_panic() {
+        assert!(tags_for_yara_rule("totally-made-up-rule").is_empty());
+    }
+}

--- a/src/taxonomy.rs
+++ b/src/taxonomy.rs
@@ -92,6 +92,11 @@ pub fn tags_for_yara_rule(rule_name: &str) -> Vec<OwaspTag> {
         // approved server's command/args/env fingerprint changes.
         "MCPConfigChanged" => vec![OwaspTag::new("MCP02")],
 
+        // Emitted by the OSV.dev integration when a stdio MCP server's
+        // npx/uvx package release has known security advisories. Pure
+        // supply-chain finding.
+        "VulnerableDependency" => vec![OwaspTag::new("MCP10")],
+
         // cross_origin_escalation.yar + the in-process cross-origin scanner
         "CrossOriginEscalation"
         | "CrossDomainContamination"

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,5 @@
 use crate::security::SecurityScanResult;
+use crate::taxonomy::OwaspTag;
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -40,6 +41,11 @@ pub struct YaraScanResult {
     pub context: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rule_metadata: Option<YaraRuleMetadata>,
+    /// OWASP MCP Top 10 categories this finding maps to. Populated from the
+    /// rule name via `taxonomy::tags_for_yara_rule`. Empty when no mapping
+    /// exists yet for the rule — the finding is still reported.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub owasp_tags: Vec<OwaspTag>,
     // Execution summary fields (when target_type is "summary")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub phase: Option<String>,
@@ -504,6 +510,7 @@ mod tests {
             matched_text: Some("matched content".to_string()),
             context: "test context".to_string(),
             rule_metadata: None,
+            owasp_tags: Vec::new(),
             phase: Some("pre-scan".to_string()),
             rules_executed: Some(vec![
                 "secrets_leakage:SecretsLeakage".to_string(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -75,6 +75,7 @@ pub struct ScanConfigBuilder {
     auth_headers: Option<HashMap<String, String>>,
     // When true, do not call the LLM; instead, return the prompts that would be used
     return_prompts: bool,
+    only: Option<Vec<ArtifactKind>>,
 }
 
 impl Default for ScanConfigBuilder {
@@ -86,6 +87,7 @@ impl Default for ScanConfigBuilder {
             format: "text".to_string(),
             auth_headers: None,
             return_prompts: false,
+            only: None,
         }
     }
 }
@@ -125,6 +127,11 @@ impl ScanConfigBuilder {
         self
     }
 
+    pub fn only(mut self, only: Option<Vec<ArtifactKind>>) -> Self {
+        self.only = only;
+        self
+    }
+
     pub fn build(self) -> ScanOptions {
         ScanOptions {
             timeout: self.timeout,
@@ -133,6 +140,7 @@ impl ScanConfigBuilder {
             format: self.format,
             auth_headers: self.auth_headers,
             return_prompts: self.return_prompts,
+            only: self.only,
         }
     }
 }
@@ -160,6 +168,47 @@ pub mod config_utils {
     }
 }
 
+/// Which artifact kinds (tools, prompts, resources) a scan covers. When
+/// `None`, every kind is included. When `Some`, the scan keeps only the
+/// listed kinds and discards the others before security analysis runs —
+/// see ramparts `--only` flag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ArtifactKind {
+    Tools,
+    Prompts,
+    Resources,
+}
+
+impl ArtifactKind {
+    /// Parse a CLI value like `"tools,prompts"` into a set of kinds.
+    /// Returns an error on unknown tokens so a typo doesn't silently
+    /// turn into "scan everything".
+    pub fn parse_set(raw: &str) -> Result<Vec<Self>> {
+        let mut out = Vec::new();
+        for token in raw.split(',') {
+            let token = token.trim();
+            if token.is_empty() {
+                continue;
+            }
+            let kind = match token.to_ascii_lowercase().as_str() {
+                "tool" | "tools" => ArtifactKind::Tools,
+                "prompt" | "prompts" => ArtifactKind::Prompts,
+                "resource" | "resources" => ArtifactKind::Resources,
+                other => {
+                    return Err(anyhow::anyhow!(
+                        "Unknown artifact kind '{other}' in --only. \
+                         Expected: tools, prompts, resources (comma-separated)"
+                    ))
+                }
+            };
+            if !out.contains(&kind) {
+                out.push(kind);
+            }
+        }
+        Ok(out)
+    }
+}
+
 /// Scan options configuration
 #[derive(Debug, Clone)]
 pub struct ScanOptions {
@@ -170,6 +219,9 @@ pub struct ScanOptions {
     pub auth_headers: Option<HashMap<String, String>>,
     /// When true, do not call the LLM; instead, return prompts to the caller
     pub return_prompts: bool,
+    /// Restrict the scan to a subset of artifact kinds. `None` = scan all.
+    /// Set via the `--only` CLI flag; see `ArtifactKind::parse_set`.
+    pub only: Option<Vec<ArtifactKind>>,
 }
 
 impl Default for ScanOptions {
@@ -181,6 +233,7 @@ impl Default for ScanOptions {
             format: "text".to_string(),
             auth_headers: None,
             return_prompts: false,
+            only: None,
         }
     }
 }
@@ -397,6 +450,7 @@ mod tests {
             format: "json".to_string(),
             auth_headers: None,
             return_prompts: false,
+            only: None,
         };
 
         let result = config_utils::validate_scan_config(&options);
@@ -412,6 +466,7 @@ mod tests {
             format: "json".to_string(),
             auth_headers: None,
             return_prompts: false,
+            only: None,
         };
 
         let result = config_utils::validate_scan_config(&options);
@@ -431,6 +486,7 @@ mod tests {
             format: "json".to_string(),
             auth_headers: None,
             return_prompts: false,
+            only: None,
         };
 
         let result = config_utils::validate_scan_config(&options);
@@ -450,6 +506,7 @@ mod tests {
             format: "json".to_string(),
             auth_headers: None,
             return_prompts: false,
+            only: None,
         };
 
         let result = config_utils::validate_scan_config(&options);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -120,10 +120,19 @@ pub fn print_result(result: &ScanResult, format: &str, detailed: bool) {
         "table" => print_table_result(result, detailed),
         "text" => print_text_result(result),
         "raw" => print_raw_json_result(result),
+        "sarif" => print_sarif_result(result),
         _ => {
             eprintln!("Unknown format: {format}. Using table format.");
             print_table_result(result, detailed);
         }
+    }
+}
+
+fn print_sarif_result(result: &ScanResult) {
+    let log = crate::sarif::scan_result_to_sarif(result);
+    match serde_json::to_string_pretty(&log) {
+        Ok(s) => println!("{s}"),
+        Err(e) => eprintln!("Error serializing SARIF: {e}"),
     }
 }
 
@@ -912,6 +921,15 @@ fn print_table_result(result: &ScanResult, detailed: bool) {
                     println!("  Rule: {} (MEDIUM)", yara_result.rule_name);
                 }
 
+                if !yara_result.owasp_tags.is_empty() {
+                    let ids: Vec<&str> = yara_result
+                        .owasp_tags
+                        .iter()
+                        .map(|t| t.id.as_str())
+                        .collect();
+                    println!("  OWASP MCP Top 10: {}", ids.join(", "));
+                }
+
                 if let Some(matched_text) = &yara_result.matched_text {
                     println!("  Matched: {matched_text}");
                 }
@@ -1248,10 +1266,19 @@ pub fn print_multi_server_results(results: &[ScanResult], format: &str, detailed
         "table" => print_multi_server_tree(results, detailed),
         "text" => print_multi_server_text(results),
         "raw" => print_multi_server_raw_json(results),
+        "sarif" => print_multi_server_sarif(results),
         _ => {
             eprintln!("Unknown format: {format}. Using tree view format.");
             print_multi_server_tree(results, detailed);
         }
+    }
+}
+
+fn print_multi_server_sarif(results: &[ScanResult]) {
+    let log = crate::sarif::scan_results_to_sarif(results);
+    match serde_json::to_string_pretty(&log) {
+        Ok(s) => println!("{s}"),
+        Err(e) => eprintln!("Error serializing SARIF: {e}"),
     }
 }
 

--- a/taxonomies/owasp-mcp-top-10/2025.yaml
+++ b/taxonomies/owasp-mcp-top-10/2025.yaml
@@ -1,0 +1,71 @@
+# OWASP MCP Top 10 (2025 — draft)
+#
+# This file is the canonical, versioned definition of the threat taxonomy
+# Ramparts uses to tag findings. The official OWASP MCP Top 10 is still
+# being ratified; this file ships the working list Ramparts maps against
+# today and is pinned to its version key. When the official list lands,
+# add a new file (e.g. `2026.yaml`) and migrate rule mappings explicitly
+# rather than editing this file in place.
+version: "2025-draft"
+title: "OWASP MCP Top 10 (2025 draft)"
+url: "https://owasp.org/www-project-mcp-top-10/"
+items:
+  - id: MCP01
+    name: Prompt Injection
+    description: >-
+      Tools, prompts, or resources contain instructions that attempt to
+      override the user's intent or coerce the agent into unsafe actions.
+      Includes both direct injection in tool descriptions and indirect
+      injection via fetched data.
+  - id: MCP02
+    name: Tool Poisoning
+    description: >-
+      A previously-approved tool's name, description, or input schema has
+      been silently modified to introduce hidden behavior or expand its
+      effective capability. Hashed-pinning detection (see ramparts#97)
+      maps to this category.
+  - id: MCP03
+    name: Excessive Agency
+    description: >-
+      The MCP server exposes capabilities (write, exec, system control)
+      far beyond what the agent's task requires, increasing blast radius
+      of any successful prompt injection or tool poisoning.
+  - id: MCP04
+    name: Insecure Tool Output Handling
+    description: >-
+      Tool outputs (paths, filenames, returned data) are not properly
+      validated or sanitized, enabling path traversal, file disclosure,
+      or downstream injection in agents that consume the output.
+  - id: MCP05
+    name: Cross-Origin Tool Confusion
+    description: >-
+      Tools, resources, or prompts span multiple unrelated domains/origins
+      in a single agent context, enabling cross-origin escalation, data
+      exfiltration via mismatched-origin tool chains, or schema spoofing.
+  - id: MCP06
+    name: Credential and Secret Leakage
+    description: >-
+      Tools handle, return, or are configured with secrets (API keys,
+      tokens, passwords, private keys) without proper redaction or scope
+      restriction.
+  - id: MCP07
+    name: Command and SQL Injection
+    description: >-
+      Tool input schemas accept free-form strings that are passed directly
+      to system commands, shells, or SQL queries without sanitization.
+  - id: MCP08
+    name: Authentication and Authorization Bypass
+    description: >-
+      Tools that access protected resources without enforcing authentication,
+      or tools that allow privilege escalation via parameter manipulation.
+  - id: MCP09
+    name: Sensitive Data Exposure
+    description: >-
+      Tools or resources expose PII, internal data, or other sensitive
+      information beyond what the calling agent or downstream user needs.
+  - id: MCP10
+    name: Supply Chain
+    description: >-
+      Risks introduced by the MCP server itself: untrusted package source,
+      unpinned versions, environment-variable leakage in the launch
+      command, or risky shell/interpreter invocations.


### PR DESCRIPTION
## Summary

Three independent features in one branch (per the agreed cut: SARIF + OWASP pair naturally; repo-scan is bonus, isolated code).

Closes #96, #101, #51.

### #101 — OWASP MCP Top 10 taxonomy
- `taxonomies/owasp-mcp-top-10/2025.yaml` — pinned draft taxonomy (10 categories: prompt injection, tool poisoning, excessive agency, insecure output handling, cross-origin tool confusion, credential leakage, command/SQL injection, authn/authz bypass, sensitive data exposure, supply chain).
- `src/taxonomy.rs` — `OwaspTag` type plus two mapping functions covering both LLM-detected `SecurityIssueType` variants and shipped YARA rule names.
- `owasp_tags` field added to `YaraScanResult` and `SecurityIssue`, populated at finding-creation. Surfaces in JSON output automatically (serde) and in terminal output as `OWASP MCP Top 10: MCP05, MCP06`.
- Tests assert every detection class maps to at least one Top 10 entry.

**Out of scope (intentional):** the `--coverage` matrix flag and per-rule YAML metadata files. Worth follow-up issues.

### #96 — SARIF 2.1.0 output
- `--format sarif` on both `scan` and `scan-config`.
- `src/sarif.rs` builds a SARIF 2.1.0 log via `serde_json::Value` (avoids ~30 unused nested types).
- One `runs[]` entry per scanned server; rule definitions deduped into `tool.driver.rules[]`.
- Severity → SARIF level: CRITICAL/HIGH → `error`, MEDIUM → `warning`, LOW → `note`. Also emits numeric `security-severity` (0–10) for GitHub code-scanning.
- OWASP tags surface as `properties.tags` (`owasp-mcp-top-10:2025-draft:MCP05`) on every result and rule.
- Banner suppressed for `--format json | raw | sarif` so downstream parsers get clean stdout.

### #51 — Repo-root config scan
- `--root <PATH>` flag on `scan-config` walks a directory for known MCP config filenames (`mcp.json`, `*.mcp.json`, `claude_desktop_config.json`, `settings.json`, etc.).
- Skips `.git`, `node_modules`, `target`, `dist`, `build`, `.venv`, `venv`, `__pycache__` and other dotdirs (except known IDE config directories). Symlinks not followed; depth cap 16.
- Reuses the existing parse + scan pipeline via new `MCPConfigManager::with_root` + `MCPScanner::scan_config_in_root`.

## Test plan

- [x] `cargo build --all-features` clean
- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --all-features` — 98/98 (5 new in taxonomy + sarif)
- [x] `--root` smoke test: temp dir with two `mcp.json` files in different subdirs → both discovered + parsed
- [x] `--format sarif` smoke test: stdio scan against `everything` MCP → valid SARIF 2.1.0, OWASP tags propagate
- [x] HTTPS smoke test against GitHub Copilot MCP — banner suppressed in `--format json/sarif`
- [x] CI green
