### PR TITLE
fix: bundle Mozilla CA list to fix "No CA certificates were loaded" on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2746,6 +2746,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "webpki-roots",
  "yara-x",
 ]
 
@@ -4627,6 +4628,15 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,10 +110,17 @@ rand = "0.9"
 
 # Pulled in transitively via reqwest 0.13 / hyper-rustls; we declare it
 # directly so we can install the process-wide CryptoProvider explicitly at
-# startup. Without an explicit install, rustls 0.23 + aws-lc-rs auto-init
-# fails on some environments (notably some macOS configurations) and
-# `reqwest::Client::builder().build()` returns an opaque `"builder error"`.
+# startup AND build a `ClientConfig` whose root cert store is the bundled
+# Mozilla CA list (see `webpki-roots` below). Without that, reqwest 0.13's
+# default `rustls` feature pulls in `rustls-platform-verifier`, which has
+# been observed to fail with "No CA certificates were loaded from the
+# system" on some macOS configurations.
 rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs"] }
+
+# Mozilla's CA bundle, ahead-of-time. We use this instead of the OS trust
+# store so HTTPS connectivity is reproducible across environments and not
+# subject to platform-verifier's "no CAs loaded" failure mode.
+webpki-roots = "1"
 
 # Bring in common as path dependency
 ramparts-common = { path = "common" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod mcp_server;
 mod scanner;
 mod security;
 mod server;
+mod tls;
 
 mod types;
 mod utils;

--- a/src/mcp_client.rs
+++ b/src/mcp_client.rs
@@ -109,6 +109,7 @@ impl McpClient {
         HttpClient::builder()
             .default_headers(headers)
             .timeout(std::time::Duration::from_secs(self.http_timeout_secs))
+            .use_preconfigured_tls((*crate::tls::default_tls_config()).clone())
             .build()
             .map_err(|e| {
                 anyhow!(

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -928,6 +928,7 @@ impl MCPScanner {
         let client = Client::builder()
             .timeout(Duration::from_secs(http_timeout))
             .user_agent(protocol::USER_AGENT)
+            .use_preconfigured_tls((*crate::tls::default_tls_config()).clone())
             .build()
             .map_err(|e| anyhow!("Failed to create HTTP client: {}", format_error_chain(&e)))?;
 

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,0 +1,36 @@
+//! Shared TLS configuration for every reqwest client ramparts builds.
+//!
+//! Why this exists: reqwest 0.13's default `rustls` feature pulls in
+//! `rustls-platform-verifier`, which loads CAs from the host OS trust store.
+//! That fails outright on some user environments (we've seen "No CA
+//! certificates were loaded from the system" on otherwise-working macOS
+//! installs), which surfaces as the very opaque
+//! `reqwest::Client::builder().build() -> "builder error"`.
+//!
+//! Switching to a built-in Mozilla CA bundle (`webpki-roots`) makes HTTPS
+//! connectivity reproducible across environments and removes our dependency
+//! on the host trust store. Every `reqwest::Client` we build for outbound
+//! traffic should use `default_tls_config()` via
+//! `Client::builder().use_preconfigured_tls(...)` so this propagates to the
+//! simple HTTP path, the rmcp streamable HTTP path, and the scanner's own
+//! reqwest client.
+
+use std::sync::Arc;
+
+use rustls::ClientConfig;
+use rustls::RootCertStore;
+
+/// Build a fresh `rustls::ClientConfig` whose root store is the bundled
+/// Mozilla CA list. The returned `ClientConfig` is `Arc`-wrapped so multiple
+/// reqwest builders can share it without recomputing the root store.
+pub fn default_tls_config() -> Arc<ClientConfig> {
+    let mut roots = RootCertStore::empty();
+    // webpki-roots ships a `&'static [TrustAnchor<'static>]`; cloning each
+    // entry is cheap and the resulting `RootCertStore` owns its data.
+    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+
+    let config = ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    Arc::new(config)
+}

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -15,15 +15,20 @@
 //! simple HTTP path, the rmcp streamable HTTP path, and the scanner's own
 //! reqwest client.
 
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use rustls::ClientConfig;
 use rustls::RootCertStore;
 
-/// Build a fresh `rustls::ClientConfig` whose root store is the bundled
-/// Mozilla CA list. The returned `ClientConfig` is `Arc`-wrapped so multiple
-/// reqwest builders can share it without recomputing the root store.
-pub fn default_tls_config() -> Arc<ClientConfig> {
+/// Built-once, shared-many `rustls::ClientConfig` whose root store is the
+/// bundled Mozilla CA list. Memoized via `LazyLock` so the (non-trivial)
+/// `RootCertStore` construction runs exactly once per process even when
+/// many reqwest builders ask for the config.
+///
+/// `LazyLock` over `OnceLock`/`once_cell` because we already use `LazyLock`
+/// elsewhere in the crate (`config::CONFIG_PATHS_CACHE`) and it's in the
+/// standard library — no extra dep.
+static DEFAULT_TLS_CONFIG: LazyLock<Arc<ClientConfig>> = LazyLock::new(|| {
     let mut roots = RootCertStore::empty();
     // webpki-roots ships a `&'static [TrustAnchor<'static>]`; cloning each
     // entry is cheap and the resulting `RootCertStore` owns its data.
@@ -33,4 +38,11 @@ pub fn default_tls_config() -> Arc<ClientConfig> {
         .with_root_certificates(roots)
         .with_no_client_auth();
     Arc::new(config)
+});
+
+/// Returns the shared `rustls::ClientConfig` (see `DEFAULT_TLS_CONFIG`).
+/// The returned `Arc` is cheap to clone — the underlying config and root
+/// store are constructed exactly once.
+pub fn default_tls_config() -> Arc<ClientConfig> {
+    Arc::clone(&DEFAULT_TLS_CONFIG)
 }


### PR DESCRIPTION
## Summary

Hotfix for a startup-blocking error reported on a fresh EC2 ubuntu/debian Linux instance:

```
ERROR Failed to create server: Failed to create HTTP client: builder error:
      unexpected error: No CA certificates were loaded from the system
```

## Root cause

reqwest 0.13's `rustls` feature (added in #102) pulls in `rustls-platform-verifier`, which on Linux loads the system CA bundle via `openssl-probe`. On minimal/distroless Linux images — or any host where `/etc/ssl/certs/ca-certificates.crt` isn't populated (e.g. Debian slim without the `ca-certificates` package, fresh EC2 AMIs without it) — it returns zero roots and `reqwest::Client::builder().build()` fails outright before any HTTPS request is attempted.

## Fix

Ship Mozilla's CA bundle ahead of time via `webpki-roots` and hand reqwest a preconfigured `rustls::ClientConfig` whose trust store is that bundle. This removes our dependency on the host OS trust store entirely — HTTPS connectivity is now reproducible across environments.

- Add `webpki-roots = "1"` direct dep.
- New `src/tls.rs::default_tls_config()` builds an `Arc<rustls::ClientConfig>` once and shares it across every reqwest builder ramparts uses.
- `MCPScanner::with_timeout` and `McpClient::create_http_client` both call `Client::builder().use_preconfigured_tls(...)` with that config.
- The aws-lc-rs CryptoProvider install in `main()` (from #103) stays — it's required for rustls 0.23 regardless of cert source.

## Test plan

- [x] `cargo build --all-features` clean
- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] `cargo test --all-features` — 93/93 pass
- [x] HTTPS smoke test: `ramparts scan https://api.githubcopilot.com/mcp/ --auth-headers "Authorization: Bearer $(gh auth token)"` — 44 tools enumerated, SUCCESS. Confirms cert validation still works against real public certs.
- [ ] CI green
- [ ] Reporter confirms `ramparts server` starts on their EC2 instance
