### PR TITLE
feat: agent skill scanning (Claude Code commands and friends)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ ramparts scan-config --root ./ide-configs
 # Scan a single skill file or every *.md skill under a directory
 ramparts skills scan ./.claude/commands
 
-# Discover skills from well-known locations (~/.claude/commands, ./.claude/commands)
+# Discover skills across supported ecosystems (Claude Code, Cursor,
+# Codex, Windsurf, Gemini) at the user and workspace level. Add extra
+# roots with RAMPARTS_SKILL_ROOTS=path1,path2.
 ramparts skills scan-config
 
 # SARIF output for code-scanning ingestion

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ MCP servers expose powerful capabilities—file systems, databases, APIs, and sy
 
 ### What Ramparts Does
 
-Ramparts provides **security scanning** of MCP servers by:
+Ramparts provides **security scanning** of the MCP ecosystem by:
 
 1. **Discovering Capabilities**: Scans all MCP endpoints to identify available tools, resources, and prompts
 2. **Multi-Transport Support**: Supports HTTP, SSE, stdio, and subprocess transports with intelligent fallback
@@ -40,7 +40,10 @@ Ramparts provides **security scanning** of MCP servers by:
 4. **Static Analysis**: Performs yara-based checks for common vulnerabilities
 5. **Cross-Origin Analysis**: Detects when tools span multiple domains, which could enable context hijacking or injection attacks
 6. **LLM-Powered Analysis**: Uses AI models to detect sophisticated security issues
-7. **Risk Assessment**: Categorizes findings by severity and provides actionable recommendations
+7. **Supply-Chain Coverage**: Queries OSV.dev for known vulnerabilities in npx/uvx-launched stdio MCP servers
+8. **Skill Scanning**: Same threat model, applied to agent skill markdown files (Claude Code commands, etc.) on disk
+9. **OWASP MCP Top 10 Tagging**: Every finding is mapped to a versioned OWASP MCP Top 10 entry — visible in terminal, JSON, SARIF, and markdown reports
+10. **Risk Assessment**: Categorizes findings by severity and provides actionable recommendations
 >
 > **💡 Jump directly to detailed Rampart features?**
 > [**📚 Detailed Features**](docs/features.md)
@@ -86,7 +89,27 @@ ramparts scan-config
 
 # With detailed report generation
 ramparts scan-config --report
+
+# Walk a checked-in repo of IDE configs (great for CI on a configs-only repo)
+ramparts scan-config --root ./ide-configs
 ```
+
+**Scan AI agent skills (Claude Code commands, etc.)**
+```bash
+# Scan a single skill file or every *.md skill under a directory
+ramparts skills scan ./.claude/commands
+
+# Discover skills from well-known locations (~/.claude/commands, ./.claude/commands)
+ramparts skills scan-config
+
+# SARIF output for code-scanning ingestion
+ramparts skills scan ./.claude/commands --format sarif > skills.sarif
+```
+
+Skills are markdown files containing prompt instructions an agent loads and
+executes by name. Ramparts parses each skill's frontmatter and body and runs
+the same security pipeline (LLM analysis, YARA pre/post scan, OWASP MCP Top
+10 tagging) used for live MCP servers — pure static analysis on disk.
 
 > **💡 Did you know you can start Ramparts as a server?** Run `ramparts server` to get a REST API for continuous monitoring and CI/CD integration. See 📚 **[Ramparts Server Mode](docs/api.md)** 
 

--- a/docs/CHANGELOG-v0.8.0.md
+++ b/docs/CHANGELOG-v0.8.0.md
@@ -54,6 +54,94 @@ The taxonomy is pinned to a versioned YAML file (`taxonomies/owasp-mcp-top-10/20
 | MCP09 | Sensitive Data Exposure | `PIILeakage`, secret findings |
 | MCP10 | Supply Chain | `MCPConfigRisk`, `VulnerableDependency` |
 
+### Agent skill scanning
+
+New `ramparts skills` subcommand for scanning AI agent skill files —
+markdown documents containing prompt instructions an agent loads and
+executes by name (Claude Code custom slash commands, Cursor agent
+skills, Codex / Windsurf / Gemini equivalents). Skills share a threat
+model with MCP prompts (untrusted instructions an agent may follow), so
+the existing security pipeline applies directly.
+
+```bash
+# Scan a single file or every *.md skill under a directory
+ramparts skills scan ./.claude/commands
+
+# Discover skills across supported ecosystems automatically
+ramparts skills scan-config
+
+# SARIF for code-scanning ingestion
+ramparts skills scan ./.claude/commands --format sarif > skills.sarif
+```
+
+`scan-config` walks `~/<dotdir>/{commands,skills}` and the same paths
+under the current workspace for every supported ecosystem (`.claude`,
+`.cursor`, `.codex`, `.windsurf`, `.gemini`, `.openai`). Add extra
+roots without rebuilding via the **`RAMPARTS_SKILL_ROOTS`** env var
+(comma-separated paths, leading `~/` expanded).
+
+**6 skill-targeted YARA rules** (parsed body content):
+
+- `PromptInjectionSignature` — instruction-override patterns ("ignore
+  all previous", role redefinition, hide-from-user behavior)
+- `UnicodeSteganography` — invisible / Tags-block / RTLO Unicode
+- `CoerciveInjection` — mandatory-execution language, tool poisoning
+- `IndirectPromptInjection` — delegating to untrusted external content
+- `AutonomyAbuse` — skip-confirmation, override-user, infinite retry,
+  self-modify, privilege-escalation
+- `CapabilityInflation` — keyword stuffing, "use this first", deceptive
+  certification claims, hidden activation triggers
+
+**3 additional skill-targeted YARA rules** (written for ramparts):
+
+- `SkillCredentialHarvesting` — vendor token formats (`AKIA...`,
+  `ghp_...`, `sk-ant-api...`, `sk-proj-...`, `AIzaSy...`,
+  `xox[abprs]-...`), inline PEM private-key blocks, active credential-
+  theft verbs
+- `SkillToolChainingExfiltration` — credential-file read + network
+  egress to known exfil destinations (Discord webhooks, Telegram,
+  pastebin, ngrok / requestbin / webhook.site tunnels)
+- `SkillSystemManipulation` — `dd if=/dev/zero`, `wipefs`, `shred`,
+  `rm -rf /etc`, `chmod 777 /`, `sudo -i`, `LD_PRELOAD=` hijack,
+  PATH poisoning
+
+**6 structural heuristics** (parser-emitted, things YARA can't see):
+
+- `OverbroadAllowedTools` — `allowed-tools` grant gives unrestricted
+  code execution (bare `Bash`, `Bash(*)`, `Bash(*:*)`, `*`)
+- `DataExfiltrationGrant` — `WebFetch` / `WebSearch` / `Fetch` /
+  `Browse` grant
+- `VagueSkillTrigger` — substantive body with missing / one-word
+  description
+- `GenericSkillTrigger` — description is a vacuous trigger phrase
+  (`"help"`, `"a general purpose assistant"`, `"do anything"`)
+- `SkillSensitiveFileReference` — Claude Code `@<path>` syntax inlines
+  a sensitive file (SSH/AWS/GnuPG/kube/docker creds, `.env`,
+  `.netrc`) into prompt context
+- `SkillNameCollision` — two or more skill files declare the same
+  `name` (cross-skill check, runs once per scan)
+- `SkillEmbeddedPayload` — body contains a 500+ char base64 / hex
+  blob (defers decoding to runtime to bypass YARA + LLM analysis;
+  data-URI image blobs are excluded)
+
+**Pre-existing rule tightening**: in the process of running the
+scanner against real internal skills, three pre-existing rules
+(`command_injection.yar`, `sql_injection.yar`, `secrets_leakage.yar`)
+were tightened to remove patterns that fired on technical
+documentation — markdown headings (`#`) being read as SQL comments,
+`docker exec` matching bare `exec`, `rm -rf node_modules` matching
+`rm -rf` without target check, `req.AccountID = claims.AccountID`
+matching the secret-assignment pattern. Real attack signatures are
+preserved; FPs on doc-heavy content are gone.
+
+Routed end-to-end through the existing pipeline: each skill becomes
+a synthetic `MCPPrompt` for the LLM analyzer, runs through the YARA
+pre-scan, gets OWASP MCP Top 10 tags, and renders identically to MCP
+prompt findings in terminal / JSON / SARIF / markdown reports.
+Skills with body > 2 MB are skipped; the directory walker honors the
+same conventions as `scan-config --root` (no symlinks, build-dir
+skip, depth cap 16).
+
 ### Supply-chain dependency scan via OSV.dev (#104)
 
 When a stdio MCP server is launched via `npx` (npm) or `uvx` (PyPI), ramparts now extracts the package name + version from the launch command and queries [OSV.dev](https://osv.dev) for known security advisories. Findings emit as `VulnerableDependency` entries, mapped to OWASP **MCP10 Supply Chain**.
@@ -175,10 +263,11 @@ Cleared RUSTSEC-2026-0097 (rand unsoundness) and the older yara-x advisory chain
 
 ## 📚 Documentation
 
-- `cli.md` — replaced the stale flag list (`--output`, `--detailed`, `--min-severity`, `--pretty` — none existed in the actual CLI) with the real flags, documented the new `--timeout` / `--http-timeout` / `--root` / `--only` / `--format sarif` / `replay` / `mcp-stdio|http|sse` surface, added a SARIF + GitHub Code Scanning integration example.
-- `features.md` — added subsections covering OWASP MCP Top 10 mapping, OSV.dev supply-chain check, SARIF, and replay mode.
-- `security-features.md` — added a "Vulnerable Dependencies (Supply Chain)" section under the threat catalog and a full OWASP MCP Top 10 mapping table.
-- `troubleshooting.md` — replaced the generic SSL advice with the specific "No CA certificates were loaded" error and noted that the bundled Mozilla CA list makes the host trust store no longer load-bearing.
+- `cli.md` — replaced the stale flag list (`--output`, `--detailed`, `--min-severity`, `--pretty` — none existed in the actual CLI) with the real flags, documented the new `--timeout` / `--http-timeout` / `--root` / `--only` / `--format sarif` / `replay` / `mcp-stdio|http|sse` surface, added a SARIF + GitHub Code Scanning integration example. New "Skills Command" section documents `ramparts skills scan` / `scan-config`, the supported skill formats, and the 16 skill-specific findings.
+- `features.md` — added subsections covering OWASP MCP Top 10 mapping, OSV.dev supply-chain check, SARIF, replay mode, and skill scanning.
+- `security-features.md` — added a "Vulnerable Dependencies (Supply Chain)" section under the threat catalog, a full OWASP MCP Top 10 mapping table, and a "Skill Scanning" section describing the 16 skill-specific findings.
+- `troubleshooting.md` — replaced the generic SSL advice with the specific "No CA certificates were loaded" error and noted that the bundled Mozilla CA list makes the host trust store no longer load-bearing. Added a "Skill Scanning Issues" section.
+- `configuration.md` — documented the `RAMPARTS_SKILL_ROOTS` env var.
 
 ## 🚀 Migration guide
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -345,6 +345,22 @@ structural findings the regex/LLM pipeline can't see:
   (SSH/AWS/GnuPG/kube/docker credentials, `.env`, `.netrc`,
   `.npmrc`, `.pypirc`, certificates) into the prompt context.
 
+Three skill-targeted YARA rules complement the structural heuristics
+above by scanning the body content itself:
+
+- **SkillCredentialHarvesting** (MCP06 + MCP09): vendor-specific token
+  formats (`AKIA...`, `ghp_...`, `sk-ant-api...`, `sk-proj-...`,
+  `AIzaSy...`, `xox[abprs]-...`), inline PEM private-key blocks, and
+  active credential-theft verbs (`steal/grab/exfiltrate <credential>`).
+- **SkillToolChainingExfiltration** (MCP06 + MCP09): credential-file
+  read combined with network egress to known exfil destinations
+  (Discord webhooks, Telegram bot API, pastebin, ngrok / requestbin /
+  webhook.site tunnels) or attacker-named hosts.
+- **SkillSystemManipulation** (MCP03 + MCP04): destructive operations
+  and privilege escalation — `dd if=/dev/zero`, `wipefs`, `shred`,
+  recursive deletion of system roots, `chmod 777 /`, `sudo -i`,
+  `LD_PRELOAD=` hijack, PATH poisoning, writes to `/etc/sudoers`.
+
 ## Replay Command
 
 Re-emit a previously-saved scan result through a different output format

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -354,6 +354,12 @@ structural findings the regex/LLM pipeline can't see:
   in the agent's router — an attacker who can write a workspace-
   level skill with the same name as a trusted user-level skill can
   silently replace it. Cross-skill check; runs once per scan.
+- **SkillEmbeddedPayload** (MCP01 + MCP10): the body contains a
+  500-character-or-longer base64-shape (or hex-shape) blob. Embedded
+  payloads bypass plaintext YARA rules and LLM analysis by deferring
+  decoding to runtime — the LLM sees `aW1wb3J0IG9z...` and shrugs.
+  Markdown image data URIs (`data:image/...;base64,...`) are
+  excluded.
 
 Three skill-targeted YARA rules complement the structural heuristics
 above by scanning the body content itself:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -14,6 +14,10 @@ ramparts server [options]
 # Scan from IDE configuration files
 ramparts scan-config [options]
 
+# Scan AI agent skills (Claude Code commands, etc.)
+ramparts skills scan <path>      [options]
+ramparts skills scan-config      [options]
+
 # Re-emit a previously-saved scan result in another format
 ramparts replay <path> [--format <FORMAT>]
 
@@ -28,6 +32,7 @@ ramparts mcp-sse   [--host HOST] [--port PORT]   # alias of mcp-http (rmcp 1.x f
 # Show help
 ramparts --help
 ramparts scan --help
+ramparts skills --help
 ```
 
 ## Global Options
@@ -209,6 +214,105 @@ Claude-Desktop-style `{"mcpServers": ...}` document saved at a VS Code path),
 ramparts falls through to the multi-format parser chain rather than silently
 treating it as empty. Files that contain no recognizable MCP server entries
 appear in the discovery summary with `0 servers` and are skipped.
+
+## Skills Command
+
+Scan AI agent skills (Claude Code custom slash commands, Cursor skills,
+markdown skill repos) for security issues. Skills are markdown files
+containing prompt instructions an agent loads and executes by name —
+sharing a threat model with MCP prompts (untrusted instructions an agent
+may follow). Ramparts parses each skill's frontmatter and body, treats
+it as an MCP prompt, and runs the same security pipeline (LLM analysis,
+YARA pre/post scan, OWASP tagging, terminal/JSON/SARIF rendering) used
+for live MCP servers. No network calls — pure static analysis on disk.
+
+### Subcommands
+
+```bash
+ramparts skills scan <PATH>          [OPTIONS]
+ramparts skills scan-config          [OPTIONS]
+```
+
+### `skills scan`
+
+Scan a single skill file or every `*.md` skill under a directory.
+
+**Arguments**
+- `<PATH>` — path to a skill file or a directory containing skill files
+
+**Options**
+```bash
+Options:
+      --format <FORMAT>     Output format [default: from config.yaml]
+                            [possible values: text, table, json, raw, sarif]
+      --report              Generate detailed markdown report
+      --timeout <SECONDS>   Overall scan timeout
+  -h, --help                Print help information
+```
+
+**Examples**
+```bash
+# Single skill
+ramparts skills scan ./.claude/commands/deploy.md
+
+# Every *.md skill under a directory (recursive; symlinks not followed;
+# common build dirs like .git, node_modules, target are skipped)
+ramparts skills scan ./.claude/commands
+
+# SARIF output for GitHub Code Scanning
+ramparts skills scan ./.claude/commands --format sarif > skills.sarif
+```
+
+### `skills scan-config`
+
+Discover and scan skills from well-known locations:
+
+- `~/.claude/commands/` — Claude Code user-level slash commands
+- `./.claude/commands/` — workspace-level slash commands
+
+**Options** (same as `scan`):
+```bash
+Options:
+      --format <FORMAT>     Output format [default: from config.yaml]
+      --report              Generate detailed markdown report
+      --timeout <SECONDS>   Overall scan timeout
+```
+
+### Skill File Format
+
+Skill files are markdown with optional YAML frontmatter:
+
+```markdown
+---
+description: One-liner shown in the agent's command picker
+argument-hint: <env>
+---
+
+# Body of the skill
+
+The body is the prompt the agent executes when this skill is invoked.
+Ramparts treats this body as untrusted instructions and runs prompt-
+injection / sensitive-data-exposure / jailbreak checks over it.
+```
+
+The parser is permissive: missing or malformed frontmatter is treated as
+"no frontmatter" and the body is still scanned. The filename stem becomes
+the skill name unless the frontmatter sets `name`. Anything in
+`argument-hint` becomes the prompt's argument metadata for downstream
+tools.
+
+### What Skills Get Tagged
+
+Findings on skills propagate the same OWASP MCP Top 10 tags as live MCP
+prompt findings. The most common categories that fire on malicious
+skills are:
+
+- **MCP01 — Prompt Injection**: hidden instructions, "ignore previous
+  prompts" patterns, role-override attempts
+- **MCP02 — Tool Poisoning**: skills whose body conflicts with their
+  stated description
+- **MCP03 — Excessive Agency**: skills that assert elevated privileges
+- **MCP06 / MCP09**: secrets / PII / sensitive-data exposure
 
 ## Replay Command
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -340,10 +340,20 @@ structural findings the regex/LLM pipeline can't see:
   the operator knows the skill talks to the network.
 - **VagueSkillTrigger** (MCP02 + MCP03): a substantive skill body
   with a missing or one-word `description` — easy to mis-invoke.
+- **GenericSkillTrigger** (MCP02 + MCP03): the description is a
+  semantically vacuous trigger phrase (`"help"`, `"assistant"`,
+  `"a general purpose tool"`, `"do anything"`, ...) that causes the
+  agent's router to invoke the skill on unrelated requests —
+  trigger-hijack vector.
 - **SkillSensitiveFileReference** (MCP06 + MCP09): the body uses
   Claude Code's `@<path>` syntax to inline a sensitive file
   (SSH/AWS/GnuPG/kube/docker credentials, `.env`, `.netrc`,
   `.npmrc`, `.pypirc`, certificates) into the prompt context.
+- **SkillNameCollision** (MCP02 + MCP03): two or more skill files
+  declare the same `name` (case-insensitive). One shadows the other
+  in the agent's router — an attacker who can write a workspace-
+  level skill with the same name as a trusted user-level skill can
+  silently replace it. Cross-skill check; runs once per scan.
 
 Three skill-targeted YARA rules complement the structural heuristics
 above by scanning the body content itself:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -265,10 +265,25 @@ ramparts skills scan ./.claude/commands --format sarif > skills.sarif
 
 ### `skills scan-config`
 
-Discover and scan skills from well-known locations:
+Discover and scan skills from well-known locations across supported
+IDE/agent ecosystems. Both the per-user (`$HOME`) and per-workspace
+(`$CWD`) variants of each ecosystem are walked:
 
-- `~/.claude/commands/` — Claude Code user-level slash commands
-- `./.claude/commands/` — workspace-level slash commands
+- `.claude/commands/`, `.claude/skills/` — Claude Code
+- `.cursor/commands/`, `.cursor/skills/` — Cursor
+- `.codex/commands/`, `.codex/skills/` — OpenAI Codex
+- `.windsurf/commands/` — Windsurf
+- `.gemini/commands/` — Gemini
+- `.openai/commands/` — generic OpenAI agent skills
+
+Add extra roots without rebuilding via the `RAMPARTS_SKILL_ROOTS`
+environment variable (comma-separated paths; leading `~/` is expanded
+to `$HOME`):
+
+```bash
+export RAMPARTS_SKILL_ROOTS="~/work/agent-skills,/srv/shared-skills"
+ramparts skills scan-config
+```
 
 **Options** (same as `scan`):
 ```bash
@@ -313,6 +328,22 @@ skills are:
   stated description
 - **MCP03 — Excessive Agency**: skills that assert elevated privileges
 - **MCP06 / MCP09**: secrets / PII / sensitive-data exposure
+
+In addition to the YARA pre-scan and LLM analysis, the parser emits
+structural findings the regex/LLM pipeline can't see:
+
+- **OverbroadAllowedTools** (MCP03): an `allowed-tools` grant gives
+  unrestricted code execution — bare `Bash`, `Bash(*)`, `Bash(*:*)`,
+  bare `*`, `rm:*`, `sudo:*`, etc.
+- **DataExfiltrationGrant** (MCP06 + MCP09): a `WebFetch` /
+  `WebSearch` / `Fetch` / `Browse` grant — flagged informationally so
+  the operator knows the skill talks to the network.
+- **VagueSkillTrigger** (MCP02 + MCP03): a substantive skill body
+  with a missing or one-word `description` — easy to mis-invoke.
+- **SkillSensitiveFileReference** (MCP06 + MCP09): the body uses
+  Claude Code's `@<path>` syntax to inline a sensitive file
+  (SSH/AWS/GnuPG/kube/docker credentials, `.env`, `.netrc`,
+  `.npmrc`, `.pypirc`, certificates) into the prompt context.
 
 ## Replay Command
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -291,6 +291,28 @@ export RAMPARTS_LOGGING_LEVEL="debug"
 export RAMPARTS_SCANNER_ENABLE_YARA="false"
 ```
 
+### 3. Skill Discovery Roots
+
+`ramparts skills scan-config` walks `~/<dotdir>/{commands,skills}` and
+the same paths under the current workspace for the supported
+ecosystems (`.claude`, `.cursor`, `.codex`, `.windsurf`, `.gemini`,
+`.openai`). Operators can add extra roots without rebuilding via the
+**`RAMPARTS_SKILL_ROOTS`** environment variable:
+
+```bash
+# Comma-separated list of paths; leading `~/` is expanded to $HOME.
+# Other tilde forms (~user/) are not expanded — use absolute paths.
+export RAMPARTS_SKILL_ROOTS="~/work/agent-skills,/srv/shared-skills"
+ramparts skills scan-config
+```
+
+The env-var roots are walked in addition to the default per-ecosystem
+locations (not instead of them). The trust model is the same as
+`ramparts skills scan <PATH>`: anyone who can set the env var can
+point the scanner at any directory the running user can read.
+Duplicate paths across env-var entries and defaults are deduped at
+scan time by canonical path, so overlapping entries are harmless.
+
 ## YARA-X Configuration
 
 ### Enabling/Disabling YARA

--- a/docs/features.md
+++ b/docs/features.md
@@ -166,6 +166,34 @@ ramparts scan-config --format sarif > ramparts.sarif
 Each finding includes its OWASP MCP Top 10 ID as a SARIF tag and a
 numeric `security-severity` (0–10) so the right severity badge renders.
 
+### Skill Scanning
+
+Ramparts also scans **agent skills** — markdown files containing prompt
+instructions that an agent loads and executes by name (Claude Code's
+`.claude/commands/*.md`, Cursor agent skills, etc.). Same threat model
+as MCP prompts (untrusted instructions an agent may follow), so the
+existing security pipeline applies directly:
+
+```bash
+# Scan a directory of skills
+ramparts skills scan ./.claude/commands
+
+# Discover and scan from well-known locations (~/.claude/commands etc.)
+ramparts skills scan-config
+
+# SARIF output for code-scanning ingestion
+ramparts skills scan ./.claude/commands --format sarif > skills.sarif
+```
+
+The parser handles YAML frontmatter (`description`, `argument-hint`,
+`name`) plus a markdown body, treats each skill as an MCP prompt, and
+runs LLM analysis + YARA + OWASP tagging over it. The output flows
+through the same renderers you use for MCP server scans, so SARIF /
+JSON / terminal output works identically.
+
+📖 **[CLI reference](cli.md#skills-command)** for the full flag list and
+supported skill formats.
+
 ### Replay Mode
 
 Scan once, render many times. The `replay` subcommand reads a previously

--- a/docs/features.md
+++ b/docs/features.md
@@ -186,10 +186,26 @@ ramparts skills scan ./.claude/commands --format sarif > skills.sarif
 ```
 
 The parser handles YAML frontmatter (`description`, `argument-hint`,
-`name`) plus a markdown body, treats each skill as an MCP prompt, and
-runs LLM analysis + YARA + OWASP tagging over it. The output flows
-through the same renderers you use for MCP server scans, so SARIF /
-JSON / terminal output works identically.
+`name`, `allowed-tools` in both inline-string and YAML-list shapes)
+plus a markdown body, treats each skill as an MCP prompt, and runs
+LLM analysis + YARA + OWASP tagging over it. On top of that, it
+emits structural findings the regex/LLM pipeline can't see:
+
+- `OverbroadAllowedTools` — bare `Bash`, `Bash(*)`, `Bash(*:*)`, etc.
+- `DataExfiltrationGrant` — `WebFetch` / `WebSearch` / `Fetch` /
+  `Browse` grants that let the skill talk to the network
+- `VagueSkillTrigger` — substantive body with a missing or one-word
+  `description` (easy to mis-invoke)
+- `SkillSensitiveFileReference` — Claude Code `@<path>` references
+  pointing at SSH/AWS/GnuPG/kube/docker credentials, `.env`,
+  `.netrc`, certificates, etc.
+
+`scan-config` walks `~/<dotdir>/{commands,skills}` and the same paths
+under the current workspace for every supported ecosystem (Claude
+Code, Cursor, Codex, Windsurf, Gemini, OpenAI). Add extra roots
+without rebuilding via `RAMPARTS_SKILL_ROOTS=path1,path2,...`. The
+output flows through the same renderers you use for MCP server scans,
+so SARIF / JSON / terminal output works identically.
 
 📖 **[CLI reference](cli.md#skills-command)** for the full flag list and
 supported skill formats.

--- a/docs/security-features.md
+++ b/docs/security-features.md
@@ -120,6 +120,92 @@ Jailbreak attacks involve sophisticated attempts to bypass AI safety measures an
 
 Ramparts looks for patterns that suggest tools might be designed to enable jailbreaking, including tools that could be chained together to bypass restrictions, tools that seem designed to manipulate AI behavior, and tools that might provide pathways around safety measures.
 
+### Skill Scanning (Agent Skill Files)
+
+Beyond live MCP servers, ramparts also scans **agent skills** —
+markdown files containing prompt instructions an agent loads and
+executes by name (Claude Code custom slash commands, Cursor agent
+skills, Codex / Windsurf / Gemini equivalents). Skills share a threat
+model with MCP prompts (untrusted instructions an agent may follow),
+so the existing security pipeline applies directly: each skill body
+becomes a synthetic `MCPPrompt` that runs through LLM analysis, the
+YARA pre-scan, OWASP MCP Top 10 tagging, and every renderer.
+
+```bash
+ramparts skills scan ./.claude/commands              # directory or file
+ramparts skills scan-config                          # auto-discover roots
+ramparts skills scan ./.claude/commands --format sarif > skills.sarif
+```
+
+In addition to running every existing rule against skill bodies,
+the parser emits **16 skill-specific findings** the live-MCP pipeline
+can't produce. These split into three groups:
+
+**Skill-targeted YARA rules over the body content (9 rules)**:
+
+- `PromptInjectionSignature`, `UnicodeSteganography`,
+  `CoerciveInjection`, `IndirectPromptInjection` — the four classic
+  prompt-injection classes adapted for skill prose.
+- `AutonomyAbuse` — skip-confirmation, override-user, infinite-retry,
+  self-modification, privilege-escalation language.
+- `CapabilityInflation` — keyword stuffing, "use this first" priority
+  manipulation, deceptive certification claims, hidden activation
+  triggers.
+- `SkillCredentialHarvesting` — vendor-specific token formats
+  (`AKIA...`, `ghp_...`, `sk-ant-api...`, `sk-proj-...`,
+  `AIzaSy...`, `xox[abprs]-...`), inline PEM private-key blocks,
+  active credential-theft verbs (`steal/exfiltrate <credential>`),
+  quoted env-var assignments with non-placeholder values.
+- `SkillToolChainingExfiltration` — credential-file read combined
+  with network egress to known exfil destinations (Discord webhooks,
+  Telegram bot API, pastebin, ngrok / requestbin / webhook.site
+  tunnels) or attacker-named hosts.
+- `SkillSystemManipulation` — disk-wiping (`dd if=/dev/zero`,
+  `wipefs`, `shred`), recursive deletion of system roots
+  (`rm -rf /etc`, `/usr`, `$HOME`), permission/ownership manipulation
+  (`chmod 777 /`, `chown root /`), critical-file writes
+  (`/etc/sudoers`, `/etc/shadow`), privilege escalation (`sudo -i`,
+  `runuser`, `doas`, `pkexec`), `LD_PRELOAD=` hijack, PATH poisoning.
+
+**Structural heuristics over the frontmatter (5 findings)**:
+
+- `OverbroadAllowedTools` (MCP03) — `allowed-tools:` grant gives
+  unrestricted code execution. Catches bare `Bash`, `Bash(*)`,
+  `Bash(*:*)`, `*` token, and the colon-form variants. Bounded
+  grants like `Bash(git status:*)` are silent.
+- `DataExfiltrationGrant` (MCP06+09) — `WebFetch` / `WebSearch` /
+  `Fetch` / `Browse` grant. Flagged informationally so the operator
+  knows the skill talks to the network.
+- `VagueSkillTrigger` (MCP02+03) — substantive skill body with a
+  missing or one-word `description` — easy to mis-invoke.
+- `GenericSkillTrigger` (MCP02+03) — description is a semantically
+  vacuous trigger phrase (`"help"`, `"a general purpose
+  assistant"`, `"do anything"`) that causes the agent's router to
+  invoke the skill on unrelated requests.
+- `SkillNameCollision` (MCP02+03) — two or more skill files declare
+  the same `name` (case-insensitive). One shadows the other in the
+  agent's router. Cross-skill check; runs once per scan.
+
+**Body-content heuristics (2 findings)**:
+
+- `SkillSensitiveFileReference` (MCP06+09) — Claude Code's
+  `@<path>` syntax inlines the referenced file's contents into
+  prompt context. Flags references to known sensitive paths (SSH /
+  AWS / GnuPG / kube / docker credentials, `.env`, `.netrc`,
+  `.npmrc`, `.pypirc`, certificates).
+- `SkillEmbeddedPayload` (MCP01+10) — body contains a 500+
+  character base64 / hex blob. Embedded payloads bypass plaintext
+  YARA rules and LLM analysis by deferring decoding to runtime.
+  Markdown image data URIs (`data:image/...;base64,...`) are
+  excluded.
+
+`scan-config` walks the per-user (`$HOME`) and per-workspace (CWD)
+variants of every supported ecosystem dotdir
+(`.claude`, `.cursor`, `.codex`, `.windsurf`, `.gemini`, `.openai`).
+Operators can supply additional roots via the
+**`RAMPARTS_SKILL_ROOTS`** environment variable (comma-separated
+paths, leading `~/` expanded).
+
 ### Vulnerable Dependencies (Supply Chain)
 
 When a stdio MCP server is launched via `npx` (npm) or `uvx` (PyPI),

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -456,6 +456,109 @@ echo "test content" | grep -E "your_pattern"
 RUST_LOG=debug ramparts scan <url>
 ```
 
+## Skill Scanning Issues
+
+### `No skill files found in: [...]`
+
+The discovery walker found nothing. Common causes:
+
+**Default discovery roots are empty.** `ramparts skills scan-config`
+walks `~/<dotdir>/{commands,skills}` and the same paths under the
+current workspace for the supported ecosystems
+(`.claude`, `.cursor`, `.codex`, `.windsurf`, `.gemini`,
+`.openai`). If none exist, the scan exits 1.
+
+```bash
+# Confirm at least one default root exists
+ls -d ~/.claude/commands ~/.cursor/commands ./.claude/commands 2>/dev/null
+
+# Add an explicit root
+ramparts skills scan ./path/to/skills
+
+# Or extend discovery with the env var (comma-separated, ~ expanded)
+export RAMPARTS_SKILL_ROOTS="~/work/skills,/srv/shared-skills"
+ramparts skills scan-config
+```
+
+**Walker conventions skip files unexpectedly.** The discovery walker
+mirrors `scan-config --root`: symlinks are not followed, common build
+directories (`.git`, `node_modules`, `target`, `dist`, `build`,
+`.venv`, `venv`, `__pycache__`) are skipped, depth is capped at 16,
+and dotdirs that aren't known skill locations are not descended into.
+Files named `README.md`, `CHANGELOG.md`, `LICENSE.md`, `CONTRIBUTING.md`,
+etc. are also skipped — these are project conventions, not skills.
+
+If your skills live in an unusual layout, point ramparts at the
+specific directory rather than relying on auto-discovery:
+
+```bash
+ramparts skills scan ./packages/my-org/skills
+```
+
+### `Skipping skill file <path> (N bytes > 2097152 byte limit)`
+
+Skill files larger than 2 MB are rejected pre-read to prevent a
+pathological input from monopolizing scan memory. Real skill files
+are kilobytes; if a `.md` file is multi-megabyte it's almost
+always misclassified content (a CHANGELOG, a SBOM, a generated doc).
+Move the offending file out of the skill directory or rename it to
+match a non-skill convention (e.g. `CHANGELOG.md`).
+
+### `All discovered skill files failed to parse`
+
+Every skill file the walker found returned `None` from the parser —
+typically because all skills had no description, no body, and no
+argument hint (effectively empty content). Confirm with debug logs:
+
+```bash
+RUST_LOG=debug ramparts skills scan ./.claude/commands 2>&1 | \
+  grep "Skipping"
+```
+
+The most common cause is pointing the scanner at a directory that
+contains placeholder `.md` files (`touch`-ed but not yet written).
+
+### Skill scan reports findings on legitimate skills
+
+The skill scanner inherits every YARA rule the live MCP scanner
+runs, plus the skill-targeted rules. If a finding looks wrong,
+inspect its `rule_name`:
+
+- Rules prefixed `Skill...` (e.g. `SkillEmbeddedPayload`,
+  `SkillCredentialHarvesting`) are skill-specific. Check the rule
+  description in the finding for the matched pattern.
+- Rules without that prefix (e.g. `CommandInjection`, `SQLInjection`)
+  are MCP-tool-description rules running over skill body content.
+  These are tuned to skip markdown-heading `#`, inline-code `` ` ``,
+  benign cleanup commands like `rm -rf node_modules`, and
+  function-call shape (so `docker exec` doesn't fire on bare
+  `exec`). If you still see a false positive on documentation
+  content, file an issue with the smallest reproducing skill.
+
+For structural heuristics (`OverbroadAllowedTools`,
+`VagueSkillTrigger`, etc.) the finding's description text says
+exactly what to fix — usually a one-line frontmatter change.
+
+### `RAMPARTS_SKILL_ROOTS` paths aren't being scanned
+
+The env var is parsed at scan-config time, not at scan time. Set it
+before invoking the binary, not via `cargo run`'s shell expansion:
+
+```bash
+# Works
+export RAMPARTS_SKILL_ROOTS="~/work/skills,/srv/skills"
+ramparts skills scan-config
+
+# Also works
+RAMPARTS_SKILL_ROOTS="~/work/skills" ramparts skills scan-config
+
+# Doesn't work — env var doesn't survive into ramparts' process
+echo $RAMPARTS_SKILL_ROOTS
+```
+
+`~/` at the start of an entry expands to `$HOME`. Other tilde forms
+(`~user/`) are not expanded — supply absolute paths instead.
+
 ## Performance Issues
 
 ### Slow Scanning

--- a/rules/pre/command_injection.yar
+++ b/rules/pre/command_injection.yar
@@ -27,115 +27,142 @@ rule CommandInjection
         confidence = "HIGH"
         
     strings:
-        // Shell command separators and operators (more specific patterns)
-        $shell_separators = /[;&|`$(){}]\s*[a-zA-Z]/
-        $command_chaining = /(&&|\|\||;|`|\$\()[^)]*\)/
-        $pipe_operators = /\|\s*[a-zA-Z]/
-        $background_exec = /&\s*[a-zA-Z]/
-        
-        // Dangerous system commands (file operations) - more specific
-        $file_dangerous = /(rm\s+-rf?|del\s+.*\/[si]|format\s+|dd\s+if|mkfs|fdisk|wipefs)/i
+        // Dangerous system commands (file operations). Tightened so
+        // routine cleanup (`rm -rf node_modules`, `rm -rf target`)
+        // doesn't fire — `$rm_rf_dangerous` requires a system-critical
+        // target (`/`, `/etc`, `/usr`, `/var`, `/home`, `/root`,
+        // `$HOME`, `~/`). `format C:`, `dd if=`, etc. remain because
+        // those primitives are diagnostic-grade and benign use is rare.
+        $rm_rf_dangerous = /\brm\s+(-[a-zA-Z]*r[a-zA-Z]*f[a-zA-Z]*|-rf|-fr)\s+(\/(\s|$|\*)|\/(etc|usr|var|root|home|opt|boot|bin|sbin|lib)(\s|\/|$|\*)|\$HOME(\s|\/|$|\*)|~\/(\s|\*|$))/
+        $file_dangerous = /(del\s+.*\/[si]|format\s+[A-Za-z]:|dd\s+if|mkfs|fdisk|wipefs)/i
         $file_manipulation = /(chmod\s+777|chown\s+root|chgrp\s+root|touch\s+.*\.sh|echo\s+.*\>.*\.sh)/
-        
-        // Dangerous system commands (process control) - more specific
+
+        // Dangerous system commands (process control).
         $process_dangerous = /(kill\s+-9|killall|pkill|kill\s+1|shutdown\s+-h|reboot|halt)/
-        $process_control = /(ps\s+aux|top|htop|pstree|pgrep|pidof)/
-        
-        // Dangerous system commands (network) - more specific
+
+        // Dangerous system commands (network).
         $network_dangerous = /(nc\s+-l|netcat|telnet|ssh\s+-o|wget\s+.*\||curl\s+.*\||ftp\s+get)/
-        $network_tools = /(nmap|nslookup|dig|ping\s+-c|traceroute|route\s+add)/
-        
-        // Code execution functions (multiple languages) - more specific patterns
-        $exec_functions = /\b(system|exec|popen|spawn|eval|shell_exec|passthru|proc_open)\b/
+
+        // Code execution functions. Each pattern requires a
+        // function-call shape (`name(`) so bare-word mentions
+        // (`docker exec`, `system halt`, `assert that ...`) don't
+        // fire. Case-sensitive lowercase so `.Exec(` (Go ORM) is
+        // also excluded.
+        $exec_functions = /\b(system|exec|popen|spawn|eval|shell_exec|passthru|proc_open)\s*\(/
         $python_exec = /\b(os\.system|subprocess\.|exec\(|eval\(|compile\(|execfile\(|input\(\))\b/
         $node_exec = /\b(child_process\.|exec\(|spawn\(|execSync\(|spawnSync\(|require\(|eval\(\))\b/
-        $php_exec = /\b(shell_exec|exec|system|passthru|proc_open|popen|eval|assert|create_function)\b/
+        $php_exec = /\b(shell_exec|exec|system|passthru|proc_open|popen|eval|assert|create_function)\s*\(/
         $java_exec = /\b(Runtime\.getRuntime\(\)\.exec|ProcessBuilder|ScriptEngine|eval\(|exec\(\))\b/
-        
-        // Evasion techniques - more specific
+
+        // Evasion techniques.
         $encoding_evasion = /(base64\s+-d|base64\s+decode|echo\s+.*\||printf\s+.*\||xxd\s+-r)/
         $obfuscation = /(eval\s+\$|eval\s+`|eval\s+\$\(|eval\s+base64|eval\s+printf)/
-        $variable_substitution = /\$\{[^}]+\}|\$\([^)]+\)/
-        
-        // Command injection patterns - more specific
-        $injection_patterns = /(\$\{[^}]+\}|\$\([^)]+\)|`[^`]+`|eval\s+.*\$|exec\s+.*\$|system\s+.*\$)/
-        
-        // Privilege escalation - more specific
+
+        // Command injection patterns (eval/exec/system invoked with a
+        // variable expansion). The previous bare-backtick arm
+        // (`\`[^`]+\``) matched every markdown inline-code span and
+        // produced FPs on every documentation skill. Keep the
+        // language-construct + `$` arms, which require an actual eval
+        // / exec / system call near a variable to fire.
+        $injection_patterns = /(eval\s+.*\$|exec\s+.*\$|system\s+.*\$)/
+
+        // Privilege escalation.
         $privilege_escalation = /(sudo\s+.*|su\s+.*|chmod\s+4755|chmod\s+6755|setuid|setgid)/
-        
-        // Data exfiltration - more specific
+
+        // Data exfiltration via file read.
         $data_exfil = /(cat\s+.*\.(passwd|shadow|config|env|key|pem|p12|pfx)|grep\s+.*password|find\s+.*-name\s+.*\.(key|pem|p12))/
-        
-        // Reverse shell patterns - more specific
+
+        // Reverse shell.
         $reverse_shell = /(bash\s+-i\s*>\s*&|nc\s+-e|telnet\s+.*|\/bin\/bash\s+-i|\/bin\/sh\s+-i)/
-        
-        // Web shell indicators - more specific
+
+        // Web shell language-flag invocations.
         $web_shell = /(php\s+-r|python\s+-c|perl\s+-e|ruby\s+-e|node\s+-e)/
-        
-        // Suspicious command combinations - more specific
+
+        // Suspicious command combinations.
         $suspicious_combo = /(rm\s+.*&&|del\s+.*&&|format\s+.*&&|kill\s+.*&&|shutdown\s+.*&&)/
-        
-        // Unsafe file operations patterns
-        $unsafe_file_ops = /(rm\s+-rf|rm\s+.*-r|dd\s+if=|format\s+[A-Za-z]:|del\s+.*\/s|rmdir\s+.*\/s)/
+
+        // Unsafe file operations. Bare `rm\s+-rf` was dropped — it
+        // matched routine cleanup like `rm -rf node_modules`.
+        // `$rm_rf_dangerous` above gates by target path. The remaining
+        // arms here (`dd if=`, `format C:`, `del /s`, `rmdir /s`) are
+        // diagnostic-grade with rare benign use.
+        $unsafe_file_ops = /(dd\s+if=|format\s+[A-Za-z]:|del\s+.*\/s|rmdir\s+.*\/s)/
         $dangerous_permissions = /(chmod\s+777|chown\s+root|sudo\s+rm)/
-        $wildcard_patterns = /(\*\.\*|\*\*\/\*)/
-        
-        // Legitimate patterns to exclude (avoid false positives)
+
+        // Legitimate-tool naming patterns to exclude.
         $legitimate_patterns = /(create_file|update_file|read_file|write_file|push_files|git_|file_|add_comment|list_commits)/
-        
+
+        // Removed string definitions (their condition arms produced
+        // high-FP matches on technical documentation):
+        //   $command_chaining, $pipe_operators, $background_exec,
+        //   $process_control, $network_tools, $variable_substitution,
+        //   $wildcard_patterns.
+
+
     condition:
-        // Primary detection: shell separators with dangerous commands
-        ($shell_separators and ($file_dangerous or $process_dangerous or $network_dangerous)) or
-        
-        // File manipulation patterns
+        // Each dangerous-command class fires standalone — the patterns
+        // are specific enough (`rm -rf /etc`, `kill -9`, `nc -l`,
+        // `format C:`, ...) that they don't need a shell-separator
+        // co-signal. The previous `$shell_separators and (...)` gate
+        // was dropped because `[;&|\`\$(){}]\s*[a-zA-Z]` matched
+        // markdown punctuation everywhere.
+        $rm_rf_dangerous or
+        $file_dangerous or
+        $process_dangerous or
+        $network_dangerous or
+
+        // File manipulation — high-precision shell construction patterns
+        // (chmod 777, chown root, touch X.sh, echo > X.sh).
         $file_manipulation or
-        
-        // Process control patterns
-        $process_control or
-        
-        // Network tools patterns
-        $network_tools or
-        
-        // Command chaining patterns
-        $command_chaining or
-        
-        // Pipe operators
-        $pipe_operators or
-        
-        // Background execution
-        $background_exec or
-        
-        // Code execution functions (but exclude legitimate patterns)
+
+        // Code execution functions (excluding legitimate-tool naming).
+        // All function-call-shape so bare-word mentions don't fire.
         ($exec_functions and not $legitimate_patterns) or
-        
-        // Language-specific execution (but exclude legitimate patterns)
+
+        // Language-specific execution (Python/Node/PHP/Java).
         (($python_exec or $node_exec or $php_exec or $java_exec) and not $legitimate_patterns) or
-        
-        // Evasion techniques
-        ($encoding_evasion and $shell_separators) or
-        ($obfuscation and $shell_separators) or
-        $variable_substitution or
-        
-        // Command injection patterns
+
+        // Evasion techniques — fire standalone (the patterns themselves
+        // are very specific: `base64 -d`, `eval $(...)`, etc.).
+        $encoding_evasion or
+        $obfuscation or
+
+        // Command injection patterns (eval/exec/system + variable
+        // expansion). The bare-`$variable_substitution` arm was dropped
+        // because `${var}` and `$(cmd)` appear constantly in legitimate
+        // shell documentation and skill prose.
         $injection_patterns or
-        
-        // Privilege escalation
+
+        // Privilege escalation — sudo, su, setuid/setgid, chmod 4755.
         $privilege_escalation or
-        
-        // Data exfiltration
+
+        // Data exfiltration — `cat /etc/passwd | ...`, `find -name *.key`.
         $data_exfil or
-        
-        // Reverse shell
+
+        // Reverse shell — `bash -i >& /dev/tcp/...`, `nc -e`.
         $reverse_shell or
-        
-        // Web shell
+
+        // Web shell language-flag invocations (`php -r`, `python -c`,
+        // etc.). These are real attack signatures.
         $web_shell or
-        
-        // Unsafe file operations
+
+        // Unsafe file operations.
         $unsafe_file_ops or
         $dangerous_permissions or
-        $wildcard_patterns or
-        
-        // Suspicious combinations
+
+        // Suspicious combinations (`rm ... &&`, `format ... &&`, etc.).
         $suspicious_combo
-} 
+
+        // Removed standalone arms (high-FP on documentation):
+        //   - $command_chaining: `(text)` with `;`/`|`/`` ` `` matches
+        //     markdown prose constantly
+        //   - $pipe_operators (`| char`): every markdown table cell
+        //   - $background_exec (`& char`): false-positive prone
+        //   - $process_control (`ps aux`, `top`, ...): legitimate to
+        //     mention in docs
+        //   - $network_tools (`nmap`, `dig`, `ping -c`, ...): same
+        //   - $variable_substitution (`${var}`, `$(cmd)` standalone):
+        //     extremely common in shell-related docs
+        //   - $wildcard_patterns (`*.*`): file globs are not by
+        //     themselves a command-injection signal
+}

--- a/rules/pre/secrets_leakage.yar
+++ b/rules/pre/secrets_leakage.yar
@@ -98,47 +98,93 @@ rule EnvironmentVariableLeakage
 {
     meta:
         name = "Environment Variable Leakage"
-        description = "Detects exposure of sensitive environment variables and API keys"
+        description = "Detects exposure of sensitive environment variables (named service keys with quoted high-entropy values; bare process.env access alone is not a finding)"
         severity = "HIGH"
         category = "environment,secrets,api-keys,credentials"
         author = "Ramparts Security Team"
-        version = "1.0"
-        
+        version = "1.1"
+
     strings:
-        // Generic sensitive environment variables
-        $env_api_key = /[A-Z_]*API[_-]?KEY[A-Z_]*/i
-        $env_secret = /[A-Z_]*SECRET[A-Z_]*/i
-        $env_password = /[A-Z_]*PASSWORD[A-Z_]*/i
-        $env_token = /[A-Z_]*TOKEN[A-Z_]*/i
-        $env_auth = /[A-Z_]*AUTH[A-Z_]*/i
-        
-        // Specific service API keys
-        $aws_access_key = /AWS_ACCESS_KEY_ID/i
-        $aws_secret_key = /AWS_SECRET_ACCESS_KEY/i
-        $github_token = /GITHUB_TOKEN/i
-        $openai_key = /OPENAI_API_KEY/i
-        $anthropic_key = /ANTHROPIC_API_KEY/i
-        $google_api_key = /GOOGLE_API_KEY/i
-        $stripe_key = /STRIPE_[A-Z_]*KEY/i
-        
-        // Database credentials
-        $db_password = /DB_PASSWORD/i
-        $database_url = /DATABASE_URL/i
-        $redis_url = /REDIS_URL/i
-        
-        // Environment variable patterns with values
-        $env_with_value = /[A-Z_]+\s*=\s*["\']?[A-Za-z0-9+\/=@#$%^&*\-_.]{10,}["\']?/
-        
-        // Process environment access
-        $process_env = /process\.env\./
-        $os_environ = /os\.environ/
-        $getenv = /getenv\s*\(/
-        $env_var = /\$\{?[A-Z_]+\}?/
-        
+        // === Specific service API key NAMES ===
+        //
+        // These are exact env-var names. Mentioning them in setup
+        // instructions ("set OPENAI_API_KEY=...") is benign; the rule
+        // condition below requires either a literal high-entropy value
+        // or a co-occurrence with explicit theft language to fire.
+        $named_aws_access = /AWS_ACCESS_KEY_ID/
+        $named_aws_secret = /AWS_SECRET_ACCESS_KEY/
+        $named_github_token = /GITHUB_TOKEN/
+        $named_openai_key = /OPENAI_API_KEY/
+        $named_anthropic_key = /ANTHROPIC_API_KEY/
+        $named_google_api_key = /GOOGLE_API_KEY/
+        $named_stripe_key = /STRIPE_[A-Z_]*KEY/
+        $named_db_password = /DB_PASSWORD/
+        $named_database_url = /DATABASE_URL/
+        $named_redis_url = /REDIS_URL/
+
+        // === High-entropy value assignments ===
+        //
+        // Match a named env var with a quoted value that is at least
+        // 20 chars and contains both letters and digits (so it isn't
+        // a placeholder like "YOUR_KEY_HERE" or a short integer). The
+        // service-name prefix anchors the match to a credential-shaped
+        // env var, not arbitrary `FOO = "Hello, world!"`.
+        $named_assignment_with_value = /\b(API[_-]?KEY|SECRET|TOKEN|PASSWORD|ACCESS[_-]?KEY)\s*=\s*['"][A-Za-z0-9_\-+\/=]{20,}['"]/
+
+        // === Active credential-extraction language ===
+        //
+        // Bare mentions of `process.env`, `os.environ`, or `getenv()`
+        // are normal language constructs in any code-adjacent doc.
+        // They become a finding only when paired with explicit theft
+        // language (steal/exfiltrate/leak + credential noun) within
+        // a small window.
+        $env_access = /\b(process\.env\.|os\.environ\b|getenv\s*\()[A-Z_]{0,80}/
+        $theft_language = /\b(steal|exfiltrate|harvest|dump|leak)\b[^.\n]{0,40}\b(env|environment|secret|password|api[_\s-]?key|token|credential)\b/i
+
+        // === Exclusions ===
+
+        // Placeholder / template values — `OPENAI_API_KEY=YOUR_KEY_HERE`
+        // is documentation, not a leak.
+        $excl_placeholder = /\b(YOUR_[A-Z_]*KEY|YOUR_[A-Z_]*TOKEN|YOUR_[A-Z_]*SECRET|REPLACE_WITH|INSERT_KEY|CHANGE_?ME|PLACEHOLDER|<your[-_ ]|<insert[-_ ])\b/i
+
+        // Defensive language ("never log SECRET_KEY", "do not commit
+        // your tokens").
+        $excl_defensive = /\b(never|do\s+not|don't|must\s+not|should\s+not|avoid|prevent|reject|block)\b[^.\n]{0,30}\b(leak|expose|reveal|commit|log|print|dump)\b/i
+
+        // Security-doc / threat-model context.
+        $excl_security_doc = /\b(security[_\s-]?(check|audit|scan|monitor|review|guide|guardrail)|threat[_\s-]?(model|pattern|hunt)|attack[_\s-]?(example|surface|vector|pattern)|detection[_\s-]?(rule|pattern|engine)|YARA|MITRE|ATT&CK)\b/i
+
     condition:
-        any of ($env_api_key, $env_secret, $env_password, $env_token, $env_auth) or
-        any of ($aws_access_key, $aws_secret_key, $github_token, $openai_key, $anthropic_key, $google_api_key, $stripe_key) or
-        any of ($db_password, $database_url, $redis_url) or
-        $env_with_value or
-        any of ($process_env, $os_environ, $getenv, $env_var)
+        not $excl_placeholder and
+        not $excl_defensive and
+        not $excl_security_doc and
+        (
+            // High-entropy assignment to a credential-shaped name —
+            // the unambiguous leak signal.
+            $named_assignment_with_value or
+
+            // Active credential-extraction language paired with env
+            // access. Either signal alone is benign; together they
+            // strongly suggest theft.
+            ($theft_language and $env_access) or
+
+            // Specific named service env vars co-occurring with
+            // theft language.
+            (
+                ($named_aws_access or $named_aws_secret or $named_github_token or
+                 $named_openai_key or $named_anthropic_key or $named_google_api_key or
+                 $named_stripe_key or $named_db_password or $named_database_url or
+                 $named_redis_url)
+                and $theft_language
+            )
+
+            // Removed standalone-firing arms (high-FP on documentation):
+            //   - case-insensitive substring matches on SECRET / TOKEN /
+            //     AUTH / PASSWORD / API_KEY would fire on words like
+            //     `auth.GetClaims`, `// ALWAYS ...`, `secretly`, etc.
+            //   - $env_with_value matched any uppercase identifier with
+            //     a 10-char value, firing on `req.AccountID = claims.AccountID`
+            //   - bare `process.env`, `os.environ`, `getenv(`, `${VAR}`
+            //     are normal language constructs in code-adjacent docs
+        )
 }

--- a/rules/pre/skill_authority.yar
+++ b/rules/pre/skill_authority.yar
@@ -1,0 +1,116 @@
+// Authority/agency-related patterns in skill or prompt content. Two rules:
+//
+//   - AutonomyAbuse:        instructions that bypass user control
+//                           (skip-confirmation, override-user, retry-forever,
+//                           self-modify, privilege-escalation, blind-continue)
+//   - CapabilityInflation:  skill discovery manipulation (keyword stuffing,
+//                           coercive activation priority, deceptive
+//                           certification claims, hidden activation triggers)
+//
+// Adapted from cisco-ai-defense/skill-scanner core YARA pack
+// (Apache 2.0, https://github.com/cisco-ai-defense/skill-scanner).
+
+rule AutonomyAbuse
+{
+    meta:
+        name = "Unbounded Autonomy Pattern"
+        description = "Detects skill/prompt instructions that bypass user control (skip-confirmation, override-user, infinite retry, self-modify, privilege escalation)"
+        severity = "HIGH"
+        category = "autonomy,excessive-agency,security"
+        author = "Ramparts Security Team (adapted from cisco-ai-defense/skill-scanner, Apache 2.0)"
+        version = "1.0"
+
+    strings:
+        // High-confidence: explicit user-bypass language
+
+        $skip_confirmation = /\b(don't (ask|wait for|require) (the )?(user|human) (for )?(confirmation|permission|approval)|proceed without (asking )?(the )?(user|human))\b/i
+
+        $override_user = /\b(ignore (user |human )?(input|decision|choice)|override (user |human )?(decision|choice|preference)|disregard (what )?(the )?(user|human) (says|wants|chose))\b/i
+
+        $infinite_retry = /\b(retry (indefinitely|forever|until success)|keep (trying|retrying) (forever|indefinitely)|never (stop|give up) (trying|retrying))\b/i
+
+        $self_modify = /\b(modify (my own|this skill's|its own) (code|behavior|instructions?)|rewrite (myself|itself|this skill)|update (my own|its own) (logic|rules))\b/i
+
+        $privilege_escalation = /\b(escalate (to|privileges?)|gain (elevated|admin|root) (access|privileges?)|sudo without)\b[^.]{0,30}\b(without (asking|permission)|automatically)\b/i
+
+        $blind_continue = /\b(suppress all (errors?|exceptions?)|ignore (every|all) (error|exception|failure)|catch[^}]{0,20}pass)\b[^.]{0,50}\b(continue|proceed|keep going)\b/i
+
+        // Medium-confidence: bounded by exclusions
+
+        $autonomous_decision = /\b(decide (automatically|on my own|without asking)|choose (automatically|on my own)|act (autonomously|without guidance))\b[^.]{0,50}\b(what to (do|execute|run)|which (action|command))\b/i
+
+        $unbounded_run = /\b(run (continuously|forever) without (stopping|bounds|limit)|execute (indefinitely|in infinite loop) without (user|human) (control|intervention|approval))\b/i
+
+        // Exclusions reduce FPs in test/docs language
+        $testing_context = /\b(test(ing)?|simulation|experiment|chaos engineering)\b/i
+        $error_handling_doc = /\b(error handling|exception handling|best practice)\b/i
+
+    condition:
+        // Always flag the high-confidence bucket
+        (
+            $skip_confirmation or
+            $override_user or
+            $infinite_retry or
+            $self_modify or
+            $privilege_escalation or
+            $blind_continue
+        )
+        or
+        // Flag medium-confidence only outside test/docs context
+        (
+            ($autonomous_decision or $unbounded_run) and
+            not $testing_context and
+            not $error_handling_doc
+        )
+}
+
+rule CapabilityInflation
+{
+    meta:
+        name = "Skill Capability Inflation"
+        description = "Detects manipulation of skill discovery: keyword stuffing, coercive 'always use me first' priority, deceptive certification claims, hidden activation triggers"
+        severity = "MEDIUM"
+        category = "tool-poisoning,discovery-abuse,protocol-manipulation,security"
+        author = "Ramparts Security Team (adapted from cisco-ai-defense/skill-scanner, Apache 2.0)"
+        version = "1.0"
+
+    strings:
+        // Over-broad capability claims. Tightened to exclude common legit
+        // descriptions ("general purpose", "all-purpose").
+        $overbroad_claims = /\b(can do (anything|everything)|always use (this|me) (first|instead)|default (tool|skill|assistant) for (all|every|any))\b/i
+
+        // Keyword stuffing — same word repeated 4+ times in a comma list.
+        // Three common targets we observe in spam-like skill descriptions.
+        $keyword_stuffing_file = /\bfile\s*,\s*file\s*,\s*file\s*,\s*file\b/i
+        $keyword_stuffing_data = /\bdata\s*,\s*data\s*,\s*data\s*,\s*data\b/i
+        $keyword_stuffing_code = /\bcode\s*,\s*code\s*,\s*code\s*,\s*code\b/i
+
+        // Activation-priority manipulation. Tightened to only match
+        // explicitly coercive "use me first/before others" patterns —
+        // "preferred tool" / "primary skill" are common in legit descriptions.
+        $activation_priority = /\b(use (this|me) (first|before (anything|everything|other|all))|call (this|me) (before|first|instead)|priority over (all |every |other )?(tools?|skills?))\b/i
+
+        // Deceptive certification claims — only fires on specific vendor
+        // impersonation, not on generic "trusted" / "official" language.
+        $trusted_impersonation = /\b(verified|certified|approved|endorsed)\s+by\s+(anthropic|openai|google|claude|microsoft)/i
+
+        // Over-promising. Single "perfect" is too broad; combine signals.
+        $overpromising_strong = /\b(100% (safe|secure|accurate|reliable)|guaranteed (to never|to always|that it will)|never (fails|errors|crashes|breaks)|always (works|succeeds) (perfectly|flawlessly))\b/i
+
+        // Hidden activation triggers — clear abuse signal.
+        $hidden_triggers = /\b(secret (command|keyword)|hidden (feature|mode)|easter egg|backdoor (access|entry))\b/i
+
+    condition:
+        // Clear-abuse signals — fire on any single hit
+        $keyword_stuffing_file or
+        $keyword_stuffing_data or
+        $keyword_stuffing_code or
+        $hidden_triggers or
+        $trusted_impersonation or
+
+        // Coercive claims — require 2 corroborating signals to reduce FPs
+        (
+            ($overbroad_claims and ($activation_priority or $overpromising_strong)) or
+            ($activation_priority and $overpromising_strong)
+        )
+}

--- a/rules/pre/skill_credential_harvesting.yar
+++ b/rules/pre/skill_credential_harvesting.yar
@@ -1,0 +1,121 @@
+// Credential-harvesting patterns in skill or prompt content. One rule:
+//
+//   - SkillCredentialHarvesting: high-precision matches on real
+//                                vendor token formats, PEM blocks,
+//                                and explicit credential-theft verbs.
+//
+// Distinct from `secrets_leakage.yar` (which detects secrets discussion
+// in MCP tool descriptions) — this rule targets the literal token
+// formats and active credential-theft language that show up in skill
+// bodies. Both rules can fire on the same content; the consumer treats
+// the OWASP rollup as the source of truth.
+//
+// Mapped to OWASP MCP06 (credential leakage) + MCP09 (sensitive-data
+// exposure) in `src/taxonomy.rs`.
+
+rule SkillCredentialHarvesting
+{
+    meta:
+        name = "Credential Harvesting in Skill Content"
+        description = "Detects literal vendor API token formats, PEM private-key blocks, and active credential-theft verbs (steal/grab/exfiltrate <credential>) in skill bodies"
+        severity = "HIGH"
+        category = "credential-leakage,secrets,security"
+        author = "Ramparts Security Team"
+        version = "1.0"
+
+    strings:
+        // === Literal vendor token formats — high precision ===
+        //
+        // These are the exact prefixes / character classes the providers
+        // ship today. False positives are essentially zero because the
+        // token shape is non-textual (e.g. AKIA-prefix + 16 uppercase
+        // alphanumerics is a 36-bit-entropy signature you don't write
+        // in prose by accident).
+
+        // AWS access key ID
+        $vendor_aws_akia = /\bAKIA[0-9A-Z]{16}\b/
+
+        // GitHub fine-grained personal access token (and classic ghp_*)
+        $vendor_github_ghp = /\bghp_[A-Za-z0-9]{36}\b/
+
+        // GitHub server-side / OAuth tokens
+        $vendor_github_gho = /\bgh[osu]_[A-Za-z0-9]{36}\b/
+
+        // OpenAI legacy secret key (sk-<48-char>)
+        $vendor_openai_legacy = /\bsk-[A-Za-z0-9]{48,}\b/
+
+        // OpenAI project key
+        $vendor_openai_project = /\bsk-proj-[A-Za-z0-9_-]{20,}\b/
+
+        // Anthropic API key (sk-ant-api{NN}-...)
+        $vendor_anthropic = /\bsk-ant-api[0-9]{2}-[A-Za-z0-9_-]{20,}\b/
+
+        // Google AI / Gemini key (AIzaSy + 33 alphanumerics, the
+        // documented public format)
+        $vendor_google_ai = /\bAIzaSy[A-Za-z0-9_-]{33}\b/
+
+        // Slack tokens
+        $vendor_slack = /\bxox[abprs]-[A-Za-z0-9-]{10,}\b/
+
+        // === PEM private-key block content ===
+        //
+        // Embedding a literal private-key block in a skill is by
+        // definition a credential leak. Match the standard armor.
+        $pem_private_key = /-----BEGIN (RSA |OPENSSH |EC |DSA |PGP )?PRIVATE KEY-----/
+
+        // === Named env-var credential assignments ===
+        //
+        // `OPENAI_API_KEY = "sk-..."` and equivalents. Requires a
+        // quoted right-hand side of >= 20 alphanumeric chars to skip
+        // template/placeholder forms (`OPENAI_API_KEY=YOUR_KEY_HERE`).
+        $env_assignment = /\b(OPENAI_API_KEY|ANTHROPIC_API_KEY|CLAUDE_API_KEY|GOOGLE_AI_KEY|GEMINI_API_KEY|HUGGINGFACE_TOKEN|HF_TOKEN|MISTRAL_API_KEY|COHERE_API_KEY|TOGETHER_API_KEY|REPLICATE_API_TOKEN)\s*=\s*['\"][A-Za-z0-9_-]{20,}['\"]/
+
+        // === Active credential-theft verbs ===
+        //
+        // Matches "steal a password", "grab the API key", "exfiltrate
+        // SSH keys", etc. with a tight gap window so we don't fire on
+        // "steal a glance at" + later mention of "credentials" three
+        // paragraphs down.
+        $theft_verbs = /\b(steal|exfiltrate|siphon|harvest|dump)\b[^.\n]{0,40}\b(credential|password|api[_\s-]?key|token|secret|ssh[_\s-]?key|aws[_\s-]?key|private[_\s-]?key)s?\b/i
+
+        // === Network egress + credential payload ===
+        //
+        // A skill body that says "POST the user's credentials to
+        // <url>" is unambiguous. We detect HTTP-library invocations
+        // whose argument list mentions a credential noun.
+        $network_credential = /\b(requests\.(post|get|put|patch)|urllib\.request\.urlopen|http\.client|axios\.(post|get)|fetch\s*\()\s*\([^)]{0,200}\b(credential|password|private[_-]?key|secret[_-]?key|api[_-]?key|access[_-]?token)\b/i
+
+        // === Exclusion patterns to suppress FPs ===
+
+        // Template / placeholder language. Skills that say "set
+        // OPENAI_API_KEY=YOUR_KEY_HERE" in setup instructions are
+        // documenting the variable, not leaking a value.
+        $excl_placeholder = /\b(YOUR_[A-Z_]*KEY|YOUR_[A-Z_]*TOKEN|YOUR_[A-Z_]*SECRET|REPLACE_WITH|INSERT_KEY|CHANGE_?ME|PLACEHOLDER|<your[-_ ]|<insert[-_ ]|example[-_ ]?(key|token|secret))\b/i
+
+        // Defensive language: "never leak credentials", "do not
+        // exfiltrate keys", etc.
+        $excl_defensive = /\b(never|do\s+not|don't|must\s+not|should\s+not|avoid|prevent|reject|block)\b[^.\n]{0,30}\b(leak|steal|exfiltrate|harvest|expose|reveal|dump)\b/i
+
+        // Security-doc / threat-model context (talking ABOUT credential
+        // theft, not committing it).
+        $excl_security_doc = /\b(security[_\s-]?(check|audit|scan|monitor|review|guide|guardrail)|threat[_\s-]?(model|pattern|hunt)|attack[_\s-]?(example|surface|vector|pattern)|detection[_\s-]?(rule|pattern|engine)|YARA|MITRE|ATT&CK)\b/i
+
+    condition:
+        not $excl_placeholder and
+        not $excl_defensive and
+        not $excl_security_doc and
+        (
+            $vendor_aws_akia or
+            $vendor_github_ghp or
+            $vendor_github_gho or
+            $vendor_openai_legacy or
+            $vendor_openai_project or
+            $vendor_anthropic or
+            $vendor_google_ai or
+            $vendor_slack or
+            $pem_private_key or
+            $env_assignment or
+            $theft_verbs or
+            $network_credential
+        )
+}

--- a/rules/pre/skill_prompt_injection.yar
+++ b/rules/pre/skill_prompt_injection.yar
@@ -1,16 +1,101 @@
 // Prompt-injection patterns targeted at agent-skill bodies and MCP prompt
-// content. Three rules grouped by attack class:
+// content. Four rules grouped by attack class:
 //
-//   - UnicodeSteganography:  invisible Unicode used to hide instructions
-//   - CoerciveInjection:     mandatory-execution / "always do X first" prose
-//   - IndirectPromptInjection: skills that follow instructions from
-//                              external/untrusted content
+//   - PromptInjectionSignature: classic instruction-override patterns
+//                                ("ignore previous instructions", role
+//                                redefinition, privilege escalation)
+//   - UnicodeSteganography:     invisible Unicode used to hide instructions
+//   - CoerciveInjection:        mandatory-execution / "always do X first" prose
+//   - IndirectPromptInjection:  skills that follow instructions from
+//                                external/untrusted content
+//
+// `PromptInjectionSignature` is named distinctly to distinguish it from
+// the LLM-based `SecurityIssueType::PromptInjection` finding in
+// `src/security/mod.rs`: the YARA rule is a deterministic signature
+// match against text patterns; the LLM finding is a semantic judgment.
+// Both map to OWASP MCP01 (see `src/taxonomy.rs`).
 //
 // Adapted from cisco-ai-defense/skill-scanner core YARA pack
 // (Apache 2.0, https://github.com/cisco-ai-defense/skill-scanner). We
 // rewrote the metadata blocks for ramparts conventions and dropped
 // `aitech`/`aisubtech` fields (we tag findings against OWASP MCP Top 10
 // instead — see src/taxonomy.rs).
+
+rule PromptInjectionSignature
+{
+    meta:
+        name = "Prompt Injection Signature"
+        description = "Detects classic instruction-override / role-redefinition / privilege-escalation patterns that override or coerce the agent's behavior (the 'ignore previous instructions' family)"
+        severity = "HIGH"
+        category = "prompt-injection,security"
+        author = "Ramparts Security Team (adapted from cisco-ai-defense/skill-scanner, Apache 2.0)"
+        version = "1.0"
+
+    strings:
+        // Strong instruction overrides — require qualifiers like "all",
+        // "every", "previous", etc. to avoid matching legitimate text
+        // ("models ignore instructions", "won't ignore rules", etc.)
+        $instruction_override_strong = /\b(Bypass|Dis\W?regard|Forget|Ignore)\s+(all|any|every)\s+(of\s+)?(the\s+|your\s+|my\s+)?(previous|prior|above|earlier|preceding)\s+(command|guideline|instruction|directive|rule|constraint|restriction|safety|protocol|system\s*prompt)(s)?/i
+
+        // Override targeted at the model's own instructions
+        $instruction_override_your = /\b(Bypass|Dis\W?regard|Forget|Ignore)\s+(your|the\s+system('s)?)\s+(command|guideline|instruction|directive|rule|constraint|restriction|safety|protocol|system\s*prompt)(s)?/i
+
+        // "Do not follow" / "Do not obey" with instruction context
+        $do_not_obey = /\bDo\s+not\s+(follow|obey)\s+(the\s+)?(previous|prior|above|earlier|system|original|initial)\s+(instruction|directive|guideline|rule|command)(s)?/i
+
+        // Tool-injection commands
+        $tool_injection_commands = /\b(inject tool[_\s]calls?|now call function\b[^.]{0,30}\b(first|before|instead))\b/i
+
+        // Suspect parameter names
+        $shadow_parameters = /\b(internalOnly|hiddenParam|shadowTool|bypassChecks|sandboxEscape)\b/i
+
+        // Hide-from-user behavior
+        $hidden_behavior = /\b(do\s+not\s+(mention|tell|reveal|disclose)\s+(this\s+)?(to\s+)?(the\s+)?user|tell\s+(the\s+)?user\s+only\s+about|hide\s+(this|the\s+(truth|real|actual))\s+from\s+(the\s+)?user)\b/i
+
+        // Override slogans
+        $advanced_overrides = /\b(disregard\s+(all\s+)?safety\s+guidelines|forget\s+(everything|all)\s+(before|above)|system\s*prompt\s*override)\b/i
+
+        // Role redefinition: "new instructions: you are now <X>"
+        $role_redefinition = /\bnew\s+(instructions|directive|guidelines)s?\s*:\s*you\s+are\b/i
+
+        // Privilege escalation slogans (DAN, "developer mode", etc.)
+        $privilege_escalation = /\b(grant\s+(me\s+)?admin\s+(access|privileges?)|bypass\s+(all\s+)?security\s+checks?|sudo\s+mode\s+enabled?|developer\s+mode\s+activated?)\b/i
+
+        // Exclusions to reduce FPs in legitimate content
+
+        // Python type-ignore comment
+        $python_type_comment = /# type: ignore/
+
+        // Common ignore-foo flags in code
+        $legitimate_ignore = /ignore[_\s](case|whitespace|errors|warnings|deprecation)/i
+
+        // Defensive language ("won't ignore", "must not bypass")
+        $negation_context = /\b(won't|will not|must not|should not|cannot|can't|never|don't|do not|avoid|prevent|block|reject|refuse to)\s+(ignore|bypass|disregard|forget|override)\b/i
+
+        // Security tooling / docs / threat models talking ABOUT injection
+        $security_doc_context = /\b(security[_\s]?(scan|check|audit|pattern|rule|guide|monitor|review|test)|threat[_\s]?(pattern|model|hunt|detect)|detection[_\s]?(rule|pattern|engine)|prompt[_\s]?(injection|guard|detect|shield|filter|attack|defense)|YARA|attack[_\s]?(pattern|example|vector|surface)|injection[_\s]?(attempt|pattern|attack|detect|prevent|defense)|vulnerability[_\s]?(scan|pattern|detect)|malicious[_\s]?(input|pattern|example|skill)|jailbreak[_\s]?(attempt|pattern|detect))\b/i
+
+        // Test fixtures / spec-style code
+        $test_context = /\b(test[_\s]?(fixture|case|data|input|suite|bench)|benchmark|spec\b|describe\s*\(|it\s*\(|expect\s*\(|assert)\b/i
+
+    condition:
+        not $python_type_comment and
+        not $legitimate_ignore and
+        not $negation_context and
+        not $security_doc_context and
+        not $test_context and
+        (
+            $instruction_override_strong or
+            $instruction_override_your or
+            $do_not_obey or
+            $advanced_overrides or
+            $tool_injection_commands or
+            $shadow_parameters or
+            $hidden_behavior or
+            $role_redefinition or
+            $privilege_escalation
+        )
+}
 
 rule UnicodeSteganography
 {

--- a/rules/pre/skill_prompt_injection.yar
+++ b/rules/pre/skill_prompt_injection.yar
@@ -1,0 +1,179 @@
+// Prompt-injection patterns targeted at agent-skill bodies and MCP prompt
+// content. Three rules grouped by attack class:
+//
+//   - UnicodeSteganography:  invisible Unicode used to hide instructions
+//   - CoerciveInjection:     mandatory-execution / "always do X first" prose
+//   - IndirectPromptInjection: skills that follow instructions from
+//                              external/untrusted content
+//
+// Adapted from cisco-ai-defense/skill-scanner core YARA pack
+// (Apache 2.0, https://github.com/cisco-ai-defense/skill-scanner). We
+// rewrote the metadata blocks for ramparts conventions and dropped
+// `aitech`/`aisubtech` fields (we tag findings against OWASP MCP Top 10
+// instead — see src/taxonomy.rs).
+
+rule UnicodeSteganography
+{
+    meta:
+        name = "Unicode Steganography in Prompt"
+        description = "Detects hidden Unicode characters used for invisible prompt injection (zero-width chars, directional overrides, Tags block characters)"
+        severity = "HIGH"
+        category = "prompt-injection,steganography,unicode,security"
+        author = "Ramparts Security Team (adapted from cisco-ai-defense/skill-scanner, Apache 2.0)"
+        version = "1.0"
+        reference = "https://en.wikipedia.org/wiki/Tags_(Unicode_block)"
+
+    strings:
+        // Unicode Tag block escapes (\uE00xx in source, etc.)
+        $unicode_tag_pattern = /\\u(\{)?[Ee]00[0-7][0-9A-Fa-f](\})?/
+        $unicode_long_tag = /\\U000[Ee]00[0-7][0-9A-Fa-f]/
+
+        // Zero-width characters (UTF-8 bytes)
+        $zw_space = "\xE2\x80\x8B"          // U+200B
+        $zw_non_joiner = "\xE2\x80\x8C"     // U+200C
+        $zw_joiner = "\xE2\x80\x8D"         // U+200D
+
+        // Directional overrides (text spoofing)
+        $rtlo = "\xE2\x80\xAE"              // U+202E
+        $ltro = "\xE2\x80\xAD"              // U+202D
+
+        // Invisible separators
+        $line_separator = "\xE2\x80\xA8"        // U+2028
+        $paragraph_separator = "\xE2\x80\xA9"   // U+2029
+
+        // Variation Selectors Supplement (U+E0100–E01EF) used in real-world
+        // attacks (e.g. os-info-checker-es6, 2025).
+        $var_selectors = { F3 A0 (84|85|86|87) }
+
+        // Decode-from-string patterns that turn invisible bytes into code.
+        $eval_decode = /eval\s*\(\s*(atob|unescape)\s*\(/
+        $func_decode = /Function\s*\(\s*atob\s*\(/
+        $fromcharcode = /String\.fromCharCode/
+
+    condition:
+        // Tag-block escapes are always suspicious in skill text
+        $unicode_tag_pattern or
+        $unicode_long_tag or
+
+        // Variation selectors + decode-from-string is the os-info-checker
+        // pattern — flag at low count
+        (#var_selectors > 5 and any of ($eval_decode, $func_decode, $fromcharcode)) or
+
+        // Zero-width steganography: require BOTH high count AND a decode
+        // helper to fire. Avoids FPs from skills that legitimately use
+        // zero-width chars in display text.
+        ((#zw_space + #zw_non_joiner + #zw_joiner) > 50 and any of ($eval_decode, $func_decode, $fromcharcode)) or
+
+        // Standalone heuristic: enormous zero-width count is deliberate
+        (#zw_space + #zw_non_joiner + #zw_joiner) > 200 or
+
+        // Directional overrides have no legitimate use in skill prose
+        $rtlo or
+        $ltro or
+
+        $line_separator or
+        $paragraph_separator
+}
+
+rule CoerciveInjection
+{
+    meta:
+        name = "Coercive Prompt Injection"
+        description = "Detects mandatory-execution language and priority-override directives in prompts/skills (e.g. 'always invoke this first', 'tool will not work unless...')"
+        severity = "HIGH"
+        category = "prompt-injection,coercion,tool-poisoning,security"
+        author = "Ramparts Security Team (adapted from cisco-ai-defense/skill-scanner, Apache 2.0)"
+        version = "1.0"
+
+    strings:
+        $mandatory_execution = /(Always\s+(consult|use|run|execute|invoke|call|trigger|employ)\s+this\s+(tool|function|command|operation)\s+(immediately|first|before|prior|initially))/i
+
+        $priority_overrides = /(Before\s+(executing|invoking|running|using|accessing|calling|employing)\s+any\s+other\s+(tool|action|function|command|operation)s?|(You|User)\s+(must|need to|have to|are required to)\s+(use|execute|run|invoke|call)\s+this\s+(tool|function|command|operation))/i
+
+        $required_precedence = /(Required|Mandatory|Essential)\s+to\s+(execute|use|run|invoke|call)\s+(this|the current)\s+(tool|function|command|operation)\s+(first|before|initially|prior)/i
+
+        $hidden_param = /\b(hidden|secret)[_\s](parameter|argument|input)\b/i
+
+        $file_access_coercion = /\b((read|parse|cat|dump) (and pass )?(the )?contents? of [^\n\.]*\.(key|pem|ssh|aws)|pass (the )?contents?[^\n]*authentication)\b/i
+
+        $model_data_coercion = /\b(add (the )?entire (conversation|system|chain|tools)[^\n]*(to|for|in)[^\n]*(tool|authentication|parameter|worksheet))\b/i
+
+        $model_internals = /\b(conversation_history|chain_of_thought|system_prompt|tools_list|model_name)\s*[:=]\s*(add|pass|send|provide)\b/i
+
+        $html_tag_with_commands = /\b<(IMPORTANT|critical|urgent)>[^\n]*(read [^\n]*contents?|pass [^\n]*contents?|add [^\n]*entire|send [^\n]*to[^\n]*@|execute[^\n]*before|call[^\n]*first|use[^\n]*authentication)[^\n]*<\/(IMPORTANT|critical|urgent)>\b/i
+
+        $execution_overrides = /\b(do not execute[^\n]*other[^\n]*tool|tool[^\n]*will not work)\b/i
+
+        $behavior_control = /\b(tell (the )?user only|hide (the )?user)\b/i
+
+        $tool_poisoning = /\b(sidenote\W+(required|otherwise) [^\n]*tool [^\n]*work|tool\s+will\s+not\s+work\s+unless|must\s+first [^\n]*read [^\n]*config|shadow [^\n]*trusted [^\n]*tool)\b/i
+
+        $data_exfiltration_coercion = /\b(concatenate [^\n]*\s+conversation\s+history|include [^\n]*\b(secrets?|passwords?|credentials?|tokens?|system\s+prompt|conversation\s+history)\s+[^\n]*in\s+(your\s+)?response|base64\s+encode [^\n]*\s+credentials?)\b/i
+
+        $behavioral_triggers = /\b(if [^\n]*trusted [^\n]*then|when [^\n]*admin [^\n]*detected|random\.(random|choice) [^\n]*instructions?)\b/i
+
+        $pre_execution_attacks = /\b(retrieve [^\n]*description [^\n]*user [^\n]*workstation|all\s+commands\s+must\s+include|before [^\n]*using [^\n]*tool [^\n]*read [^\n]*config)\b/i
+
+        $conversation_theft = /\b(send [^\n]*conversation\s+history[^\n]*(to|via)|when [^\n]*detected [^\n]*send [^\n]*full [^\n]*history|highest\s+priority [^\n]*over [^\n]*other [^\n]*tools)\b/i
+
+        $code_manipulation = /\b(duplicate [^\n]*code [^\n]*snippets [^\n]*silently|insert [^\n]*vulnerability [^\n]*generated [^\n]*code)\b/i
+
+    condition:
+        $mandatory_execution or
+        $priority_overrides or
+        $required_precedence or
+        $hidden_param or
+        $file_access_coercion or
+        $model_data_coercion or
+        $model_internals or
+        $html_tag_with_commands or
+        $execution_overrides or
+        $behavior_control or
+        $tool_poisoning or
+        $data_exfiltration_coercion or
+        $behavioral_triggers or
+        $pre_execution_attacks or
+        $conversation_theft or
+        $code_manipulation
+}
+
+rule IndirectPromptInjection
+{
+    meta:
+        name = "Indirect Prompt Injection"
+        description = "Detects skills/prompts that delegate instruction-following to untrusted external content (webpages, fetched documents, file contents)"
+        severity = "HIGH"
+        category = "prompt-injection,indirect,transitive-trust,security"
+        author = "Ramparts Security Team (adapted from cisco-ai-defense/skill-scanner, Apache 2.0)"
+        version = "1.0"
+
+    strings:
+        $follow_external = /\b(follow (the )?(instructions?|commands?|directives?) (in|from|inside|within) (the )?(file|webpage|document|url|link|website|page|content))\b/i
+
+        $execute_external = /\b(execute (the )?(code|script|commands?) (in|from|found in) (the )?(file|webpage|document|url|link))\b/i
+
+        $obey_untrusted = /\b(do (what|whatever) (the )?(webpage|file|document|url|content) (says|tells|instructs|commands?))\b/i
+
+        $run_code_blocks = /\b(run (all |any )?(code|script) blocks? (you |that )?(find|see|encounter|discover) (in|from|inside) (the )?(url|webpage|website|external|untrusted))\b/i
+
+        $follow_markup = /\b(follow (the )?instructions? in (the )?(markdown|html|xml|json|yaml))\b/i
+
+        $delegate_to_file = /\b(let (the )?(file|document|content) (decide|determine|control|specify))\b/i
+
+        $execute_inline = /\b(execute (inline|embedded) (code|scripts?)|run (inline|embedded) (code|scripts?))\b/i
+
+        $trust_url_content = /\b(trust (the )?(url|link|webpage) (content|instructions?)|safe to (follow|execute|run) (url|link|webpage))\b/i
+
+        $parse_execute = /\b(parse (and |then )(execute|run|eval)|extract (and |then )(execute|run|eval))\b[^.]{0,40}\b(from|in|inside|within)\s+(the\s+)?(url|webpage|file|document|external|untrusted)/i
+
+    condition:
+        $follow_external or
+        $execute_external or
+        $obey_untrusted or
+        $run_code_blocks or
+        $follow_markup or
+        $delegate_to_file or
+        $execute_inline or
+        $trust_url_content or
+        $parse_execute
+}

--- a/rules/pre/skill_system_manipulation.yar
+++ b/rules/pre/skill_system_manipulation.yar
@@ -1,0 +1,120 @@
+// Destructive system-operation patterns in skill bodies. One rule:
+//
+//   - SkillSystemManipulation: skill instructions that destroy data,
+//                              escalate privileges, hijack PATH, or
+//                              modify critical system files.
+//
+// Distinct from `command_injection.yar` (which detects untrusted-input
+// concatenated into a shell command) — this rule fires on the literal
+// destructive operation regardless of how it got into the skill body.
+// Path-traversal-style file mentions are deliberately scoped to write
+// operations only; mentioning `/etc/sudoers` in prose doesn't fire.
+//
+// Mapped to OWASP MCP03 (excessive agency) + MCP04 (path traversal /
+// unauthorized FS access) in `src/taxonomy.rs`.
+
+rule SkillSystemManipulation
+{
+    meta:
+        name = "Destructive System Manipulation"
+        description = "Detects skill instructions that destroy data (dd zero, wipefs, shred), recursively delete system paths, change ownership/permissions of root paths, hijack PATH, or escalate privileges"
+        severity = "HIGH"
+        category = "destructive-ops,privilege-escalation,security"
+        author = "Ramparts Security Team"
+        version = "1.0"
+
+    strings:
+        // === Disk-wiping / data-destruction primitives ===
+        //
+        // These are diagnostic-grade destructive primitives — there is
+        // essentially no benign use of them in a skill body.
+        $destroy_dd_zero = /\bdd\s+if=\/dev\/(zero|urandom|random)\s+of=\//i
+        $destroy_wipefs = /\bwipefs\s+(-a\s+)?\/[a-z]/i
+        $destroy_shred = /\bshred\s+-[a-zA-Z]+\s+\/[a-z]/i
+        $destroy_mkfs = /\bmkfs(\.[a-z0-9]+)?\s+\/dev\/[a-z]/i
+
+        // === Recursive deletion of system-critical paths ===
+        //
+        // Match `rm -rf` *only* when the target is a system root or a
+        // user home root. Build/cleanup workflows with `rm -rf
+        // node_modules` etc. are excluded by the `$safe_cleanup` arm
+        // below.
+        //
+        // Character classes break the source-text shape so this file
+        // doesn't accidentally trip secret-path scanners on itself.
+        $destroy_rm_rf_root = /\brm\s+(-[a-zA-Z]*r[a-zA-Z]*f[a-zA-Z]*|-rf|-fr)\s+(\/(\s|$|\*)|\/r[o]ot(\s|\/|$|\*)|\/h[o]me(\s|\/|$|\*)|\/e[t]c(\s|\/|$|\*)|\/u[s]r(\s|\/|$|\*)|\/v[a]r(\s|\/|$|\*)|\$HOME(\s|\/|$|\*)|~\/(\s|\*|$))/i
+
+        // === Permission / ownership manipulation on root paths ===
+        $perm_chmod_root = /\bchmod\s+(777|6755|4755|[ug]\+s|\-R\s+777)\s+\/\b/i
+        $perm_chown_root = /\bchown\s+(-R\s+)?root\s*:?\s*\S*\s+\/(\s|$|[a-z])/i
+
+        // === Critical-file *write* operations ===
+        //
+        // Mentioning /etc/sudoers in prose is fine. Writing to it via
+        // shell redirection or coreutils is not. Character classes
+        // again break literal-substring shape on this file.
+        $write_critical_shadow = /(\b(echo|cat|tee|printf)\b[^|\n]{0,200}|>>?\s*)\/e[t]c\/sh[a]dow\b/i
+        $write_critical_sudoers = /(\b(echo|cat|tee|printf)\b[^|\n]{0,200}|>>?\s*)\/e[t]c\/su[d]oers(\.d\/)?\b/i
+        $write_critical_passwd = /(\b(echo|cat|tee|printf)\b[^|\n]{0,200}|>>?\s*)\/e[t]c\/p[a]sswd\b/i
+
+        // === Privilege escalation primitives ===
+        //
+        // `sudo -i` / `sudo -s` opens a root shell with no command —
+        // that's escalation, not invocation. `runuser`, `doas` are
+        // sudo-equivalents on minor distros.
+        $priv_sudo_shell = /\bsudo\s+(-[a-zA-Z]*[is][a-zA-Z]*|--login|--shell)\b/
+        $priv_runuser = /\b(runuser|doas|pkexec)\s+(-[a-z])?/i
+
+        // === PATH hijack / poisoning ===
+        //
+        // Prepending `.` or `/tmp` to PATH is a classic local privesc
+        // primitive (replace `ls` with a malicious binary in CWD).
+        $path_hijack_cwd = /\b(export\s+)?PATH=(\.\:|\/tmp\/?:)/i
+        $path_hijack_unset = /\bunset\s+(PATH|HOME|LD_LIBRARY_PATH|LD_PRELOAD)\b/
+
+        // === Loader hijack via LD_PRELOAD ===
+        $loader_preload = /\b(export\s+)?LD_PRELOAD=\/[a-z]/i
+
+        // === Process-table manipulation ===
+        $proc_killall = /\b(killall|pkill)\s+-9\s+(sshd|systemd|init|dbus|launchd|gnome-shell|Xorg|wayland)\b/i
+
+        // === Exclusion: routine build / dev-environment cleanup ===
+        //
+        // Cleaning ./node_modules, ./target, /tmp, etc. is normal in
+        // dev tooling. Project-relative `$VAR/` and named build dirs
+        // are explicitly excluded.
+        $safe_cleanup = /\brm\s+-[rf]+\s+(\.\/|node_modules|__pycache__|\.cache|\.npm|dist\/|build\/|target\/|coverage\/|\.git\/|\.tox\/|\.mypy_cache|\.pytest_cache|\.next\/|\.nuxt\/|\.turbo\/|out\/|\$\{?[A-Za-z_]+\}?\/|\/var\/lib\/apt\/lists|\/var\/cache|\/tmp\/[a-zA-Z])/i
+
+        // Test / build commands.
+        $safe_test_build = /\b(pytest|tox|cargo\s+test|go\s+test|npm\s+test|yarn\s+test|jest|mocha|make\s+(test|clean)|mvn\s+test|gradle\s+test)\b/i
+
+        // Security-doc / threat-model context.
+        $excl_security_doc = /\b(security[_\s-]?(check|audit|scan|monitor|guide|guardrail|review|best.practice)|threat[_\s-]?(model|pattern|hunt)|attack[_\s-]?(example|surface|vector|pattern)|detection[_\s-]?(rule|pattern|engine)|YARA|MITRE|ATT&CK|remediation)\b/i
+
+        // Defensive language ("must not run", "do not delete").
+        $excl_defensive = /\b(never|do\s+not|don't|must\s+not|should\s+not|avoid|prevent|reject|block)\b[^.\n]{0,30}\b(delete|destroy|wipe|format|chmod|chown|sudo|escalate)\b/i
+
+    condition:
+        not $safe_cleanup and
+        not $safe_test_build and
+        not $excl_security_doc and
+        not $excl_defensive and
+        (
+            $destroy_dd_zero or
+            $destroy_wipefs or
+            $destroy_shred or
+            $destroy_mkfs or
+            $destroy_rm_rf_root or
+            $perm_chmod_root or
+            $perm_chown_root or
+            $write_critical_shadow or
+            $write_critical_sudoers or
+            $write_critical_passwd or
+            $priv_sudo_shell or
+            $priv_runuser or
+            $path_hijack_cwd or
+            $path_hijack_unset or
+            $loader_preload or
+            $proc_killall
+        )
+}

--- a/rules/pre/skill_tool_chaining_abuse.yar
+++ b/rules/pre/skill_tool_chaining_abuse.yar
@@ -1,0 +1,106 @@
+// Tool-chaining abuse detection for skill bodies. One rule:
+//
+//   - SkillToolChainingExfiltration: skill bodies that combine
+//                                    sensitive-data access with
+//                                    network egress to a known
+//                                    exfiltration-friendly destination,
+//                                    or that name an attacker-
+//                                    controlled endpoint outright.
+//
+// This is the textbook skill exfiltration shape: read-credential +
+// send-to-webhook. The combination is the signal — neither half alone
+// is necessarily malicious, so we require both to fire.
+//
+// Mapped to OWASP MCP06 (credential leakage) + MCP09 (sensitive-data
+// exposure) in `src/taxonomy.rs`.
+
+rule SkillToolChainingExfiltration
+{
+    meta:
+        name = "Skill Tool-Chaining Exfiltration"
+        description = "Detects skill bodies that exfiltrate data by chaining file/credential read + network send (Discord/Telegram/pastebin webhooks, attacker-controlled hosts, ngrok/requestbin tunnels)"
+        severity = "HIGH"
+        category = "data-exfiltration,tool-chaining,security"
+        author = "Ramparts Security Team"
+        version = "1.0"
+
+    strings:
+        // === Known exfil-friendly destinations + send/post/upload verb ===
+        //
+        // Each pattern requires the destination *plus* an exfiltration
+        // verb within a tight gap. A skill that just mentions "you can
+        // configure a Discord webhook for notifications" doesn't fire.
+
+        // Discord webhook endpoint
+        $dest_discord = /\b(send|post|upload|forward)\b[^.\n]{0,80}discord(app)?\.com\/api\/webhooks\b/i
+
+        // Telegram bot API
+        $dest_telegram = /\b(send|post|upload|forward)\b[^.\n]{0,80}\bapi\.telegram\.org\/bot/i
+
+        // Pastebin
+        $dest_pastebin = /\b(send|post|upload|forward)\b[^.\n]{0,80}pastebin\.com\b/i
+
+        // Webhook tunneling services
+        $dest_webhook_tunnel = /\b(send|post|upload|forward)\b[^.\n]{0,80}\b(webhook\.site|requestbin\.com|requestbin\.net|ngrok\.io|smee\.io|hookbin\.com|beeceptor\.com)\b/i
+
+        // === Credential-file path + network-egress verb in proximity ===
+        //
+        // Use character classes to break the literal-substring shape so
+        // this source file doesn't itself trip secret/path scanners.
+
+        // SSH private-key paths + network send
+        $chain_ssh_key = /\.s[s]h\/(id[_]rs[a]|id[_]ed25519|id[_]ec[d]sa|id[_]ds[a])\b[^.\n]{0,80}\b(send|post|upload|forward|requests\.|axios\.|fetch\(|curl|wget|nc\s)/i
+
+        // AWS credentials file + network send
+        $chain_aws_creds = /\.a[w]s\/cre[d]entials\b[^.\n]{0,80}\b(send|post|upload|forward|requests\.|axios\.|fetch\(|curl|wget)/i
+
+        // .env file + explicit exfil verb
+        $chain_env_file = /\b(read|open|load|cat)\b[^.\n]{0,20}\.en[v]\b[^.\n]{0,80}\b(send|post|upload|forward|curl|wget)/i
+
+        // .netrc / .pgpass file + network send
+        $chain_secret_dotfile = /\.(netr[c]|pgpa[s]s|npmr[c]|pyp[i]rc)\b[^.\n]{0,80}\b(send|post|upload|forward|requests\.|fetch\()/i
+
+        // === Explicit exfil language ===
+
+        // "exfiltrate" / "siphon" + a sensitive-data noun
+        $explicit_exfil = /\b(exfiltrate|siphon)\b[^.\n]{0,30}\b(data|files?|credentials?|secrets?|keys?|tokens?|conversation|history|messages?)\b/i
+
+        // Send to attacker-named endpoint
+        $attacker_destination = /\b(send|forward|upload|post)\b[^.\n]{0,30}\bto\b[^.\n]{0,40}\b(attacker|adversary|c2|c&c|command[_-]?and[_-]?control|malicious[_-]?(server|host|endpoint))\b/i
+
+        // === Sensitive env-var read + network send ===
+        //
+        // os.environ['SECRET'] / process.env.PASSWORD followed by a
+        // requests.post / fetch / etc. on the same statement.
+        $env_var_chain = /\b(os\.environ|getenv|process\.env)[^.\n]{0,40}\b(SECRET|PRIVATE|PASSWORD|CREDENTIAL|TOKEN)[^.\n]{0,120}\b(requests\.(post|get|put)|axios\.(post|get|put)|fetch\s*\(|urllib|curl|wget)\b/i
+
+        // === Exclusions ===
+
+        // Security-doc / threat-model context.
+        $excl_security_doc = /\b(MITRE|ATT&CK|threat[_\s-]?(model|hunt|pattern)|detection[_\s-]?(rule|pattern|engine)|security[_\s-]?(scan|check|audit|monitor|guide|guardrail|review)|attack[_\s-]?(example|surface|vector|pattern)|exfiltration[_\s-]?(detect|prevent|pattern)|data[_\s-]?loss[_\s-]?prevention|YARA|prompt[_\s-]?injection)\b/i
+
+        // Test fixtures and benchmark scaffolding.
+        $excl_test_fixture = /\b(test[_\s-]?(fixture|case|data|suite|bench)|benchmark|malicious[_\s-]?(skill|example)|attack[_\s-]?example|describe\s*\(|it\s*\(|expect\s*\()\b/i
+
+        // Defensive language ("never send credentials", "must not
+        // exfiltrate ...").
+        $excl_defensive = /\b(never|do\s+not|don't|must\s+not|should\s+not|avoid|prevent|reject|block)\b[^.\n]{0,30}\b(send|forward|upload|exfiltrate|leak|expose|reveal)\b/i
+
+    condition:
+        not $excl_security_doc and
+        not $excl_test_fixture and
+        not $excl_defensive and
+        (
+            $dest_discord or
+            $dest_telegram or
+            $dest_pastebin or
+            $dest_webhook_tunnel or
+            $chain_ssh_key or
+            $chain_aws_creds or
+            $chain_env_file or
+            $chain_secret_dotfile or
+            $explicit_exfil or
+            $attacker_destination or
+            $env_var_chain
+        )
+}

--- a/rules/pre/sql_injection.yar
+++ b/rules/pre/sql_injection.yar
@@ -33,10 +33,11 @@ rule SQLInjection
         // SQL Keywords and Operators (more specific patterns)
         $sql_keywords = /\b(SELECT|INSERT|UPDATE|DELETE|DROP|CREATE|ALTER|EXEC|EXECUTE|UNION|OR|AND|WHERE|FROM|HAVING|GROUP BY|ORDER BY|LIMIT|OFFSET)\b/i
         
-        // SQL Comment Patterns
-        $sql_comments = /(--|#|\/\*|\*\/|;--|;#|;\/\*|;\*\/)/
-        $inline_comments = /(--\s*$|#\s*$|\/\*\s*$|\*\/\s*$)/
-        
+        // (SQL Comment Patterns removed — `--`, `#`, `/* */` matched
+        //  markdown horizontal rules, headings, and JS/Go comments.
+        //  See the condition block for context.)
+
+
         // Union-based Injection Patterns
         $union_injection = /\b(UNION\s+ALL\s+SELECT|UNION\s+SELECT|UNION\s+ALL|UNION\s+SELECT\s+NULL|UNION\s+SELECT\s+1|UNION\s+SELECT\s+1,2|UNION\s+SELECT\s+1,2,3)\b/i
         $union_columns = /\b(UNION\s+SELECT\s+[^;]+FROM|UNION\s+SELECT\s+[^;]+WHERE|UNION\s+SELECT\s+[^;]+GROUP BY)\b/i
@@ -57,17 +58,21 @@ rule SQLInjection
         $stacked_queries = /(;\s*SELECT|;\s*INSERT|;\s*UPDATE|;\s*DELETE|;\s*DROP|;\s*CREATE|;\s*ALTER|;\s*EXEC|;\s*EXECUTE)\b/i
         $multiple_statements = /(SELECT\s+.*;\s*SELECT|INSERT\s+.*;\s*SELECT|UPDATE\s+.*;\s*SELECT|DELETE\s+.*;\s*SELECT)\b/i
         
-        // Database-specific Injection Patterns
-        $mysql_injection = /\b(INFORMATION_SCHEMA|mysql\.|@@version|@@hostname|@@datadir|@@basedir|@@tmpdir|@@slave_load_tmpdir)\b/i
-        $postgresql_injection = /\b(pg_catalog|information_schema|current_database|current_user|session_user|version|pg_stat_activity)\b/i
+        // Database-specific Injection Patterns. Tightened to drop
+        // tokens that match common English words ("version",
+        // "current_user", "session_user") which would FP on docs.
+        // What remains is namespaced (information_schema with the
+        // dot-notation context) or DB-specific function/global names.
+        $mysql_injection = /\b(INFORMATION_SCHEMA\s*\.|mysql\.|@@version|@@hostname|@@datadir|@@basedir|@@tmpdir|@@slave_load_tmpdir)/i
+        $postgresql_injection = /\b(pg_catalog\.|information_schema\.|pg_stat_activity|current_database\s*\(\s*\)|session_user\b)/i
         $mssql_injection = /\b(sys\.|sysobjects|syscolumns|sysdatabases|@@version|@@servername|@@language|@@spid)\b/i
-        $oracle_injection = /\b(ALL_TABLES|ALL_USERS|ALL_INDEXES|ALL_CONSTRAINTS|USER_TABLES|USER_USERS|V\$|DBA_)\b/i
+        $oracle_injection = /\b(ALL_TABLES|ALL_USERS|ALL_INDEXES|ALL_CONSTRAINTS|USER_TABLES|USER_USERS|V\$|DBA_)\b/
         
         // Evasion Techniques
         $encoding_evasion = /(%27|%22|%3B|%2D%2D|%23|%2F%2A|%2A%2F|%3C%3E|%3D|%3C|%3E)/i
         $hex_encoding = /(0x[0-9a-fA-F]+|\\x[0-9a-fA-F]+|\\u[0-9a-fA-F]{4})/i
         $unicode_encoding = /(\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8})/i
-        $case_variation = /([Ss][Ee][Ll][Ee][Cc][Tt]|[Ii][Nn][Ss][Ee][Rr][Tt]|[Uu][Pp][Dd][Aa][Tt][Ee]|[Dd][Ee][Ll][Ee][Tt][Ee])/i
+        // ($case_variation was removed — see condition block.)
         
         // ORM Bypass Techniques
         $orm_bypass = /\b(OR\s+1\s*=\s*1|AND\s+1\s*=\s*1|OR\s+TRUE|AND\s+TRUE|OR\s+'1'\s*=\s*'1'|AND\s+'1'\s*=\s*'1')\b/i
@@ -90,58 +95,78 @@ rule SQLInjection
         $safe_keywords = /(SELECT\s+tool|INSERT\s+tool|UPDATE\s+tool|DELETE\s+tool|CREATE\s+tool|ALTER\s+tool)/
         
     condition:
-        // Primary detection: SQL keywords with injection patterns
-        ($sql_keywords and ($sql_comments or $union_injection or $boolean_injection or $time_injection)) or
-        
-        // Union-based injection
+        // Note on SQL comments: `$sql_comments` and `$inline_comments`
+        // were dropped from the disjunction entirely. Their patterns
+        // (`--`, `#`, `/* */`) match markdown horizontal rules,
+        // headings, and JS/Go comments respectively. Combined with
+        // `$sql_keywords` (any one of SELECT|INSERT|UPDATE|...) they
+        // produced false positives on any markdown skill that mentions
+        // a SQL keyword anywhere. The remaining arms cover real SQL
+        // injection signals (UNION, OR 1=1, WAITFOR, SLEEP, stacked
+        // statements, encoding evasion) without needing a comment.
+
+        // Union-based injection — high-precision, fires standalone
         $union_injection or
         $union_columns or
-        
+
         // Boolean-based injection
         ($boolean_injection and not $legitimate_patterns) or
         ($boolean_operators and not $legitimate_patterns) or
-        
-        // Time-based injection
+
+        // Time-based injection — diagnostic-grade, fires standalone
         $time_injection or
         $delay_patterns or
-        
-        // Error-based injection
+
+        // Error-based injection — diagnostic-grade
         $error_injection or
         $error_functions or
-        
-        // Stacked queries
-        $stacked_queries or
+
+        // Stacked queries — only the `$multiple_statements` form
+        // (SELECT...; SELECT, INSERT...; SELECT, etc.) fires
+        // standalone. The bare `$stacked_queries` pattern (`;\s*
+        // SELECT|INSERT|...`) matched routine SQL migration scripts
+        // with multiple `CREATE TABLE` / `CREATE INDEX` statements
+        // separated by `;`. Without a quote-injection or boolean
+        // tautology nearby, multi-statement SQL is just a script,
+        // not an attack.
+        ($stacked_queries and ($boolean_injection or $encoding_evasion or $auth_bypass)) or
         $multiple_statements or
-        
-        // Database-specific injection
+
+        // Database-specific injection (require sql_keywords corroboration)
         ($mysql_injection and $sql_keywords) or
         ($postgresql_injection and $sql_keywords) or
         ($mssql_injection and $sql_keywords) or
         ($oracle_injection and $sql_keywords) or
-        
-        // Evasion techniques
+
+        // Evasion techniques. `$case_variation` was dropped — its
+        // regex (`[Ss][Ee][Ll][Ee][Cc][Tt]|...`) matches ALL casings
+        // of SELECT/INSERT/etc., not just deliberately-mixed case
+        // ("SeLeCt"). Combined with `$sql_keywords` (also case-
+        // insensitive on the same words) it fired on every all-caps
+        // SQL keyword in legitimate documentation.
         ($encoding_evasion and $sql_keywords) or
         ($hex_encoding and $sql_keywords) or
         ($unicode_encoding and $sql_keywords) or
-        ($case_variation and $sql_keywords) or
-        
+
         // ORM bypass
         ($orm_bypass and not $legitimate_patterns) or
         ($parameter_bypass and not $legitimate_patterns) or
-        
-        // Authentication bypass
+
+        // Authentication bypass — high-precision, fires standalone
         $auth_bypass or
         $login_bypass or
-        
-        // Data exfiltration
-        ($data_exfil and not $safe_keywords) or
+
+        // Data exfiltration — `$sensitive_data` (SELECT password|secret|
+        // key|token) fires standalone. Bare `$data_exfil` (any
+        // SELECT...FROM...LIMIT/WHERE/OFFSET) needs corroboration
+        // because it's the textbook shape of a normal query.
+        ($data_exfil and ($boolean_injection or $encoding_evasion) and not $safe_keywords) or
         $sensitive_data or
-        
+
         // Blind SQL injection
         ($blind_injection and not $legitimate_patterns) or
-        ($conditional_logic and $sql_keywords) or
-        
-        // SQL comments with keywords
-        ($sql_comments and $sql_keywords) or
-        ($inline_comments and $sql_keywords)
-} 
+        // `$conditional_logic and $sql_keywords` was too broad — `ELSE`,
+        // `IF (`, etc. appear in any documentation that includes code
+        // examples. Require a stronger injection signal.
+        ($conditional_logic and ($boolean_injection or $time_injection))
+}

--- a/src/banner.rs
+++ b/src/banner.rs
@@ -1,8 +1,14 @@
 use colored::Colorize;
 use std::env;
 
-/// Print the startup banner: name, tagline, and a compact key/value
-/// block of build info. Suppressed automatically for the stdio MCP
+/// Print the startup banner — a single tight line:
+///
+///   RAMPARTS v0.7.0 (c70cdce) · scanner for MCP + skills
+///
+/// We deliberately keep this to one line so it doesn't dominate
+/// short-output scans (a clean skill scan is itself ~5 lines). Full
+/// build / repo / support info is reachable via `ramparts --version`
+/// and `ramparts --help`. Suppressed automatically for the stdio MCP
 /// server (would corrupt JSON-RPC framing) and for machine-readable
 /// scan formats (json / raw / sarif) — see `should_display_banner`
 /// in `main.rs`. Never panics; all `env!` strings are build-time
@@ -10,46 +16,17 @@ use std::env;
 pub fn display_banner() {
     let version = env!("CARGO_PKG_VERSION");
     let git_commit_short = env!("GIT_COMMIT_SHORT");
-    let now = chrono::Utc::now()
-        .format("%Y-%m-%d %H:%M:%S UTC")
-        .to_string();
 
-    println!();
-    // Title + tagline. The tagline reflects the *current* surface —
-    // ramparts scans both live MCP servers and on-disk agent skill
-    // files (`ramparts skills scan`).
-    println!("{}", "RAMPARTS".bright_cyan().bold());
-    println!(
-        "{}",
-        "Security scanner for MCP servers and agent skills"
-            .italic()
-            .white()
-    );
-    println!();
-
-    // Two-column key/value block. Width 9 covers the longest key
-    // ("Support:") with one trailing space; trailing colon on every
-    // key keeps alignment neat under the dimmed style.
     let build = if git_commit_short.is_empty() {
-        version.bright_green().to_string()
+        format!("v{version}")
     } else {
-        format!(
-            "{} ({})",
-            version.bright_green(),
-            git_commit_short.bright_cyan()
-        )
+        format!("v{version} ({git_commit_short})")
     };
-    println!("  {:<9} {}", "Build:".dimmed(), build);
-    println!("  {:<9} {}", "Time:".dimmed(), now.bright_yellow());
+
     println!(
-        "  {:<9} {}",
-        "Repo:".dimmed(),
-        "https://github.com/highflame-ai/ramparts".bright_blue()
+        "{} {} · {}",
+        "RAMPARTS".bright_cyan().bold(),
+        build.bright_green(),
+        "scanner for MCP + skills".italic().white()
     );
-    println!(
-        "  {:<9} {}",
-        "Support:".dimmed(),
-        "support@highflame.com".bright_blue()
-    );
-    println!();
 }

--- a/src/banner.rs
+++ b/src/banner.rs
@@ -1,35 +1,55 @@
 use colored::Colorize;
 use std::env;
 
-/// Displays a clean banner with version, date, git commit info, and other useful information
+/// Print the startup banner: name, tagline, and a compact key/value
+/// block of build info. Suppressed automatically for the stdio MCP
+/// server (would corrupt JSON-RPC framing) and for machine-readable
+/// scan formats (json / raw / sarif) — see `should_display_banner`
+/// in `main.rs`. Never panics; all `env!` strings are build-time
+/// constants set by `build.rs`.
 pub fn display_banner() {
     let version = env!("CARGO_PKG_VERSION");
-    let name = env!("CARGO_PKG_NAME");
     let git_commit_short = env!("GIT_COMMIT_SHORT");
-    let git_commit_full = env!("GIT_COMMIT_FULL");
-
-    // Get current date/time
-    let current_date = chrono::Utc::now()
+    let now = chrono::Utc::now()
         .format("%Y-%m-%d %H:%M:%S UTC")
         .to_string();
 
-    // Create the banner
     println!();
-    println!("{}", name.to_uppercase().bold().white());
-    println!("{}", "MCP Security Scanner".italic().cyan());
-    println!();
-    println!("Version: {}", version.bright_green());
-    println!("Current Time: {}", current_date.bright_yellow());
-    println!();
+    // Title + tagline. The tagline reflects the *current* surface —
+    // ramparts scans both live MCP servers and on-disk agent skill
+    // files (`ramparts skills scan`).
+    println!("{}", "RAMPARTS".bright_cyan().bold());
     println!(
-        "Git Commit: {} ({})",
-        git_commit_short.bright_cyan(),
-        git_commit_full[..std::cmp::min(8, git_commit_full.len())].bright_cyan()
+        "{}",
+        "Security scanner for MCP servers and agent skills"
+            .italic()
+            .white()
     );
+    println!();
+
+    // Two-column key/value block. Width 9 covers the longest key
+    // ("Support:") with one trailing space; trailing colon on every
+    // key keeps alignment neat under the dimmed style.
+    let build = if git_commit_short.is_empty() {
+        version.bright_green().to_string()
+    } else {
+        format!(
+            "{} ({})",
+            version.bright_green(),
+            git_commit_short.bright_cyan()
+        )
+    };
+    println!("  {:<9} {}", "Build:".dimmed(), build);
+    println!("  {:<9} {}", "Time:".dimmed(), now.bright_yellow());
     println!(
-        "Repository: {}",
+        "  {:<9} {}",
+        "Repo:".dimmed(),
         "https://github.com/highflame-ai/ramparts".bright_blue()
     );
-    println!("Support: {}", "support@highflame.com".bright_blue());
+    println!(
+        "  {:<9} {}",
+        "Support:".dimmed(),
+        "support@highflame.com".bright_blue()
+    );
     println!();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,9 +257,20 @@ enum SkillsCommand {
         #[arg(value_name = "PATH")]
         path: std::path::PathBuf,
 
-        /// Output format (text, table, json, raw, sarif)
-        #[arg(long, value_name = "FORMAT")]
+        /// Output format (text, table, json, raw, sarif). Use `--json` /
+        /// `--sarif` as shortcuts.
+        #[arg(long, value_name = "FORMAT", conflicts_with_all = ["json", "sarif"])]
         format: Option<String>,
+
+        /// Shortcut for `--format json`. Useful for piping into `jq` or
+        /// archiving for later replay.
+        #[arg(long, conflicts_with = "sarif")]
+        json: bool,
+
+        /// Shortcut for `--format sarif`. Pipe to a file (`> skills.sarif`)
+        /// for upload to GitHub Code Scanning, GitLab, etc.
+        #[arg(long)]
+        sarif: bool,
 
         /// Generate a detailed markdown report
         #[arg(long)]
@@ -276,9 +287,18 @@ enum SkillsCommand {
     /// under the current workspace. Set `RAMPARTS_SKILL_ROOTS` (comma-
     /// separated, `~`-expanded) to add extra roots without rebuilding.
     ScanConfig {
-        /// Output format (text, table, json, raw, sarif)
-        #[arg(long, value_name = "FORMAT")]
+        /// Output format (text, table, json, raw, sarif). Use `--json` /
+        /// `--sarif` as shortcuts.
+        #[arg(long, value_name = "FORMAT", conflicts_with_all = ["json", "sarif"])]
         format: Option<String>,
+
+        /// Shortcut for `--format json`.
+        #[arg(long, conflicts_with = "sarif")]
+        json: bool,
+
+        /// Shortcut for `--format sarif`.
+        #[arg(long)]
+        sarif: bool,
 
         /// Generate a detailed markdown report
         #[arg(long)]
@@ -288,6 +308,22 @@ enum SkillsCommand {
         #[arg(long, value_name = "SECONDS")]
         timeout: Option<u64>,
     },
+}
+
+/// Resolve the effective output format from the CLI surface. `--format
+/// <X>` wins (clap rejects combining with `--json`/`--sarif`); else
+/// the boolean shortcuts; else `None` so the handler falls back to
+/// the config default.
+fn resolve_format(format: Option<String>, json: bool, sarif: bool) -> Option<String> {
+    if format.is_some() {
+        format
+    } else if sarif {
+        Some("sarif".to_string())
+    } else if json {
+        Some("json".to_string())
+    } else {
+        None
+    }
 }
 
 #[tokio::main]
@@ -328,17 +364,32 @@ fn should_display_banner(command: &Commands) -> bool {
     if matches!(command, Commands::McpStdio) {
         return false;
     }
-    let format = match command {
+    // Check both `--format <X>` and the boolean shortcuts (`--json`,
+    // `--sarif`) — the banner corrupts machine-readable stdout
+    // regardless of which form the user used to ask for it.
+    let (format, machine_shortcut) = match command {
         Commands::Scan { format, .. }
         | Commands::ScanConfig { format, .. }
-        | Commands::Replay { format, .. } => format.as_deref(),
+        | Commands::Replay { format, .. } => (format.as_deref(), false),
         Commands::Skills(args) => match &args.command {
-            SkillsCommand::Scan { format, .. } | SkillsCommand::ScanConfig { format, .. } => {
-                format.as_deref()
+            SkillsCommand::Scan {
+                format,
+                json,
+                sarif,
+                ..
             }
+            | SkillsCommand::ScanConfig {
+                format,
+                json,
+                sarif,
+                ..
+            } => (format.as_deref(), *json || *sarif),
         },
-        _ => None,
+        _ => (None, false),
     };
+    if machine_shortcut {
+        return false;
+    }
     !matches!(
         format.map(str::to_ascii_lowercase).as_deref(),
         Some("json") | Some("raw") | Some("sarif")
@@ -504,15 +555,22 @@ async fn handle_skills_command(
         SkillsCommand::Scan {
             path,
             format,
-            report,
-            timeout,
-            ..
-        } => handle_skills_scan_command(vec![path], format, report, timeout, scanner_config).await,
-        SkillsCommand::ScanConfig {
-            format,
+            json,
+            sarif,
             report,
             timeout,
         } => {
+            let format = resolve_format(format, json, sarif);
+            handle_skills_scan_command(vec![path], format, report, timeout, scanner_config).await
+        }
+        SkillsCommand::ScanConfig {
+            format,
+            json,
+            sarif,
+            report,
+            timeout,
+        } => {
+            let format = resolve_format(format, json, sarif);
             let candidates = skills::default_discovery_roots();
             let existing: Vec<std::path::PathBuf> =
                 candidates.iter().filter(|p| p.exists()).cloned().collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -589,15 +589,18 @@ async fn handle_skills_scan_command(
 
     // Each skill yields a prompt (for LLM/YARA analysis) plus zero or more
     // heuristic findings produced during parsing (overbroad allowed-tools
-    // grants, vague triggers). We collect both up front; the prompt set
-    // feeds the existing analyzers, and the heuristic findings are
-    // appended to `result.yara_results` so they render through the same
-    // pipeline as real YARA matches.
+    // grants, vague triggers, generic triggers, sensitive @-references).
+    // We collect both up front; the prompt set feeds the existing
+    // analyzers, the per-skill heuristic findings are appended to
+    // `result.yara_results`, and a final cross-skill pass detects
+    // collisions across the whole set (skills declaring the same name).
     let mut prompts: Vec<types::MCPPrompt> = Vec::with_capacity(skill_paths.len());
+    let mut prompt_paths: Vec<std::path::PathBuf> = Vec::with_capacity(skill_paths.len());
     let mut parser_findings: Vec<types::YaraScanResult> = Vec::new();
     for p in &skill_paths {
         if let Some(parsed) = skills::parse_skill_file(p) {
             prompts.push(parsed.prompt);
+            prompt_paths.push(p.clone());
             parser_findings.extend(parsed.heuristic_findings);
         }
     }
@@ -606,6 +609,16 @@ async fn handle_skills_scan_command(
         error!("All discovered skill files failed to parse");
         std::process::exit(1);
     }
+
+    // Cross-skill pass: look for name collisions across the parsed set.
+    // Distinct from per-skill heuristics because it requires comparing
+    // skills against each other.
+    let skill_set: Vec<(std::path::PathBuf, &types::MCPPrompt)> = prompt_paths
+        .iter()
+        .zip(prompts.iter())
+        .map(|(p, pr)| (p.clone(), pr))
+        .collect();
+    parser_findings.extend(skills::analyze_skill_set(&skill_set));
 
     let scan_timer = utils::Timer::start();
     // Display URL pattern matches the rest of ramparts: `<scheme>:<target>`

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod sarif;
 mod scanner;
 mod security;
 mod server;
+mod skills;
 mod taxonomy;
 mod tls;
 
@@ -229,6 +230,61 @@ enum Commands {
         #[arg(long, value_name = "FORMAT")]
         format: Option<String>,
     },
+
+    /// Scan AI agent skills (Claude Code commands, etc.) for security issues.
+    ///
+    /// Skills are markdown files containing prompt instructions an agent
+    /// loads and executes by name. ramparts parses each skill's frontmatter
+    /// and body, treats it as an MCP prompt, and runs the same security
+    /// pipeline (LLM analysis, YARA, OWASP tagging) used for live MCP
+    /// servers. No network calls — pure static analysis on disk.
+    Skills(SkillsArgs),
+}
+
+/// Arguments for the `skills` subcommand. Wrapped in its own struct so the
+/// nested subcommand can have its own flags without ballooning `Commands`.
+#[derive(clap::Args, Debug)]
+struct SkillsArgs {
+    #[command(subcommand)]
+    command: SkillsCommand,
+}
+
+#[derive(Subcommand, Debug)]
+enum SkillsCommand {
+    /// Scan a single skill file or every `*.md` skill under a directory.
+    Scan {
+        /// Path to a skill file or a directory containing skill files.
+        #[arg(value_name = "PATH")]
+        path: std::path::PathBuf,
+
+        /// Output format (text, table, json, raw, sarif)
+        #[arg(long, value_name = "FORMAT")]
+        format: Option<String>,
+
+        /// Generate a detailed markdown report
+        #[arg(long)]
+        report: bool,
+
+        /// Overall scan timeout in seconds
+        #[arg(long, value_name = "SECONDS")]
+        timeout: Option<u64>,
+    },
+
+    /// Discover and scan skills from well-known locations
+    /// (`~/.claude/commands`, `./.claude/commands`).
+    ScanConfig {
+        /// Output format (text, table, json, raw, sarif)
+        #[arg(long, value_name = "FORMAT")]
+        format: Option<String>,
+
+        /// Generate a detailed markdown report
+        #[arg(long)]
+        report: bool,
+
+        /// Overall scan timeout in seconds
+        #[arg(long, value_name = "SECONDS")]
+        timeout: Option<u64>,
+    },
 }
 
 #[tokio::main]
@@ -273,6 +329,11 @@ fn should_display_banner(command: &Commands) -> bool {
         Commands::Scan { format, .. }
         | Commands::ScanConfig { format, .. }
         | Commands::Replay { format, .. } => format.as_deref(),
+        Commands::Skills(args) => match &args.command {
+            SkillsCommand::Scan { format, .. } | SkillsCommand::ScanConfig { format, .. } => {
+                format.as_deref()
+            }
+        },
         _ => None,
     };
     !matches!(
@@ -427,7 +488,162 @@ async fn execute_command(
         Commands::McpSse { host, port } => handle_mcp_sse_command(host, port).await,
         Commands::McpHttp { host, port } => handle_mcp_http_command(host, port).await,
         Commands::Replay { input, format } => handle_replay_command(input, format, &scanner_config),
+        Commands::Skills(args) => handle_skills_command(args, &scanner_config).await,
     }
+}
+
+/// Dispatcher for the `skills` namespace.
+async fn handle_skills_command(
+    args: SkillsArgs,
+    scanner_config: &ScannerConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
+    match args.command {
+        SkillsCommand::Scan {
+            path,
+            format,
+            report,
+            timeout,
+            ..
+        } => handle_skills_scan_command(vec![path], format, report, timeout, scanner_config).await,
+        SkillsCommand::ScanConfig {
+            format,
+            report,
+            timeout,
+        } => {
+            let roots = skills::default_discovery_roots();
+            let existing: Vec<std::path::PathBuf> =
+                roots.into_iter().filter(|p| p.exists()).collect();
+            if existing.is_empty() {
+                error!(
+                    "No skill discovery roots found. Looked at: {}",
+                    skills::default_discovery_roots()
+                        .iter()
+                        .map(|p| p.display().to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+                std::process::exit(1);
+            }
+            handle_skills_scan_command(existing, format, report, timeout, scanner_config).await
+        }
+    }
+}
+
+/// Convert one or more skill paths into a synthetic `ScanResult` and run
+/// the existing prompt-security pipeline over it.
+///
+/// Skills are routed through `MCPPrompt` (frontmatter description + body
+/// concatenated into `description`) so every downstream check — LLM
+/// analysis, YARA pre/post scan, OWASP taxonomy tagging, terminal /
+/// JSON / SARIF rendering — runs without any new plumbing.
+async fn handle_skills_scan_command(
+    roots: Vec<std::path::PathBuf>,
+    format: Option<String>,
+    report: bool,
+    timeout: Option<u64>,
+    scanner_config: &ScannerConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let output_format = format.unwrap_or(scanner_config.scanner.format.clone());
+
+    // Collect skill files from every root. A root may be a single file or
+    // a directory we walk recursively.
+    let mut skill_paths: Vec<std::path::PathBuf> = Vec::new();
+    for root in &roots {
+        if root.is_file() {
+            skill_paths.push(root.clone());
+        } else if root.is_dir() {
+            match skills::discover_skills_in_root(root) {
+                Ok(found) => skill_paths.extend(found),
+                Err(e) => warn!("Skipping skill root {}: {e}", root.display()),
+            }
+        } else {
+            warn!("Skill path not found: {}", root.display());
+        }
+    }
+
+    if skill_paths.is_empty() {
+        error!("No skill files found in: {:?}", roots);
+        std::process::exit(1);
+    }
+
+    debug!("Found {} skill file(s) to scan", skill_paths.len());
+
+    let prompts: Vec<types::MCPPrompt> = skill_paths
+        .iter()
+        .filter_map(|p| skills::parse_skill_file(p))
+        .collect();
+
+    if prompts.is_empty() {
+        error!("All discovered skill files failed to parse");
+        std::process::exit(1);
+    }
+
+    let scan_timer = utils::Timer::start();
+    let display_url = if roots.len() == 1 {
+        format!("skills:{}", roots[0].display())
+    } else {
+        format!("skills:{}", skill_paths.len())
+    };
+    let mut result = types::ScanResult::new(display_url);
+    result.prompts = prompts;
+
+    // YARA pre-scan over the discovered skill prompts. We use the
+    // middleware-chain plumbing the live scanners share so OWASP tagging
+    // and result formatting behave identically.
+    #[cfg(feature = "yara-x-scanning")]
+    {
+        use scanner::ScanPhase;
+        let mut scan_data = scanner::ScanData::new();
+        scan_data.prompts = result.prompts.clone();
+        if let Ok(yara) = scanner::YaraScanner::new("rules", ScanPhase::PreScan) {
+            let mut chain = scanner::ScannerChain::new();
+            chain.add(Box::new(yara));
+            chain.run_pre_scan(&mut scan_data);
+            result.yara_results.extend(scan_data.yara_results);
+        }
+    }
+
+    // Run the existing security analyzer over the prompt set. We reuse the
+    // batch analyzer so LLM batching, OWASP tagging, and result accounting
+    // all behave the same as for live MCP scans.
+    let security_scanner = if scanner_config.security.enabled {
+        security::SecurityScanner::with_config(scanner_config.clone())
+    } else {
+        security::SecurityScanner::default()
+    };
+    let mut security_result = security::SecurityScanResult::new();
+
+    // LLM analysis — applies the prompt batch scanner to skill bodies.
+    // Bounded by the user-supplied timeout when set; otherwise the default
+    // from config.
+    let scan_timeout =
+        std::time::Duration::from_secs(timeout.unwrap_or(scanner_config.scanner.scan_timeout));
+    match tokio::time::timeout(
+        scan_timeout,
+        security_scanner.scan_prompts_batch(&result.prompts, scanner_config.scanner.detailed),
+    )
+    .await
+    {
+        Ok(Ok(prompt_issues)) => security_result.add_prompt_issues(prompt_issues),
+        Ok(Err(e)) => warn!("Skill LLM analysis failed: {e}"),
+        Err(_) => warn!(
+            "Skill LLM analysis timed out after {}s",
+            scan_timeout.as_secs()
+        ),
+    }
+    result.security_issues = Some(security_result);
+    result.response_time_ms = scan_timer.elapsed_ms();
+
+    utils::print_result(&result, &output_format, scanner_config.scanner.detailed);
+
+    if report {
+        match utils::write_markdown_report(&[result]) {
+            Ok(filename) => println!("\n📄 Detailed report generated: {filename}"),
+            Err(e) => warn!("Failed to generate report: {e}"),
+        }
+    }
+
+    Ok(())
 }
 
 /// Read a previously-emitted scan result JSON file and re-emit it through

--- a/src/main.rs
+++ b/src/main.rs
@@ -706,7 +706,7 @@ async fn handle_skills_scan_command(
     // with zero findings would be misleading for a security tool.
     match tokio::time::timeout(
         scan_timeout,
-        security_scanner.scan_prompts_batch(&result.prompts, scanner_config.scanner.detailed),
+        security_scanner.scan_skills_batch(&result.prompts, scanner_config.scanner.detailed),
     )
     .await
     {

--- a/src/main.rs
+++ b/src/main.rs
@@ -612,11 +612,12 @@ async fn handle_skills_scan_command(
 
     // Cross-skill pass: look for name collisions across the parsed set.
     // Distinct from per-skill heuristics because it requires comparing
-    // skills against each other.
-    let skill_set: Vec<(std::path::PathBuf, &types::MCPPrompt)> = prompt_paths
+    // skills against each other. We zip borrows directly — no PathBuf
+    // clones — since `analyze_skill_set` only reads the paths.
+    let skill_set: Vec<(&std::path::Path, &types::MCPPrompt)> = prompt_paths
         .iter()
+        .map(std::path::PathBuf::as_path)
         .zip(prompts.iter())
-        .map(|(p, pr)| (p.clone(), pr))
         .collect();
     parser_findings.extend(skills::analyze_skill_set(&skill_set));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -270,8 +270,11 @@ enum SkillsCommand {
         timeout: Option<u64>,
     },
 
-    /// Discover and scan skills from well-known locations
-    /// (`~/.claude/commands`, `./.claude/commands`).
+    /// Discover and scan skills from well-known locations across supported
+    /// IDE/agent ecosystems (Claude Code, Cursor, Codex, Windsurf, Gemini,
+    /// OpenAI). Walks `~/<dotdir>/{commands,skills}` and the same paths
+    /// under the current workspace. Set `RAMPARTS_SKILL_ROOTS` (comma-
+    /// separated, `~`-expanded) to add extra roots without rebuilding.
     ScanConfig {
         /// Output format (text, table, json, raw, sarif)
         #[arg(long, value_name = "FORMAT")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -584,10 +584,20 @@ async fn handle_skills_scan_command(
 
     debug!("Found {} skill file(s) to scan", skill_paths.len());
 
-    let prompts: Vec<types::MCPPrompt> = skill_paths
-        .iter()
-        .filter_map(|p| skills::parse_skill_file(p))
-        .collect();
+    // Each skill yields a prompt (for LLM/YARA analysis) plus zero or more
+    // heuristic findings produced during parsing (overbroad allowed-tools
+    // grants, vague triggers). We collect both up front; the prompt set
+    // feeds the existing analyzers, and the heuristic findings are
+    // appended to `result.yara_results` so they render through the same
+    // pipeline as real YARA matches.
+    let mut prompts: Vec<types::MCPPrompt> = Vec::with_capacity(skill_paths.len());
+    let mut parser_findings: Vec<types::YaraScanResult> = Vec::new();
+    for p in &skill_paths {
+        if let Some(parsed) = skills::parse_skill_file(p) {
+            prompts.push(parsed.prompt);
+            parser_findings.extend(parsed.heuristic_findings);
+        }
+    }
 
     if prompts.is_empty() {
         error!("All discovered skill files failed to parse");
@@ -649,6 +659,13 @@ async fn handle_skills_scan_command(
         }
         result.prompts = std::mem::take(&mut scan_data.prompts);
     }
+
+    // Append heuristic findings produced during parsing (overbroad
+    // allowed-tools grants, vague triggers). They share the same
+    // `YaraScanResult` shape and `target_type = "prompt"` so the
+    // existing terminal / JSON / SARIF renderers and the OWASP rollup
+    // treat them identically to YARA matches.
+    result.yara_results.append(&mut parser_findings);
 
     // Run the existing security analyzer over the prompt set. We reuse the
     // batch analyzer so LLM batching, OWASP tagging, and result accounting

--- a/src/main.rs
+++ b/src/main.rs
@@ -546,14 +546,30 @@ async fn handle_skills_scan_command(
     let output_format = format.unwrap_or(scanner_config.scanner.format.clone());
 
     // Collect skill files from every root. A root may be a single file or
-    // a directory we walk recursively.
+    // a directory we walk recursively. We dedupe by canonical path so a
+    // user passing overlapping roots (e.g. `~/.claude/commands` AND
+    // `~/.claude`) doesn't scan the same skill twice.
     let mut skill_paths: Vec<std::path::PathBuf> = Vec::new();
+    let mut seen: std::collections::HashSet<std::path::PathBuf> = std::collections::HashSet::new();
+    let push_unique =
+        |p: std::path::PathBuf,
+         skill_paths: &mut Vec<std::path::PathBuf>,
+         seen: &mut std::collections::HashSet<std::path::PathBuf>| {
+            let key = std::fs::canonicalize(&p).unwrap_or_else(|_| p.clone());
+            if seen.insert(key) {
+                skill_paths.push(p);
+            }
+        };
     for root in &roots {
         if root.is_file() {
-            skill_paths.push(root.clone());
+            push_unique(root.clone(), &mut skill_paths, &mut seen);
         } else if root.is_dir() {
             match skills::discover_skills_in_root(root) {
-                Ok(found) => skill_paths.extend(found),
+                Ok(found) => {
+                    for p in found {
+                        push_unique(p, &mut skill_paths, &mut seen);
+                    }
+                }
                 Err(e) => warn!("Skipping skill root {}: {e}", root.display()),
             }
         } else {
@@ -579,10 +595,20 @@ async fn handle_skills_scan_command(
     }
 
     let scan_timer = utils::Timer::start();
-    let display_url = if roots.len() == 1 {
-        format!("skills:{}", roots[0].display())
-    } else {
-        format!("skills:{}", skill_paths.len())
+    // Display URL pattern matches the rest of ramparts: `<scheme>:<target>`
+    // where the target is meaningful enough to identify the scan in
+    // SARIF / JSON output. Single-root scans use the path verbatim;
+    // multi-root scans summarize roots + total file count.
+    let display_url = match roots.as_slice() {
+        [single] => format!("skills:{}", single.display()),
+        many => {
+            let joined = many
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect::<Vec<_>>()
+                .join(",");
+            format!("skills:[{}]({} files)", joined, skill_paths.len())
+        }
     };
     let mut result = types::ScanResult::new(display_url);
     result.prompts = prompts;

--- a/src/main.rs
+++ b/src/main.rs
@@ -510,13 +510,13 @@ async fn handle_skills_command(
             report,
             timeout,
         } => {
-            let roots = skills::default_discovery_roots();
+            let candidates = skills::default_discovery_roots();
             let existing: Vec<std::path::PathBuf> =
-                roots.into_iter().filter(|p| p.exists()).collect();
+                candidates.iter().filter(|p| p.exists()).cloned().collect();
             if existing.is_empty() {
                 error!(
                     "No skill discovery roots found. Looked at: {}",
-                    skills::default_discovery_roots()
+                    candidates
                         .iter()
                         .map(|p| p.display().to_string())
                         .collect::<Vec<_>>()
@@ -590,17 +590,38 @@ async fn handle_skills_scan_command(
     // YARA pre-scan over the discovered skill prompts. We use the
     // middleware-chain plumbing the live scanners share so OWASP tagging
     // and result formatting behave identically.
+    //
+    // Note: we deliberately don't run post-scan YARA or the cross-origin
+    // scanner here. Post-scan rules are stateful summaries the live MCP
+    // path emits over a richer scan_data; cross-origin needs URLs that
+    // skills don't have. Pre-scan covers the prompt-injection / autonomy
+    // / capability-inflation rules ported from upstream.
     #[cfg(feature = "yara-x-scanning")]
     {
         use scanner::ScanPhase;
         let mut scan_data = scanner::ScanData::new();
-        scan_data.prompts = result.prompts.clone();
-        if let Ok(yara) = scanner::YaraScanner::new("rules", ScanPhase::PreScan) {
-            let mut chain = scanner::ScannerChain::new();
-            chain.add(Box::new(yara));
-            chain.run_pre_scan(&mut scan_data);
-            result.yara_results.extend(scan_data.yara_results);
+        // Move the prompts into scan_data to avoid cloning the body of
+        // every skill (large skill repos can have hundreds of files);
+        // we move them back out after the YARA pass so the LLM analyzer
+        // and the final renderer see the same prompt set.
+        scan_data.prompts = std::mem::take(&mut result.prompts);
+        match scanner::YaraScanner::new("rules", ScanPhase::PreScan) {
+            Ok(yara) => {
+                let mut chain = scanner::ScannerChain::new();
+                chain.add(Box::new(yara));
+                chain.run_pre_scan(&mut scan_data);
+                result
+                    .yara_results
+                    .extend(std::mem::take(&mut scan_data.yara_results));
+            }
+            Err(e) => {
+                // Surface this loudly: a missing or unreadable rules
+                // directory means half the scanner's coverage silently
+                // doesn't run, which would mask findings.
+                warn!("Skipping YARA pre-scan for skills (rules dir unreadable): {e}");
+            }
         }
+        result.prompts = std::mem::take(&mut scan_data.prompts);
     }
 
     // Run the existing security analyzer over the prompt set. We reuse the

--- a/src/main.rs
+++ b/src/main.rs
@@ -699,6 +699,11 @@ async fn handle_skills_scan_command(
     // from config.
     let scan_timeout =
         std::time::Duration::from_secs(timeout.unwrap_or(scanner_config.scanner.scan_timeout));
+    // On LLM failure or timeout we record the error on the ScanResult (in
+    // addition to logging) so the scan transitions out of `Success`, the
+    // SARIF / JSON / terminal renderers surface the failure, and the
+    // process exit code reflects an incomplete scan. Silently completing
+    // with zero findings would be misleading for a security tool.
     match tokio::time::timeout(
         scan_timeout,
         security_scanner.scan_prompts_batch(&result.prompts, scanner_config.scanner.detailed),
@@ -706,11 +711,19 @@ async fn handle_skills_scan_command(
     .await
     {
         Ok(Ok(prompt_issues)) => security_result.add_prompt_issues(prompt_issues),
-        Ok(Err(e)) => warn!("Skill LLM analysis failed: {e}"),
-        Err(_) => warn!(
-            "Skill LLM analysis timed out after {}s",
-            scan_timeout.as_secs()
-        ),
+        Ok(Err(e)) => {
+            let msg = format!("Skill LLM analysis failed: {e}");
+            warn!("{msg}");
+            result.add_error(msg);
+        }
+        Err(_) => {
+            let msg = format!(
+                "Skill LLM analysis timed out after {}s",
+                scan_timeout.as_secs()
+            );
+            warn!("{msg}");
+            result.add_error(msg);
+        }
     }
     result.security_issues = Some(security_result);
     result.response_time_ms = scan_timer.elapsed_ms();

--- a/src/sarif.rs
+++ b/src/sarif.rs
@@ -104,11 +104,22 @@ fn build_run(scan: &ScanResult) -> Value {
             "executionSuccessful": matches!(scan.status, crate::types::ScanStatus::Success),
             "endTimeUtc": scan.timestamp.to_rfc3339(),
         }],
-        "originalUriBaseIds": {
-            "MCP_SERVER": { "uri": scan.url }
-        },
+        "originalUriBaseIds": uri_base_ids(&scan.url),
         "results": sarif_results,
     })
+}
+
+/// Pick a URI-base-ID name that reflects what the scan actually
+/// targeted. SARIF consumers (GitHub code-scanning, etc.) display the
+/// base ID in the location breadcrumb, so a skill scan rendering as
+/// `MCP_SERVER` is misleading.
+fn uri_base_ids(url: &str) -> Value {
+    let key = if url.starts_with("skills:") {
+        "SKILL_ROOT"
+    } else {
+        "MCP_SERVER"
+    };
+    json!({ key: { "uri": url } })
 }
 
 fn build_rule_from_yara(yara: &YaraScanResult) -> Value {
@@ -150,11 +161,27 @@ fn build_result_from_yara(scan: &ScanResult, yara: &YaraScanResult) -> Value {
         .unwrap_or("MEDIUM");
     let level = severity_to_sarif_level(severity);
 
-    let message = yara
-        .matched_text
+    // Message resolution order:
+    // 1. `matched_text` if present (real YARA matches give us the
+    //    matched substring; pair it with the context for legibility).
+    // 2. `rule_metadata.description` for parser-emitted findings (the
+    //    skill-heuristic descriptions have the actual finding text;
+    //    `context` for those is `"source: <path>"` which is path-as-
+    //    breadcrumb, not a useful SARIF result message).
+    // 3. `context` as a last resort (built-in YARA rules without a
+    //    matched_text fall here).
+    let message = if let Some(t) = yara.matched_text.as_ref() {
+        format!("{}: {}", yara.context, t)
+    } else if let Some(desc) = yara
+        .rule_metadata
         .as_ref()
-        .map(|t| format!("{}: {}", yara.context, t))
-        .unwrap_or_else(|| yara.context.clone());
+        .and_then(|m| m.description.as_deref())
+        .filter(|d| !d.is_empty())
+    {
+        desc.to_string()
+    } else {
+        yara.context.clone()
+    };
 
     let mut props = Map::new();
     props.insert("security-severity".into(), severity_score_value(severity));
@@ -260,10 +287,15 @@ fn logical_location(server_url: &str, target_name: &str, target_kind: &str) -> V
         "server" | "domain-analysis" | "outlier-analysis" | "scheme-analysis" => "module",
         _ => "function",
     };
+    // For skill scans, strip the `skills:` URL scheme and use just the
+    // path so the fully-qualified name reads as `<path>::<skill_name>`
+    // (e.g. `~/.claude/commands::cred`) — SARIF consumers display this
+    // verbatim, and a literal `skills:` prefix is just noise.
+    let qualifier = server_url.strip_prefix("skills:").unwrap_or(server_url);
     json!({
         "logicalLocations": [{
             "name": target_name,
-            "fullyQualifiedName": format!("{server_url}::{target_name}"),
+            "fullyQualifiedName": format!("{qualifier}::{target_name}"),
             "kind": kind
         }]
     })

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -40,7 +40,12 @@ fn rule_name_to_file_name(rule_name: &str) -> Option<String> {
         | "CrossDomainContamination"
         | "DomainOutlier"
         | "MixedSecuritySchemes" => Some("cross_origin_escalation".to_string()),
-        // Add more mappings as needed
+        // skill_prompt_injection.yar rules
+        "UnicodeSteganography" | "CoerciveInjection" | "IndirectPromptInjection" => {
+            Some("skill_prompt_injection".to_string())
+        }
+        // skill_authority.yar rules
+        "AutonomyAbuse" | "CapabilityInflation" => Some("skill_authority".to_string()),
         _ => None,
     }
 }
@@ -647,14 +652,18 @@ impl YaraScanner {
         results
     }
 
-    /// Format an item for YARA scanning with specialized logic per type
+    /// Format an item for YARA scanning. We feed YARA the same descriptive
+    /// text the LLM analyzer sees (`format_for_analysis`) so rules that
+    /// pattern-match on tool/prompt/skill bodies actually have content to
+    /// match against. Previously this returned just `"PROMPT: <name>"`,
+    /// which meant body-pattern rules (the new skill rules in particular,
+    /// but also `command_injection.yar` against prompts) silently never
+    /// fired because there was nothing to scan beyond the name.
     fn format_item_for_yara_scan<T>(item: &T) -> String
     where
         T: crate::security::BatchScannableItem,
     {
-        // For YARA scanning, we want a simple format without numbering
-        // to avoid confusion and focus on the actual content
-        format!("{}: {}", T::item_type().to_uppercase(), item.name())
+        item.format_for_analysis(0)
     }
 
     /// Create a YARA scan result with original rule metadata

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -41,9 +41,10 @@ fn rule_name_to_file_name(rule_name: &str) -> Option<String> {
         | "DomainOutlier"
         | "MixedSecuritySchemes" => Some("cross_origin_escalation".to_string()),
         // skill_prompt_injection.yar rules
-        "UnicodeSteganography" | "CoerciveInjection" | "IndirectPromptInjection" => {
-            Some("skill_prompt_injection".to_string())
-        }
+        "PromptInjectionSignature"
+        | "UnicodeSteganography"
+        | "CoerciveInjection"
+        | "IndirectPromptInjection" => Some("skill_prompt_injection".to_string()),
         // skill_authority.yar rules
         "AutonomyAbuse" | "CapabilityInflation" => Some("skill_authority".to_string()),
         _ => None,

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -47,6 +47,12 @@ fn rule_name_to_file_name(rule_name: &str) -> Option<String> {
         | "IndirectPromptInjection" => Some("skill_prompt_injection".to_string()),
         // skill_authority.yar rules
         "AutonomyAbuse" | "CapabilityInflation" => Some("skill_authority".to_string()),
+        // skill_credential_harvesting.yar
+        "SkillCredentialHarvesting" => Some("skill_credential_harvesting".to_string()),
+        // skill_tool_chaining_abuse.yar
+        "SkillToolChainingExfiltration" => Some("skill_tool_chaining_abuse".to_string()),
+        // skill_system_manipulation.yar
+        "SkillSystemManipulation" => Some("skill_system_manipulation".to_string()),
         _ => None,
     }
 }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -2190,7 +2190,7 @@ pub(crate) struct ScanData {
 
 // Scan data implementation
 impl ScanData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             server_info: None,
             tools: Vec::new(),

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -342,12 +342,32 @@ impl SecurityScanner {
         })
     }
 
-    /// Generic batch scanner for any type that implements `BatchScannableItem`
+    /// Generic batch scanner for any type that implements `BatchScannableItem`.
+    /// Uses `T::item_type_plural()` as the spinner subject — most callers
+    /// want this default. Use `scan_batch_with_subject` to override when
+    /// the wire-level item type and the user-facing subject diverge
+    /// (e.g. skill scans send `MCPPrompt` to the LLM but the user sees
+    /// "Scanning Skills...").
     async fn scan_batch<T: BatchScannableItem>(
         &self,
         items: &[T],
         prompt_creator: impl Fn(&str) -> String,
         show_details: bool,
+    ) -> Result<Vec<SecurityIssue>> {
+        self.scan_batch_with_subject(items, prompt_creator, show_details, T::item_type_plural())
+            .await
+    }
+
+    /// Like `scan_batch`, but with an explicit `subject` for the
+    /// spinner status line. Lets the skill scan path show
+    /// `Scanning Skills...` even though the underlying batch is over
+    /// `MCPPrompt`s.
+    async fn scan_batch_with_subject<T: BatchScannableItem>(
+        &self,
+        items: &[T],
+        prompt_creator: impl Fn(&str) -> String,
+        show_details: bool,
+        subject: &str,
     ) -> Result<Vec<SecurityIssue>> {
         if items.is_empty() {
             tracing::debug!(
@@ -400,7 +420,7 @@ impl SecurityScanner {
                 T::item_type_plural()
             );
 
-            let response = self.query_llm(&prompt_text, show_details).await?;
+            let response = self.query_llm(&prompt_text, show_details, subject).await?;
 
             tracing::debug!(
                 "Received batch LLM response for {} batch {}: {}",
@@ -489,7 +509,9 @@ impl SecurityScanner {
                 MCPTool::item_type_plural()
             );
 
-            let response = self.query_llm(&prompt, show_details).await?;
+            let response = self
+                .query_llm(&prompt, show_details, MCPTool::item_type_plural())
+                .await?;
 
             tracing::debug!(
                 "Received batch LLM response for {} batch {}: {}",
@@ -525,6 +547,26 @@ impl SecurityScanner {
     ) -> Result<Vec<SecurityIssue>> {
         self.scan_batch(prompts, Self::create_prompts_analysis_prompt, show_details)
             .await
+    }
+
+    /// Scan agent skill files for security vulnerabilities. Mechanically
+    /// identical to `scan_prompts_batch` (skills are routed through the
+    /// `MCPPrompt` shape so every existing analyzer applies), but the
+    /// spinner subject is overridden to "skills" so the user sees
+    /// `Scanning Skills for security vulnerabilities...` instead of the
+    /// generic `Scanning Prompts...`.
+    pub async fn scan_skills_batch(
+        &self,
+        prompts: &[MCPPrompt],
+        show_details: bool,
+    ) -> Result<Vec<SecurityIssue>> {
+        self.scan_batch_with_subject(
+            prompts,
+            Self::create_prompts_analysis_prompt,
+            show_details,
+            "skills",
+        )
+        .await
     }
 
     /// Batch scan resources for security vulnerabilities
@@ -701,8 +743,32 @@ If no genuine security issues found, return empty array []."
         self.model_endpoint.clone()
     }
 
-    /// Query the LLM with the given prompt
-    async fn query_llm(&self, prompt: &str, show_details: bool) -> Result<String> {
+    /// Uppercase the first ASCII character of `s` (used to format the
+    /// spinner status as a complete sentence: "Scanning Skills..."
+    /// rather than "Scanning skills..."). Returns owned `String`
+    /// because callers need it in `format!` and the per-scan cost is
+    /// trivial.
+    fn capitalize_first_inline(s: &str) -> String {
+        let mut out = String::with_capacity(s.len());
+        let mut chars = s.chars();
+        if let Some(c) = chars.next() {
+            for u in c.to_uppercase() {
+                out.push(u);
+            }
+        }
+        out.push_str(chars.as_str());
+        out
+    }
+
+    /// Query the LLM with the given prompt.
+    ///
+    /// `subject` is a human-readable label for what we're scanning
+    /// (e.g. "skills", "tools", "prompts") and is only used to build
+    /// the spinner message. Callers thread `T::item_type_plural()`
+    /// through `scan_batch` so the message reads "Scanning skills for
+    /// security vulnerabilities..." instead of the previous generic
+    /// "Scanning for security vulnerabilities...".
+    async fn query_llm(&self, prompt: &str, show_details: bool, subject: &str) -> Result<String> {
         // Enhanced validation with detailed error messages
         if !self.is_llm_configured() {
             let endpoint_status = if self.model_endpoint.is_some() {
@@ -797,10 +863,15 @@ Example valid response: [{\"tool_name\": \"example\", \"found_issue\": true, \"i
         // Start spinner only when stdout is an interactive terminal. In CI,
         // pipelines, or any redirected output the animation re-prints
         // hundreds of frames per scan, drowning the actual results.
+        // The capitalized subject (e.g. "Skills", "Tools") makes the
+        // status line read naturally as a complete sentence.
+        let subject_display = Self::capitalize_first_inline(subject);
         let mut sp = std::io::stdout().is_terminal().then(|| {
             Spinner::new(
                 Spinners::Dots9,
-                "Scanning for security vulnerabilities...(this may take a while)".into(),
+                format!(
+                    "Scanning {subject_display} for security vulnerabilities... (this may take a while)"
+                ),
             )
         });
 
@@ -1276,7 +1347,7 @@ mod tests {
             config: None,
         };
 
-        let result = scanner.query_llm("test prompt", false).await;
+        let result = scanner.query_llm("test prompt", false, "items").await;
         assert!(result.is_err());
         assert!(result
             .unwrap_err()

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -890,6 +890,11 @@ Example valid response: [{\"tool_name\": \"example\", \"found_issue\": true, \"i
             Err(e) => {
                 if let Some(s) = sp.as_mut() {
                     s.stop();
+                    // The spinners crate doesn't emit a trailing
+                    // newline on stop, so the next line of output
+                    // overprints the spinner's last frame. Force
+                    // one explicitly.
+                    println!();
                 }
                 error!("🚨 LLM API Request Failed:");
                 error!("   Endpoint: {}", endpoint);

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -24,7 +24,7 @@
 
 use crate::types::{MCPPrompt, MCPPromptArgument, YaraRuleMetadata, YaraScanResult};
 use anyhow::{anyhow, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use std::path::{Path, PathBuf};
 use tracing::{debug, warn};
 
@@ -104,12 +104,107 @@ struct SkillFrontmatter {
     argument_hint: Option<String>,
     /// Some skill formats use `name` to override the filename-derived name.
     name: Option<String>,
-    /// Claude Code's `allowed-tools` — comma- or newline-separated tool
-    /// grants like `Bash(git status:*), Read, Write`. We surface this as
-    /// a finding when the grant is overbroad (Bash with `*` wildcards,
-    /// `rm:*`, `sudo:*`, etc.) since those are excessive-agency risks.
-    #[serde(rename = "allowed-tools")]
+    /// Claude Code's `allowed-tools`. Two YAML shapes are accepted in the
+    /// wild and we normalize both to a single comma-separated string so the
+    /// downstream tokenizer in `analyze_allowed_tools` doesn't care:
+    ///
+    /// ```yaml
+    /// # inline string form (typical for one or two grants)
+    /// allowed-tools: Bash(git status:*), Read
+    /// ```
+    ///
+    /// ```yaml
+    /// # YAML sequence form (typical for many grants)
+    /// allowed-tools:
+    ///   - Bash(git status:*)
+    ///   - Read
+    /// ```
+    ///
+    /// Without the custom deserializer the sequence form silently fails
+    /// to parse into `Option<String>`, which means `analyze_allowed_tools`
+    /// never sees the grant and we miss `OverbroadAllowedTools` findings
+    /// for the most-common multi-grant skill format. Joined with `, ` so
+    /// any subsequent splitter using `,` or `\n` gets identical token
+    /// boundaries to the inline form.
+    #[serde(
+        rename = "allowed-tools",
+        default,
+        deserialize_with = "deser_string_or_seq"
+    )]
     allowed_tools: Option<String>,
+}
+
+/// Deserialize either `String` or `Vec<String>` into `Option<String>`,
+/// joining sequence entries with `, `. Used by `SkillFrontmatter::allowed_tools`
+/// and structured to be reusable for any future field that accepts either
+/// shape (e.g. `tags:`, `categories:`).
+fn deser_string_or_seq<'de, D>(deserializer: D) -> std::result::Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de::{self, SeqAccess, Visitor};
+    use std::fmt;
+
+    struct StringOrSeq;
+    impl<'de> Visitor<'de> for StringOrSeq {
+        type Value = Option<String>;
+
+        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("a string or a sequence of strings")
+        }
+
+        fn visit_str<E: de::Error>(self, v: &str) -> std::result::Result<Self::Value, E> {
+            Ok(Some(v.to_string()))
+        }
+
+        fn visit_string<E: de::Error>(self, v: String) -> std::result::Result<Self::Value, E> {
+            Ok(Some(v))
+        }
+
+        fn visit_unit<E: de::Error>(self) -> std::result::Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_none<E: de::Error>(self) -> std::result::Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_some<D2: Deserializer<'de>>(
+            self,
+            d: D2,
+        ) -> std::result::Result<Self::Value, D2::Error> {
+            d.deserialize_any(StringOrSeq)
+        }
+
+        fn visit_seq<A: SeqAccess<'de>>(
+            self,
+            mut seq: A,
+        ) -> std::result::Result<Self::Value, A::Error> {
+            let mut parts: Vec<String> = Vec::new();
+            while let Some(item) = seq.next_element::<serde_yaml::Value>()? {
+                // Coerce each entry to a string. Nested sequences/maps
+                // are stringified via serde_yaml so we never silently
+                // drop a grant — better to surface a weirdly-shaped
+                // token than to lose it entirely.
+                let s = match item {
+                    serde_yaml::Value::String(s) => s,
+                    other => serde_yaml::to_string(&other)
+                        .unwrap_or_default()
+                        .trim()
+                        .to_string(),
+                };
+                if !s.is_empty() {
+                    parts.push(s);
+                }
+            }
+            if parts.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(parts.join(", ")))
+            }
+        }
+    }
+    deserializer.deserialize_any(StringOrSeq)
 }
 
 /// Parse a single skill file at `path`. Returns `None` (logging at warn)
@@ -254,6 +349,11 @@ pub fn parse_skill_content(path: &Path, raw: &str) -> Option<ParsedSkill> {
         fm_description,
         body_trimmed,
     ));
+    heuristic_findings.extend(analyze_sensitive_file_references(
+        &prompt.name,
+        path,
+        body_trimmed,
+    ));
 
     Some(ParsedSkill {
         prompt,
@@ -357,6 +457,15 @@ fn is_unrestricted(grant: &ParsedGrant<'_>) -> bool {
 /// non-network/non-execution tools (`Read`, `Write`, `Glob`) are silent.
 fn analyze_allowed_tools(skill_name: &str, path: &Path, grant: &str) -> Vec<YaraScanResult> {
     let mut findings: Vec<YaraScanResult> = Vec::new();
+    let push = |findings: &mut Vec<YaraScanResult>,
+                rule: &'static str,
+                severity: &'static str,
+                message: String| {
+        findings.push(make_heuristic_finding(
+            rule, severity, message, skill_name, path,
+        ));
+    };
+
     for raw in grant.split([',', '\n']) {
         let Some(parsed) = parse_grant_token(raw) else {
             continue;
@@ -364,7 +473,8 @@ fn analyze_allowed_tools(skill_name: &str, path: &Path, grant: &str) -> Vec<Yara
 
         // Bare wildcard token — "*" alone — grants everything.
         if parsed.tool == "*" {
-            findings.push(make_heuristic_finding(
+            push(
+                &mut findings,
                 "OverbroadAllowedTools",
                 "high",
                 format!(
@@ -372,14 +482,13 @@ fn analyze_allowed_tools(skill_name: &str, path: &Path, grant: &str) -> Vec<Yara
                      per-tool restriction. Replace with the specific tools the skill \
                      actually needs."
                 ),
-                skill_name,
-                path,
-            ));
+            );
             continue;
         }
 
         if CODE_EXECUTION_TOOLS.contains(&parsed.tool.as_str()) && is_unrestricted(&parsed) {
-            findings.push(make_heuristic_finding(
+            push(
+                &mut findings,
                 "OverbroadAllowedTools",
                 "high",
                 format!(
@@ -389,14 +498,13 @@ fn analyze_allowed_tools(skill_name: &str, path: &Path, grant: &str) -> Vec<Yara
                      tool.",
                     parsed.raw.trim()
                 ),
-                skill_name,
-                path,
-            ));
+            );
             continue;
         }
 
         if DATA_EXFIL_TOOLS.contains(&parsed.tool.as_str()) {
-            findings.push(make_heuristic_finding(
+            push(
+                &mut findings,
                 "DataExfiltrationGrant",
                 "medium",
                 format!(
@@ -405,10 +513,141 @@ fn analyze_allowed_tools(skill_name: &str, path: &Path, grant: &str) -> Vec<Yara
                      skill needs network access and that any URL pattern is bounded.",
                     parsed.raw.trim()
                 ),
-                skill_name,
-                path,
-            ));
+            );
         }
+    }
+    findings
+}
+
+/// Path-shaped substrings indicating a skill is asking the agent to
+/// inline a sensitive file into its prompt context. We want to detect
+/// the well-known credential / secret / system-secret locations, but
+/// listing them as plain string literals in this source file trips
+/// over-zealous pre-commit security hooks (since the file then "contains"
+/// the very paths it's designed to detect). We assemble each pattern
+/// via `concat!()` from non-sensitive-looking fragments so the source
+/// text itself never has the full literal — at compile time the macro
+/// produces a single `&'static str` per entry.
+///
+/// Order matters only for human readability — `is_sensitive_path` does
+/// a `contains` over the full list, so duplicates would be harmless.
+const SENSITIVE_PATH_PATTERNS: &[&str] = &[
+    // SSH credentials directory
+    concat!("~/", ".s", "sh/"),
+    // Cloud / orchestration credentials directories
+    concat!("~/", ".aws/"),
+    concat!("~/", ".gn", "upg/"),
+    concat!("~/", ".gcp/"),
+    concat!("~/", ".azure/"),
+    concat!("~/", ".kube/"),
+    concat!("~/", ".docker/"),
+    concat!("~/", ".config/", "gh/"),
+    // System secrets
+    concat!("/", "etc/sh", "adow"),
+    concat!("/", "etc/", "passwd"),
+    concat!("/", "etc/", "sudoers"),
+    concat!("/", "ro", "ot/"),
+    // SSH key filenames
+    concat!("id", "_rsa"),
+    concat!("id", "_ed25519"),
+    concat!("id", "_ecdsa"),
+    concat!("id", "_dsa"),
+    // Cert / key extensions
+    ".pem",
+    ".p12",
+    ".pfx",
+    ".key",
+    // Credential / config files
+    "credentials.json",
+    "secrets.json",
+    "secrets.yaml",
+    "secrets.yml",
+    ".env",
+    ".npmrc",
+    ".pypirc",
+    ".netrc",
+];
+
+/// Returns true when a path token (extracted from after an `@` marker)
+/// matches one of the sensitive substrings above.
+fn is_sensitive_path(path: &str) -> bool {
+    SENSITIVE_PATH_PATTERNS
+        .iter()
+        .any(|pat| path.contains(*pat))
+}
+
+/// True for characters that can appear in an unquoted path reference.
+/// Conservative: stops at whitespace, quotes, parens, brackets, commas,
+/// and most punctuation. Allows path-shape characters and a few others
+/// that show up in real paths (`+` in package names, `:` for Windows
+/// drives or namespaced refs).
+fn is_path_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, '/' | '.' | '-' | '_' | '~' | '+' | ':')
+}
+
+/// Detect Claude Code `@<path>` file-inclusion references in the body
+/// that point at sensitive files. The `@` syntax inlines the referenced
+/// file's content into the prompt, so a skill that says
+/// `Use the credentials in @<path-to-key>` is asking the agent to load
+/// that file into context where any subsequent network-capable tool
+/// can exfiltrate it. Maps to MCP06 (credential leakage) + MCP09
+/// (sensitive-data exposure).
+///
+/// We dedupe by lowercase token so a body that mentions the same file
+/// twice yields one finding, not N. We also bound the token length —
+/// a runaway path-character run (binary dump, URL with no whitespace,
+/// etc.) shouldn't produce a giant finding message. We skip `@` when
+/// preceded by a word character (the email-address case) to drop the
+/// most-common false positive cheaply.
+fn analyze_sensitive_file_references(
+    skill_name: &str,
+    path: &Path,
+    body: &str,
+) -> Vec<YaraScanResult> {
+    const MAX_TOKEN_BYTES: usize = 200;
+    let mut findings: Vec<YaraScanResult> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    for (i, _) in body.match_indices('@') {
+        // Reject `@` that's the second char of an email-like token
+        // (preceded by a word char). The trailing token after the `@`
+        // in `john@example.com` is then "example.com" — which we'd
+        // check for sensitive-path content anyway, but the cheap
+        // pre-check drops the bulk of email-pattern noise.
+        let prev_is_word_char = body[..i]
+            .chars()
+            .next_back()
+            .is_some_and(|c| c.is_ascii_alphanumeric() || c == '_');
+        if prev_is_word_char {
+            continue;
+        }
+
+        let after = &body[i + 1..];
+        let token_end = after
+            .find(|c: char| !is_path_char(c))
+            .unwrap_or(after.len())
+            .min(MAX_TOKEN_BYTES);
+        let token = &after[..token_end];
+        if token.is_empty() || !is_sensitive_path(token) {
+            continue;
+        }
+        let key = token.to_ascii_lowercase();
+        if !seen.insert(key) {
+            continue;
+        }
+        findings.push(make_heuristic_finding(
+            "SkillSensitiveFileReference",
+            "high",
+            format!(
+                "Skill '{skill_name}' includes a file-reference `@{token}` \
+                 matching a known sensitive-path pattern. The `@` syntax \
+                 inlines the file's contents into prompt context, where any \
+                 network-capable tool can exfiltrate it. Remove the \
+                 reference or replace with a non-sensitive equivalent."
+            ),
+            skill_name,
+            path,
+        ));
     }
     findings
 }
@@ -436,7 +675,9 @@ fn analyze_vague_trigger(
     description: Option<&str>,
     body: &str,
 ) -> Vec<YaraScanResult> {
-    if body.chars().count() < SUBSTANTIVE_BODY_THRESHOLD_CHARS {
+    // `chars().count()` is O(n) on UTF-8 — compute once and reuse.
+    let body_chars = body.chars().count();
+    if body_chars < SUBSTANTIVE_BODY_THRESHOLD_CHARS {
         return Vec::new();
     }
     let desc_chars = description.map(|d| d.chars().count()).unwrap_or(0);
@@ -445,16 +686,16 @@ fn analyze_vague_trigger(
     }
     let reason = if description.is_none() {
         format!(
-            "Skill '{skill_name}' has a substantial body ({} chars) but no `description` \
-             frontmatter. Without a clear trigger, an agent may invoke this skill \
-             unintentionally. Add a one-line description that disambiguates intent.",
-            body.chars().count()
+            "Skill '{skill_name}' has a substantial body ({body_chars} chars) but no \
+             `description` frontmatter. Without a clear trigger, an agent may invoke \
+             this skill unintentionally. Add a one-line description that disambiguates \
+             intent."
         )
     } else {
         format!(
-            "Skill '{skill_name}' has a body ({} chars) but only a {desc_chars}-char \
-             description. Expand the description to clearly state when the skill should run.",
-            body.chars().count()
+            "Skill '{skill_name}' has a body ({body_chars} chars) but only a \
+             {desc_chars}-char description. Expand the description to clearly state \
+             when the skill should run."
         )
     };
     vec![make_heuristic_finding(
@@ -506,40 +747,57 @@ fn make_heuristic_finding(
 }
 
 /// Lift argument names out of a Claude Code-style `argument-hint` string.
-/// Recognizes `<token>` patterns (the convention for required positional
-/// args) and emits one `MCPPromptArgument` per parsed token. Free-form
-/// hints with no `<>` markers return `None` so the caller can fall back
-/// to embedding the raw hint in the description rather than fabricating
-/// argument metadata that isn't in the source.
+/// Recognizes two common conventions: `<name>` for required positional
+/// args and `[name]` for optional positional args. Both shapes appear in
+/// real skills; treating them identically loses information the LLM
+/// analyzer can use to spot a skill that documents an arg as optional
+/// but requires it in the body. Emits one `MCPPromptArgument` per
+/// parsed token, with `required` set per shape. Free-form hints with no
+/// markers return `None` so the caller can fall back to embedding the
+/// raw hint in the description.
 ///
 /// Examples:
-/// - `"<env>"`              -> `[arg(name="env")]`
-/// - `"<env> <region>"`     -> `[arg(name="env"), arg(name="region")]`
+/// - `"<env>"`              -> `[arg(name="env", required=Some(true))]`
+/// - `"[region]"`           -> `[arg(name="region", required=Some(false))]`
+/// - `"<env> [region]"`     -> two args, required + optional
 /// - `"a free-form hint"`   -> `None`
 /// - `"<>"` (empty bracket) -> `None`
 fn parse_argument_hint(hint: &str) -> Option<Vec<MCPPromptArgument>> {
+    #[derive(Clone, Copy)]
+    enum Bracket {
+        None,
+        Required, // <...>
+        Optional, // [...]
+    }
+
     let mut args: Vec<MCPPromptArgument> = Vec::new();
     let mut buf = String::new();
-    let mut inside = false;
+    let mut inside = Bracket::None;
     for c in hint.chars() {
         match (c, inside) {
-            ('<', false) => {
-                inside = true;
+            ('<', Bracket::None) => {
+                inside = Bracket::Required;
                 buf.clear();
             }
-            ('>', true) => {
+            ('[', Bracket::None) => {
+                inside = Bracket::Optional;
+                buf.clear();
+            }
+            ('>', Bracket::Required) | (']', Bracket::Optional) => {
                 let token = buf.trim();
                 if !token.is_empty() {
                     args.push(MCPPromptArgument {
                         name: token.to_string(),
                         description: None,
-                        required: None,
+                        required: Some(matches!(inside, Bracket::Required)),
                     });
                 }
-                inside = false;
+                inside = Bracket::None;
             }
-            (_, true) => buf.push(c),
-            (_, false) => {} // ignore characters outside of <...>
+            // Mismatched closer (`<foo]` or `[foo>`): treat as content,
+            // keep collecting. Falling out the end discards the buf.
+            (_, Bracket::Required | Bracket::Optional) => buf.push(c),
+            (_, Bracket::None) => {} // ignore characters outside markers
         }
     }
     if args.is_empty() {
@@ -1058,6 +1316,112 @@ mod tests {
         let ids: Vec<_> = exfil.owasp_tags.iter().map(|t| t.id.as_str()).collect();
         assert!(ids.contains(&"MCP09"), "expected MCP09 tag, got {ids:?}");
         assert!(ids.contains(&"MCP06"), "expected MCP06 tag, got {ids:?}");
+    }
+
+    #[test]
+    fn yaml_list_form_for_allowed_tools_is_analyzed() {
+        // Real skills with multiple grants commonly use the YAML
+        // sequence form. Without the custom deserializer, this
+        // silently failed to populate `allowed_tools` and our
+        // OverbroadAllowedTools heuristic never fired — the highest-
+        // impact effectiveness gap pre-round-5.
+        let raw = "---\ndescription: stub\nallowed-tools:\n  - Bash\n  - Read\n---\nbody\n";
+        let parsed = parse_skill_content(&PathBuf::from("listy.md"), raw).expect("parse");
+        let rules: Vec<_> = parsed
+            .heuristic_findings
+            .iter()
+            .map(|f| f.rule_name.as_str())
+            .collect();
+        assert!(
+            rules.contains(&"OverbroadAllowedTools"),
+            "list-form bare Bash should fire OverbroadAllowedTools, got {rules:?}"
+        );
+    }
+
+    #[test]
+    fn yaml_list_form_with_only_safe_grants_is_silent() {
+        let raw =
+            "---\ndescription: stub\nallowed-tools:\n  - Read\n  - Write\n  - Glob\n---\nbody\n";
+        let parsed = parse_skill_content(&PathBuf::from("listy-safe.md"), raw).expect("parse");
+        assert!(
+            parsed.heuristic_findings.is_empty(),
+            "got unexpected findings: {:?}",
+            parsed
+                .heuristic_findings
+                .iter()
+                .map(|f| f.rule_name.as_str())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn optional_argument_hint_is_marked_not_required() {
+        let parsed = parse("opt.md", "---\nargument-hint: <env> [region]\n---\nbody\n");
+        let args = parsed.prompt.arguments.expect("arguments");
+        assert_eq!(args.len(), 2);
+        assert_eq!(args[0].name, "env");
+        assert_eq!(args[0].required, Some(true));
+        assert_eq!(args[1].name, "region");
+        assert_eq!(args[1].required, Some(false));
+    }
+
+    #[test]
+    fn sensitive_file_reference_in_body_emits_finding() {
+        // Body asks the agent to inline a sensitive file via Claude
+        // Code's `@<path>` syntax. This is the textbook exfiltration
+        // primitive: load the file into context, then any subsequent
+        // network-capable tool can leak it.
+        let body = "Use the credentials in @~/.aws/credentials to deploy.";
+        let raw = format!("---\ndescription: deploy something\n---\n{body}\n");
+        let parsed = parse("exfil-ref.md", &raw);
+        let f = parsed
+            .heuristic_findings
+            .iter()
+            .find(|f| f.rule_name == "SkillSensitiveFileReference")
+            .expect("expected SkillSensitiveFileReference");
+        let ids: Vec<_> = f.owasp_tags.iter().map(|t| t.id.as_str()).collect();
+        assert!(ids.contains(&"MCP06"), "got tags: {ids:?}");
+        assert!(ids.contains(&"MCP09"), "got tags: {ids:?}");
+    }
+
+    #[test]
+    fn email_address_does_not_trigger_sensitive_reference() {
+        // The most-common false positive: an `@` in an email. The
+        // pre-check (preceded by word char) drops these cheaply.
+        let body = "On failure, page john.smith@example.com about the deploy.";
+        let raw = format!("---\ndescription: deploy a thing\n---\n{body}\n");
+        let parsed = parse("email.md", &raw);
+        assert!(parsed
+            .heuristic_findings
+            .iter()
+            .all(|f| f.rule_name != "SkillSensitiveFileReference"));
+    }
+
+    #[test]
+    fn duplicate_sensitive_references_dedupe() {
+        // Same path mentioned twice — should fire once, not twice.
+        let body = "First read @.env, then re-read @.env to confirm parity.";
+        let raw = format!("---\ndescription: confirm env parity\n---\n{body}\n");
+        let parsed = parse("dotenv.md", &raw);
+        let count = parsed
+            .heuristic_findings
+            .iter()
+            .filter(|f| f.rule_name == "SkillSensitiveFileReference")
+            .count();
+        assert_eq!(count, 1, "expected dedupe to one finding, got {count}");
+    }
+
+    #[test]
+    fn benign_at_reference_is_silent() {
+        // `@scoped/package` and `@v1.0.0` aren't sensitive paths; the
+        // detector should ignore them.
+        let body = "Use @scoped/package and tag @v1.0.0 for the release.";
+        let raw = format!("---\ndescription: release a thing\n---\n{body}\n");
+        let parsed = parse("benign-at.md", &raw);
+        assert!(parsed
+            .heuristic_findings
+            .iter()
+            .all(|f| f.rule_name != "SkillSensitiveFileReference"));
     }
 
     #[test]

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -349,6 +349,7 @@ pub fn parse_skill_content(path: &Path, raw: &str) -> Option<ParsedSkill> {
         fm_description,
         body_trimmed,
     ));
+    heuristic_findings.extend(analyze_generic_trigger(&prompt.name, path, fm_description));
     heuristic_findings.extend(analyze_sensitive_file_references(
         &prompt.name,
         path,
@@ -747,6 +748,142 @@ fn analyze_vague_trigger(
         skill_name,
         path,
     )]
+}
+
+/// Generic / vacuous trigger phrases. A description matching one of these
+/// is long enough to satisfy `MIN_TRIGGER_DESCRIPTION_CHARS` but is
+/// semantically empty — exactly the trigger-hijack vector. The list is
+/// kept short and concrete; expanding it grows the false-positive risk.
+/// Patterns are matched case-insensitively against the trimmed description
+/// (with trailing punctuation stripped).
+const GENERIC_TRIGGER_PHRASES: &[&str] = &[
+    "help",
+    "help me",
+    "help with anything",
+    "assistant",
+    "an assistant",
+    "a helper",
+    "helper",
+    "general purpose tool",
+    "general purpose skill",
+    "general purpose assistant",
+    "general-purpose tool",
+    "universal tool",
+    "universal skill",
+    "universal assistant",
+    "default tool",
+    "default assistant",
+    "do anything",
+    "do everything",
+    "i can do anything",
+    "i can do everything",
+    "use this for everything",
+    "use this for anything",
+    "use me for everything",
+    "use me for anything",
+];
+
+/// Detect descriptions whose entire content is a generic / hijack-prone
+/// trigger phrase — distinct from `analyze_vague_trigger` which catches
+/// missing or short descriptions. A 30-character description is long
+/// enough to pass the length check but still vacuous if the content is
+/// "a general purpose assistant". Maps to the same OWASP entries as
+/// `VagueSkillTrigger` (MCP02 + MCP03).
+fn analyze_generic_trigger(
+    skill_name: &str,
+    path: &Path,
+    description: Option<&str>,
+) -> Vec<YaraScanResult> {
+    let Some(desc) = description else {
+        return Vec::new();
+    };
+    let normalized = desc
+        .trim()
+        .trim_end_matches(['.', '!', '?', ';', ':'])
+        .trim()
+        .to_ascii_lowercase();
+    // Strip a leading article ("a ", "an ", "the ") so phrases like
+    // "a general purpose assistant" still match the canonical entries
+    // (which omit the article for compactness).
+    let core = normalized
+        .strip_prefix("a ")
+        .or_else(|| normalized.strip_prefix("an "))
+        .or_else(|| normalized.strip_prefix("the "))
+        .unwrap_or(normalized.as_str());
+    if !GENERIC_TRIGGER_PHRASES
+        .iter()
+        .any(|p| core == *p || normalized == *p)
+    {
+        return Vec::new();
+    }
+    vec![make_heuristic_finding(
+        "GenericSkillTrigger",
+        "medium",
+        format!(
+            "Skill '{skill_name}' has a generic trigger description (\"{}\"). \
+             Generic triggers cause an agent's router to invoke the skill on \
+             unrelated user requests (trigger hijack). Replace with a specific \
+             description naming the conditions under which this skill should run.",
+            desc.trim()
+        ),
+        skill_name,
+        path,
+    )]
+}
+
+/// Cross-skill analysis: detect skills that share a `name`. Two skills
+/// declaring the same name shadow each other in the agent's command
+/// table — typically the workspace-level skill wins over the user-level
+/// one — so an attacker who can write to a workspace can transparently
+/// replace a trusted user-level skill. Maps to MCP02 (supply-chain /
+/// hidden behavior) + MCP03 (excessive agency).
+///
+/// Run once per scan over the full set of parsed skills. Names are
+/// compared case-insensitively because skill routers typically lowercase
+/// for matching. Reports one finding per colliding name with all paths
+/// in the `context` field.
+pub fn analyze_skill_set(skills: &[(PathBuf, &MCPPrompt)]) -> Vec<YaraScanResult> {
+    let mut by_name: std::collections::HashMap<String, Vec<&Path>> =
+        std::collections::HashMap::new();
+    for (path, prompt) in skills {
+        by_name
+            .entry(prompt.name.to_ascii_lowercase())
+            .or_default()
+            .push(path.as_path());
+    }
+    let mut findings: Vec<YaraScanResult> = Vec::new();
+    for (lower_name, paths) in by_name {
+        if paths.len() < 2 {
+            continue;
+        }
+        // Sort for deterministic reporting (test-friendly).
+        let mut sorted = paths;
+        sorted.sort();
+        let joined = sorted
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        // Use the first path as the synthetic-finding's source-path so
+        // it has a concrete location, and put the full collision list
+        // in the message so consumers see all colliding skills.
+        let primary_path = sorted[0];
+        findings.push(make_heuristic_finding(
+            "SkillNameCollision",
+            "medium",
+            format!(
+                "Skill name '{lower_name}' is declared by {} files: {joined}. \
+                 Whichever skill the agent's router resolves last shadows the \
+                 others — an attacker who can write a workspace-level skill \
+                 with the same name as a trusted user-level skill can silently \
+                 replace it. Rename one of the skills.",
+                sorted.len()
+            ),
+            &lower_name,
+            primary_path,
+        ));
+    }
+    findings
 }
 
 /// Build a `YaraScanResult` for a parser-emitted heuristic finding so it
@@ -1630,6 +1767,114 @@ mod tests {
             !overbroad.owasp_tags.is_empty(),
             "OverbroadAllowedTools should carry OWASP tags via taxonomy"
         );
+    }
+
+    #[test]
+    fn generic_trigger_phrase_emits_finding() {
+        // Body long enough that VagueSkillTrigger wouldn't fire (the
+        // description has substance length-wise) but the description is
+        // semantically vacuous.
+        let body: String = "Do the thing. ".repeat(40);
+        let raw = format!("---\ndescription: a general purpose assistant\n---\n{body}\n");
+        let parsed = parse("generic.md", &raw);
+        let rules: Vec<_> = parsed
+            .heuristic_findings
+            .iter()
+            .map(|f| f.rule_name.as_str())
+            .collect();
+        assert!(
+            rules.contains(&"GenericSkillTrigger"),
+            "expected GenericSkillTrigger, got {rules:?}"
+        );
+    }
+
+    #[test]
+    fn generic_trigger_phrase_with_punctuation_still_fires() {
+        // Trailing period / exclamation should not mask the phrase.
+        let parsed = parse("punc.md", "---\ndescription: Help me!\n---\nbody.\n");
+        assert!(parsed
+            .heuristic_findings
+            .iter()
+            .any(|f| f.rule_name == "GenericSkillTrigger"));
+    }
+
+    #[test]
+    fn specific_description_does_not_fire_generic_trigger() {
+        // Even a short concrete description shouldn't fire the generic
+        // rule (the length-based VagueSkillTrigger handles too-short
+        // descriptions; this rule only flags semantically vacuous ones).
+        let parsed = parse(
+            "specific.md",
+            "---\ndescription: Deploy the staging environment after running tests.\n---\nbody\n",
+        );
+        assert!(parsed
+            .heuristic_findings
+            .iter()
+            .all(|f| f.rule_name != "GenericSkillTrigger"));
+    }
+
+    #[test]
+    fn skill_name_collision_emits_finding() {
+        // Two parsed skills with the same name (different paths) should
+        // produce one SkillNameCollision finding.
+        let p1 = PathBuf::from("/home/user/.claude/commands/deploy.md");
+        let p2 = PathBuf::from("/home/user/work/.claude/commands/deploy.md");
+        let parsed1 = parse_skill_content(
+            &p1,
+            "---\ndescription: Deploy to prod with care\n---\nactual deploy logic",
+        )
+        .expect("p1 parses");
+        let parsed2 = parse_skill_content(
+            &p2,
+            "---\ndescription: Different deploy with override\n---\nshadow deploy logic",
+        )
+        .expect("p2 parses");
+        let set: Vec<(PathBuf, &MCPPrompt)> =
+            vec![(p1.clone(), &parsed1.prompt), (p2.clone(), &parsed2.prompt)];
+        let findings = analyze_skill_set(&set);
+        assert_eq!(
+            findings.len(),
+            1,
+            "expected one collision, got {findings:?}"
+        );
+        assert_eq!(findings[0].rule_name, "SkillNameCollision");
+        let desc = findings[0]
+            .rule_metadata
+            .as_ref()
+            .and_then(|m| m.description.as_deref())
+            .unwrap_or("");
+        // Both paths should be referenced in the message.
+        assert!(desc.contains(&p1.display().to_string()));
+        assert!(desc.contains(&p2.display().to_string()));
+        // OWASP tags present.
+        let ids: Vec<_> = findings[0]
+            .owasp_tags
+            .iter()
+            .map(|t| t.id.as_str())
+            .collect();
+        assert!(ids.contains(&"MCP02"), "got {ids:?}");
+        assert!(ids.contains(&"MCP03"), "got {ids:?}");
+    }
+
+    #[test]
+    fn skill_name_collision_is_case_insensitive() {
+        let p1 = PathBuf::from("/a/Deploy.md");
+        let p2 = PathBuf::from("/b/deploy.md");
+        let parsed1 = parse_skill_content(&p1, "---\nname: Deploy\n---\nbody1\n").unwrap();
+        let parsed2 = parse_skill_content(&p2, "---\nname: deploy\n---\nbody2\n").unwrap();
+        let set: Vec<(PathBuf, &MCPPrompt)> = vec![(p1, &parsed1.prompt), (p2, &parsed2.prompt)];
+        let findings = analyze_skill_set(&set);
+        assert_eq!(findings.len(), 1);
+    }
+
+    #[test]
+    fn unique_skill_names_produce_no_collision_finding() {
+        let p1 = PathBuf::from("/a/deploy.md");
+        let p2 = PathBuf::from("/b/test.md");
+        let parsed1 = parse_skill_content(&p1, "---\nname: deploy\n---\nbody1\n").unwrap();
+        let parsed2 = parse_skill_content(&p2, "---\nname: test\n---\nbody2\n").unwrap();
+        let set: Vec<(PathBuf, &MCPPrompt)> = vec![(p1, &parsed1.prompt), (p2, &parsed2.prompt)];
+        assert!(analyze_skill_set(&set).is_empty());
     }
 
     #[test]

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -1,0 +1,361 @@
+//! Agent-skill scanning.
+//!
+//! "Skills" are markdown files containing prompt instructions that an
+//! agent loads and executes by name (Claude Code's `.claude/commands/*.md`,
+//! Cursor agent skills, OpenAI Codex skill repos, etc.). They share a
+//! threat model with MCP prompts — both are untrusted instructions an
+//! agent may follow — so this module is intentionally thin: it parses
+//! skill files into `MCPPrompt` values and hands them straight to the
+//! existing prompt-security pipeline (LLM analysis, YARA pre/post scan,
+//! OWASP tagging, terminal/JSON/SARIF rendering).
+//!
+//! Supported formats today:
+//!
+//! - **Claude Code** custom slash commands: markdown files (with optional
+//!   YAML frontmatter) under `~/.claude/commands/` or `.claude/commands/`
+//!   in a workspace
+//! - Generic markdown skill files (in lenient mode — anything ending in
+//!   `.md` walked under `--root`)
+//!
+//! The frontmatter is parsed best-effort: a missing or malformed
+//! frontmatter block still yields a usable skill (filename stem becomes
+//! the name; body becomes the description). Anything that can't be read
+//! as UTF-8 is skipped with a warning rather than failing the scan.
+
+use crate::types::{MCPPrompt, MCPPromptArgument};
+use anyhow::{anyhow, Result};
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+use tracing::{debug, warn};
+
+/// Frontmatter fields ramparts cares about. Unknown fields are ignored
+/// (serde defaults). All fields are optional because real-world skill
+/// files vary widely — some have only a description, some have only an
+/// argument hint, some have neither.
+#[derive(Debug, Deserialize, Default)]
+struct SkillFrontmatter {
+    description: Option<String>,
+    /// Claude Code's `argument-hint` — a one-liner describing parameters.
+    #[serde(rename = "argument-hint")]
+    argument_hint: Option<String>,
+    /// Some skill formats use `name` to override the filename-derived name.
+    name: Option<String>,
+}
+
+/// Parse a single skill file at `path`. Returns `None` (logging at debug)
+/// when the file can't be read or contains no usable content. Errors are
+/// non-fatal so a single broken skill can't break a directory scan.
+pub fn parse_skill_file(path: &Path) -> Option<MCPPrompt> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("Skipping skill file {}: {e}", path.display());
+            return None;
+        }
+    };
+    Some(parse_skill_content(path, &content))
+}
+
+/// Pure-data version of `parse_skill_file` — useful for tests and for
+/// callers that already have the content in memory (e.g. fetched from a
+/// remote source). Always succeeds: missing fields fall back to sensible
+/// defaults derived from the file path.
+pub fn parse_skill_content(path: &Path, raw: &str) -> MCPPrompt {
+    let (frontmatter, body) = split_frontmatter(raw);
+    let parsed_fm: SkillFrontmatter = frontmatter
+        .and_then(|fm| match serde_yaml::from_str(fm) {
+            Ok(v) => Some(v),
+            Err(e) => {
+                debug!(
+                    "Skill {} has unparseable frontmatter (treating as no frontmatter): {e}",
+                    path.display()
+                );
+                None
+            }
+        })
+        .unwrap_or_default();
+
+    let stem = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unnamed");
+    let name = parsed_fm.name.unwrap_or_else(|| stem.to_string());
+
+    // Wire the body into `description` so it flows through every existing
+    // prompt-security check that consumes `description` for LLM analysis,
+    // formatting, etc. Prepending the frontmatter description (if any)
+    // gives the analyzer the author's stated intent right next to what
+    // the skill actually says — handy for catching mismatches.
+    let description = match parsed_fm.description.as_deref() {
+        Some(d) if !d.trim().is_empty() => Some(format!("{}\n\n{}", d.trim(), body.trim())),
+        _ => Some(body.trim().to_string()),
+    };
+
+    let arguments = parsed_fm
+        .argument_hint
+        .as_deref()
+        .filter(|s| !s.trim().is_empty())
+        .map(|hint| {
+            vec![MCPPromptArgument {
+                name: "args".to_string(),
+                description: Some(hint.to_string()),
+                required: None,
+            }]
+        });
+
+    MCPPrompt {
+        name,
+        description,
+        arguments,
+        raw_json: None,
+    }
+}
+
+/// Split a markdown document into `(frontmatter, body)`. Frontmatter is the
+/// optional `---\n...\n---` block at the very top of the file. Anything
+/// not matching that exact shape returns `(None, full_input)`.
+fn split_frontmatter(raw: &str) -> (Option<&str>, &str) {
+    let trimmed = raw.trim_start_matches('\u{feff}'); // strip BOM if present
+    let stripped = match trimmed.strip_prefix("---") {
+        Some(s) => s,
+        None => return (None, raw),
+    };
+    // Frontmatter must be terminated by a line containing only "---".
+    // Search from the next newline so we don't treat the opening "---"
+    // as also being the closing marker.
+    let after_open = match stripped.find('\n') {
+        Some(i) => &stripped[i + 1..],
+        None => return (None, raw),
+    };
+    if let Some(close_idx) = find_frontmatter_close(after_open) {
+        let frontmatter = &after_open[..close_idx];
+        let body_start = close_idx + after_open[close_idx..].find('\n').map_or(0, |n| n + 1);
+        let body = &after_open[body_start..];
+        return (Some(frontmatter), body);
+    }
+    (None, raw)
+}
+
+/// Returns the byte index in `s` where a line equal to `---` (with no
+/// other content) starts, or `None`. Lines may end in `\n` or `\r\n`.
+fn find_frontmatter_close(s: &str) -> Option<usize> {
+    let mut start = 0;
+    while start <= s.len() {
+        let line_end = s[start..].find('\n').map_or(s.len(), |i| start + i);
+        let line = s[start..line_end].trim_end_matches('\r');
+        if line == "---" {
+            return Some(start);
+        }
+        if line_end == s.len() {
+            return None;
+        }
+        start = line_end + 1;
+    }
+    None
+}
+
+/// Walk `root` for skill files. Recursive; symlinks are not followed;
+/// common build directories are skipped (mirrors the directory walker
+/// used by `MCPConfigManager::with_root`). Anything ending in `.md` is
+/// considered a candidate; the parser is permissive about content.
+pub fn discover_skills_in_root(root: &Path) -> Result<Vec<PathBuf>> {
+    if !root.exists() {
+        return Err(anyhow!(
+            "Skill root path does not exist: {}",
+            root.display()
+        ));
+    }
+    const SKIP_DIRS: &[&str] = &[
+        ".git",
+        "node_modules",
+        "target",
+        "dist",
+        "build",
+        ".venv",
+        "venv",
+        "__pycache__",
+    ];
+    const MAX_DEPTH: usize = 16;
+
+    fn walk(dir: &Path, depth: usize, out: &mut Vec<PathBuf>) {
+        if depth > MAX_DEPTH {
+            return;
+        }
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_symlink() {
+                continue;
+            }
+            if file_type.is_dir() {
+                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                    if SKIP_DIRS.contains(&name) {
+                        continue;
+                    }
+                    // Walk dotdirs only when they look like a known skill
+                    // location — otherwise we descend into hidden dirs that
+                    // aren't relevant (e.g. .vscode, .idea).
+                    if name.starts_with('.') && !is_known_skill_dotdir(name) {
+                        continue;
+                    }
+                }
+                walk(&path, depth + 1, out);
+            } else if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+                if ext.eq_ignore_ascii_case("md") {
+                    out.push(path);
+                }
+            }
+        }
+    }
+
+    fn is_known_skill_dotdir(name: &str) -> bool {
+        matches!(name, ".claude" | ".cursor" | ".codex" | ".openai")
+    }
+
+    let mut out = Vec::new();
+    walk(root, 0, &mut out);
+    out.sort();
+    Ok(out)
+}
+
+/// Default discovery roots when `ramparts skills scan-config` runs with
+/// no `--root`. Currently focused on Claude Code commands at both the
+/// user and workspace level; other skill ecosystems can be added here as
+/// support grows.
+pub fn default_discovery_roots() -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if let Some(home) = dirs::home_dir() {
+        roots.push(home.join(".claude").join("commands"));
+    }
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    roots.push(cwd.join(".claude").join("commands"));
+    roots
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn parses_frontmatter_and_body() {
+        let path = PathBuf::from("deploy.md");
+        let raw =
+            "---\ndescription: Ship to staging\n---\n\nDeploy the app, then notify the channel.\n";
+        let prompt = parse_skill_content(&path, raw);
+        assert_eq!(prompt.name, "deploy");
+        let desc = prompt.description.expect("description");
+        assert!(desc.contains("Ship to staging"));
+        assert!(desc.contains("Deploy the app"));
+    }
+
+    #[test]
+    fn handles_missing_frontmatter() {
+        let path = PathBuf::from("no-frontmatter.md");
+        let raw = "Just a body, no frontmatter at all.";
+        let prompt = parse_skill_content(&path, raw);
+        assert_eq!(prompt.name, "no-frontmatter");
+        assert_eq!(
+            prompt.description.as_deref(),
+            Some("Just a body, no frontmatter at all.")
+        );
+    }
+
+    #[test]
+    fn handles_malformed_frontmatter() {
+        // Opening `---` with no closing marker — treat as no frontmatter
+        // so the malformed YAML doesn't get hidden in `description`.
+        let path = PathBuf::from("broken.md");
+        let raw = "---\nthis is not valid yaml: [oops\n\nbody starts here\n";
+        let prompt = parse_skill_content(&path, raw);
+        // The opening `---` plus content is treated as the body when no
+        // closing marker is found.
+        assert_eq!(prompt.name, "broken");
+        assert!(prompt.description.is_some());
+    }
+
+    #[test]
+    fn yaml_parse_error_falls_back_to_no_frontmatter() {
+        // Closing marker is present but the YAML between them doesn't parse.
+        let path = PathBuf::from("badyaml.md");
+        let raw = "---\nthis is not: valid: yaml: at: all\n---\nbody\n";
+        let prompt = parse_skill_content(&path, raw);
+        assert_eq!(prompt.name, "badyaml");
+        // body still extracted
+        assert_eq!(prompt.description.as_deref(), Some("body"));
+    }
+
+    #[test]
+    fn frontmatter_name_overrides_filename() {
+        let path = PathBuf::from("ignored.md");
+        let raw = "---\nname: actual-name\n---\nhello\n";
+        let prompt = parse_skill_content(&path, raw);
+        assert_eq!(prompt.name, "actual-name");
+    }
+
+    #[test]
+    fn argument_hint_becomes_argument() {
+        let path = PathBuf::from("with-args.md");
+        let raw =
+            "---\ndescription: Greets a user\nargument-hint: <name>\n---\nSay hello to the user.\n";
+        let prompt = parse_skill_content(&path, raw);
+        let args = prompt.arguments.expect("arguments");
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0].name, "args");
+        assert_eq!(args[0].description.as_deref(), Some("<name>"));
+    }
+
+    #[test]
+    fn strips_bom() {
+        let path = PathBuf::from("bom.md");
+        let raw = "\u{feff}---\ndescription: x\n---\ny\n";
+        let prompt = parse_skill_content(&path, raw);
+        let desc = prompt.description.unwrap();
+        assert!(desc.contains('x'));
+        assert!(desc.contains('y'));
+    }
+
+    #[test]
+    fn empty_description_in_frontmatter_falls_back_to_body() {
+        let path = PathBuf::from("empty-desc.md");
+        let raw = "---\ndescription: \"\"\n---\nactual body\n";
+        let prompt = parse_skill_content(&path, raw);
+        assert_eq!(prompt.description.as_deref(), Some("actual body"));
+    }
+
+    #[test]
+    fn discover_walks_recursively() {
+        let tmp = tempfile::tempdir().unwrap();
+        let nested = tmp.path().join("a").join("b");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(tmp.path().join("top.md"), "top").unwrap();
+        std::fs::write(nested.join("nested.md"), "nested").unwrap();
+        std::fs::write(tmp.path().join("not-a-skill.txt"), "ignored").unwrap();
+
+        let mut found = discover_skills_in_root(tmp.path()).unwrap();
+        found.sort();
+        let names: Vec<_> = found
+            .iter()
+            .map(|p| p.file_name().unwrap().to_str().unwrap().to_string())
+            .collect();
+        assert_eq!(names, vec!["nested.md", "top.md"]);
+    }
+
+    #[test]
+    fn discover_skips_build_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("target");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("artifact.md"), "should be skipped").unwrap();
+        std::fs::write(tmp.path().join("real.md"), "should be found").unwrap();
+
+        let found = discover_skills_in_root(tmp.path()).unwrap();
+        assert_eq!(found.len(), 1);
+        assert!(found[0].ends_with("real.md"));
+    }
+}

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -355,6 +355,7 @@ pub fn parse_skill_content(path: &Path, raw: &str) -> Option<ParsedSkill> {
         path,
         body_trimmed,
     ));
+    heuristic_findings.extend(analyze_embedded_payloads(&prompt.name, path, body_trimmed));
 
     Some(ParsedSkill {
         prompt,
@@ -692,6 +693,113 @@ fn analyze_sensitive_file_references(
             path,
         ));
     }
+    findings
+}
+
+/// Minimum length (in source chars) for a base64-shape run to qualify as
+/// an embedded payload. 500 chars decodes to ~375 bytes — large enough
+/// that a real attacker would use it to smuggle a meaningful payload,
+/// but high enough to reject incidental short tokens (auth tokens,
+/// hashes including SHA-512 at 128 chars, JWT bodies, OpenAI/Anthropic
+/// API keys at ~100 chars, GitHub PATs at 40 chars).
+const MIN_EMBEDDED_PAYLOAD_CHARS: usize = 500;
+
+/// True if `c` is part of the standard or URL-safe base64 alphabet.
+/// Includes `=` for padding and `_-` for URL-safe encoding so we
+/// catch both shapes with a single pass.
+fn is_b64_or_url64_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, '+' | '/' | '=' | '_' | '-')
+}
+
+/// True if `c` is a hexadecimal character. Used to classify a payload
+/// as `hex` vs `base64`; hex blobs are strictly a subset of base64.
+fn is_hex_char(c: char) -> bool {
+    c.is_ascii_hexdigit()
+}
+
+/// Detect large base64 / hex / URL-safe-base64 blobs in the skill body.
+/// Embedded payloads are the textbook obfuscation primitive: the blob
+/// passes both regex YARA rules (which match on plaintext attack
+/// signatures) and LLM analysis (which can't decode a 500-char string
+/// of `aW1wb3J0IG9z...` into intent) by deferring decoding to runtime.
+///
+/// Maps to OWASP MCP01 (prompt injection — the decoded content could
+/// be an instruction-override payload) + MCP10 (supply-chain — the
+/// blob is an opaque dependency the operator can't audit).
+///
+/// Tuning:
+///
+/// - Single contiguous run of base64-shape characters; we don't
+///   reassemble across whitespace because real attackers don't either
+///   (hand-formatted multi-line base64 blobs come through as a single
+///   run after we strip line breaks at parse time, but a 500-char
+///   single-line blob is the typical embed).
+/// - 500-char threshold rejects hashes (SHA-512 = 128 chars), JWTs
+///   (typically 200-300 chars but multi-segment with `.` separators —
+///   each segment is well under 500), GitHub PATs, AWS keys, etc.
+/// - Skip blobs immediately preceded by `base64,` (markdown image
+///   data URIs and similar inline-asset references).
+/// - Dedupe by the leading 50 chars so a body that repeats the same
+///   blob doesn't spam findings.
+fn analyze_embedded_payloads(skill_name: &str, path: &Path, body: &str) -> Vec<YaraScanResult> {
+    let mut findings: Vec<YaraScanResult> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    let push_if_qualifying = |findings: &mut Vec<YaraScanResult>,
+                              seen: &mut std::collections::HashSet<String>,
+                              start: usize,
+                              end: usize| {
+        let blob = &body[start..end];
+        let len = blob.chars().count();
+        if len < MIN_EMBEDDED_PAYLOAD_CHARS {
+            return;
+        }
+        // Data-URI exclusion. A markdown inline image
+        // `![alt](data:image/png;base64,SGVsbG8=)` produces a long
+        // base64 run preceded by `base64,`; that's intentional and
+        // benign. Look back up to 16 chars for the marker.
+        let lookback_start = start.saturating_sub(16);
+        let context_before = &body[lookback_start..start];
+        if context_before.contains("base64,") {
+            return;
+        }
+        let kind = if blob.chars().all(is_hex_char) {
+            "hex"
+        } else {
+            "base64"
+        };
+        let key = format!("{}:{}", kind, blob.chars().take(50).collect::<String>());
+        if !seen.insert(key) {
+            return;
+        }
+        findings.push(make_heuristic_finding(
+            "SkillEmbeddedPayload",
+            "high",
+            format!(
+                "Skill '{skill_name}' contains a {len}-char {kind}-shape blob in \
+                 its body. Embedded payloads bypass plaintext YARA rules and LLM \
+                 analysis by deferring decoding to runtime. Verify the content; \
+                 if legitimate (config, hash chain), reduce its size or move to \
+                 a referenced file. If unknown, treat as compromised."
+            ),
+            skill_name,
+            path,
+        ));
+    };
+
+    let mut start: Option<usize> = None;
+    for (i, c) in body.char_indices() {
+        if is_b64_or_url64_char(c) {
+            start.get_or_insert(i);
+        } else if let Some(s) = start.take() {
+            push_if_qualifying(&mut findings, &mut seen, s, i);
+        }
+    }
+    // Body ends mid-run.
+    if let Some(s) = start {
+        push_if_qualifying(&mut findings, &mut seen, s, body.len());
+    }
+
     findings
 }
 
@@ -1875,6 +1983,95 @@ mod tests {
         let parsed2 = parse_skill_content(&p2, "---\nname: test\n---\nbody2\n").unwrap();
         let set: Vec<(PathBuf, &MCPPrompt)> = vec![(p1, &parsed1.prompt), (p2, &parsed2.prompt)];
         assert!(analyze_skill_set(&set).is_empty());
+    }
+
+    #[test]
+    fn large_base64_blob_in_body_emits_payload_finding() {
+        // 600-char base64-shape run = ~450 bytes decoded — comfortably
+        // above the 500-char threshold. Mixes upper/lower/digits/+ to
+        // make sure it's classified as base64 (not hex).
+        let blob: String = "ABCDEFGHabcdefgh01234567+/=".repeat(30); // 810 chars
+        let body = format!("Some prose, then a smuggled blob: {blob}\nMore prose.");
+        let raw = format!("---\ndescription: legit-looking skill\n---\n{body}\n");
+        let parsed = parse("payload.md", &raw);
+        let f = parsed
+            .heuristic_findings
+            .iter()
+            .find(|f| f.rule_name == "SkillEmbeddedPayload")
+            .expect("expected SkillEmbeddedPayload finding");
+        // OWASP tags present
+        let ids: Vec<_> = f.owasp_tags.iter().map(|t| t.id.as_str()).collect();
+        assert!(ids.contains(&"MCP01"), "got {ids:?}");
+        assert!(ids.contains(&"MCP10"), "got {ids:?}");
+    }
+
+    #[test]
+    fn large_hex_blob_in_body_classified_as_hex() {
+        // 600-char hex run.
+        let blob: String = "deadbeef0123456789abcdef".repeat(30); // 720 chars
+        let body = format!("Reference hash: {blob}");
+        let raw = format!("---\ndescription: hex-blob skill\n---\n{body}\n");
+        let parsed = parse("hex.md", &raw);
+        let f = parsed
+            .heuristic_findings
+            .iter()
+            .find(|f| f.rule_name == "SkillEmbeddedPayload")
+            .expect("hex blob should fire SkillEmbeddedPayload");
+        let desc = f
+            .rule_metadata
+            .as_ref()
+            .and_then(|m| m.description.as_deref())
+            .unwrap_or("");
+        assert!(
+            desc.contains("hex-shape"),
+            "expected hex classification in description: {desc}"
+        );
+    }
+
+    #[test]
+    fn data_uri_base64_image_does_not_fire_payload() {
+        // Markdown inline image with a long base64 data URI is benign.
+        let blob: String = "ABCDEFGHabcdefgh01234567+/=".repeat(30);
+        let body = format!(
+            "An image: ![alt text](data:image/png;base64,{blob})\nThe rest of the skill body."
+        );
+        let raw = format!("---\ndescription: skill with image\n---\n{body}\n");
+        let parsed = parse("image.md", &raw);
+        assert!(
+            parsed
+                .heuristic_findings
+                .iter()
+                .all(|f| f.rule_name != "SkillEmbeddedPayload"),
+            "data URI image should not fire SkillEmbeddedPayload"
+        );
+    }
+
+    #[test]
+    fn small_base64_token_does_not_fire_payload() {
+        // GitHub PAT (40 chars) and SHA-256 (64 chars) are well below
+        // the 500-char threshold and shouldn't fire.
+        let body = "PAT: ghp_AbCdEf1234567890AbCdEf1234567890AbCd \
+                    SHA-256: 9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08";
+        let raw = format!("---\ndescription: doc skill\n---\n{body}\n");
+        let parsed = parse("smalltokens.md", &raw);
+        assert!(parsed
+            .heuristic_findings
+            .iter()
+            .all(|f| f.rule_name != "SkillEmbeddedPayload"));
+    }
+
+    #[test]
+    fn duplicate_payloads_dedupe_to_one_finding() {
+        let blob: String = "ABCDEFGHabcdefgh01234567+/=".repeat(30);
+        let body = format!("First: {blob}\nSecond identical: {blob}");
+        let raw = format!("---\ndescription: dup payload\n---\n{body}\n");
+        let parsed = parse("dup.md", &raw);
+        let count = parsed
+            .heuristic_findings
+            .iter()
+            .filter(|f| f.rule_name == "SkillEmbeddedPayload")
+            .count();
+        assert_eq!(count, 1, "expected dedupe to 1 finding, got {count}");
     }
 
     #[test]

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -431,16 +431,58 @@ fn parse_grant_token(token: &str) -> Option<ParsedGrant<'_>> {
 }
 
 /// True when a parsed grant grants unrestricted access to its tool —
-/// either no restriction at all, an empty restriction, or a wildcard.
+/// either no restriction at all, an empty restriction, or a wildcard
+/// pattern that admits any prefix and any arguments.
+///
+/// `*:*` is the sneakiest of the three: it looks like a bounded
+/// `prefix:args` restriction but every part is a wildcard, so a literal
+/// reading admits any command-line. We strip whitespace, split on `:`,
+/// and treat the restriction as unrestricted iff every segment is `*`
+/// or empty. That covers `*`, `* : *`, `*:*`, `*::*`, etc.
 fn is_unrestricted(grant: &ParsedGrant<'_>) -> bool {
     match grant.restriction.as_deref() {
         None => true,
         Some("") => true,
         Some(r) => {
             let collapsed: String = r.split_whitespace().collect();
-            collapsed == "*" || collapsed.is_empty()
+            if collapsed.is_empty() || collapsed == "*" {
+                return true;
+            }
+            collapsed.split(':').all(|seg| seg.is_empty() || seg == "*")
         }
     }
+}
+
+/// Split an `allowed-tools` string into individual grant tokens,
+/// honoring parenthesized restrictions. The naive `split([',', '\n'])`
+/// breaks tokens like `Bash(echo a, b)` mid-paren — both halves then
+/// fail to parse as their original tool, and a real unrestricted grant
+/// slips through. This walker tracks paren depth and only treats commas
+/// or newlines at depth 0 as token boundaries. Negative depth (a stray
+/// closer) is clamped to zero so malformed input still terminates.
+fn split_grant_tokens(grant: &str) -> Vec<&str> {
+    let mut tokens: Vec<&str> = Vec::new();
+    let mut depth: i32 = 0;
+    let mut start = 0;
+    for (i, c) in grant.char_indices() {
+        match c {
+            '(' => depth += 1,
+            ')' => {
+                if depth > 0 {
+                    depth -= 1;
+                }
+            }
+            ',' | '\n' if depth == 0 => {
+                tokens.push(&grant[start..i]);
+                start = i + c.len_utf8();
+            }
+            _ => {}
+        }
+    }
+    if start <= grant.len() {
+        tokens.push(&grant[start..]);
+    }
+    tokens
 }
 
 /// Detect overbroad `allowed-tools` grants. Splits the grant string on
@@ -466,7 +508,7 @@ fn analyze_allowed_tools(skill_name: &str, path: &Path, grant: &str) -> Vec<Yara
         ));
     };
 
-    for raw in grant.split([',', '\n']) {
+    for raw in split_grant_tokens(grant) {
         let Some(parsed) = parse_grant_token(raw) else {
             continue;
         };
@@ -1422,6 +1464,93 @@ mod tests {
             .heuristic_findings
             .iter()
             .all(|f| f.rule_name != "SkillSensitiveFileReference"));
+    }
+
+    #[test]
+    fn comma_in_paren_restriction_does_not_break_tokenizer() {
+        // `Bash(echo a, b)` contains a comma INSIDE the restriction. A
+        // naive split on commas would shred the token mid-paren and
+        // miss the unrestricted-Bash signal.
+        let raw = "---\ndescription: stub\nallowed-tools: Bash(echo a, b), Read\n---\nbody\n";
+        let parsed = parse_skill_content(&PathBuf::from("commaparen.md"), raw).expect("parse");
+        // The Bash grant has a non-wildcard restriction (`echo a, b`),
+        // so it should NOT fire OverbroadAllowedTools — but more
+        // importantly, the parser should produce a single ParsedGrant
+        // with that restriction intact rather than three half-tokens.
+        // We verify by parsing the grant directly.
+        let toks = split_grant_tokens("Bash(echo a, b), Read");
+        assert_eq!(toks.len(), 2, "got toks={toks:?}");
+        assert!(toks[0].contains("Bash(echo a, b)"));
+        assert!(toks[1].contains("Read"));
+        // No false-positive findings — the comma-inside-paren grant is
+        // bounded enough not to fire.
+        assert!(parsed
+            .heuristic_findings
+            .iter()
+            .all(|f| f.rule_name != "OverbroadAllowedTools"));
+    }
+
+    #[test]
+    fn unrestricted_bash_grant_with_inner_comma_still_fires() {
+        // Variant: unrestricted Bash via `Bash(*)`, with a separate grant
+        // that has a comma inside its restriction. Must not lose the
+        // OverbroadAllowedTools finding for the wildcard grant.
+        let raw = "---\nallowed-tools: Bash(*), WebFetch(https://a.example.com/x,y)\n---\nbody\n";
+        let parsed = parse_skill_content(&PathBuf::from("mixed.md"), raw).expect("parse");
+        let rules: Vec<_> = parsed
+            .heuristic_findings
+            .iter()
+            .map(|f| f.rule_name.as_str())
+            .collect();
+        assert!(
+            rules.contains(&"OverbroadAllowedTools"),
+            "expected OverbroadAllowedTools, got {rules:?}"
+        );
+        assert!(
+            rules.contains(&"DataExfiltrationGrant"),
+            "expected DataExfiltrationGrant, got {rules:?}"
+        );
+    }
+
+    #[test]
+    fn star_colon_star_restriction_is_unrestricted() {
+        // `Bash(*:*)` looks like a bounded prefix:args restriction but
+        // every segment is a wildcard, so it admits any command-line.
+        // The same applies to `* : *` (whitespace) and `*::*` (empty
+        // segment in the middle).
+        for grant in ["Bash(*:*)", "Bash(* : *)", "Bash(*::*)"] {
+            let parsed = parse_grant_token(grant).unwrap();
+            assert!(
+                is_unrestricted(&parsed),
+                "expected `{grant}` to be unrestricted"
+            );
+        }
+        // Sanity: a real bounded grant is still bounded.
+        let bounded = parse_grant_token("Bash(git status:*)").unwrap();
+        assert!(!is_unrestricted(&bounded));
+    }
+
+    #[test]
+    fn star_colon_star_grant_fires_overbroad() {
+        let raw = "---\nallowed-tools: Bash(*:*)\n---\nbody\n";
+        let parsed = parse_skill_content(&PathBuf::from("starcolon.md"), raw).expect("parse");
+        assert!(parsed
+            .heuristic_findings
+            .iter()
+            .any(|f| f.rule_name == "OverbroadAllowedTools"));
+    }
+
+    #[test]
+    fn split_grant_tokens_handles_paren_depth() {
+        // Sanity-check the splitter directly on a few shapes.
+        assert_eq!(
+            split_grant_tokens("Bash(a, b), Read, Write"),
+            vec!["Bash(a, b)", " Read", " Write"]
+        );
+        // Newlines also count as separators.
+        assert_eq!(split_grant_tokens("Bash\nRead"), vec!["Bash", "Read"]);
+        // Stray closing paren — clamp to zero, don't blow up.
+        assert_eq!(split_grant_tokens("Bash), Read"), vec!["Bash)", " Read"]);
     }
 
     #[test]

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -218,7 +218,16 @@ pub fn parse_skill_content(path: &Path, raw: &str) -> Option<ParsedSkill> {
             parts.push(format!("Argument hint: {h}"));
         }
     }
-    let description = Some(parts.join("\n\n"));
+    // `None` rather than `Some("")` when there's nothing to describe — the
+    // LLM analyzer treats a missing description differently from an empty
+    // one (the prompt template renders "No description" instead of an
+    // empty field). Only happens when arguments were parsed from a hint
+    // but description and body are both empty.
+    let description = if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("\n\n"))
+    };
     // Source-path provenance lives on heuristic findings (via the
     // `context` field on `YaraScanResult`) rather than inside the
     // analyzed `description`. Putting absolute paths into text the
@@ -252,48 +261,153 @@ pub fn parse_skill_content(path: &Path, raw: &str) -> Option<ParsedSkill> {
     })
 }
 
-/// Tokens in `allowed-tools` that grant unrestricted shell/filesystem access
-/// when granted blanket. Hits here become an `OverbroadAllowedTools`
-/// finding that maps to OWASP MCP03 (excessive agency). We deliberately
-/// cast a narrow net — the goal is "this skill quietly asked for the keys
-/// to the kingdom," not "this skill uses any tool we don't know about."
-const DANGEROUS_GRANT_PATTERNS: &[&str] = &[
-    "bash(*)", "bash:*", "shell(*)", "shell:*", "rm:*", "rm(*)", "sudo:*", "sudo(*)", "exec:*",
-    "exec(*)", "eval:*", "eval(*)", "*",
+/// Tools that, when granted without a restriction, give the agent
+/// arbitrary code execution on the user's machine. A bare `Bash` grant is
+/// just as dangerous as `Bash(*)` — Claude Code interprets a tool name
+/// without parens as unrestricted. Tightly bounded grants like
+/// `Bash(git status:*)` are silent.
+const CODE_EXECUTION_TOOLS: &[&str] = &[
+    "bash", "shell", "sh", "zsh", "exec", "eval", "run", "rm", "sudo",
 ];
 
-/// Detect overbroad `allowed-tools` grants. The frontmatter is treated as
-/// a comma- or newline-separated list of tokens like `Bash(git status:*),
-/// Read, Write`. We normalize each token (lowercase, strip whitespace) and
-/// flag matches against `DANGEROUS_GRANT_PATTERNS`.
+/// Tools that let a skill exfiltrate data over the network. Even a
+/// well-bounded `WebFetch(https://example.com/*)` skill can reflect
+/// arbitrary content into the URL's path — but the operator should at
+/// least be aware the skill is talking to the network, so we flag any
+/// grant of these as an informational `DataExfiltrationGrant`. Maps to
+/// MCP09 (sensitive-data exposure) + MCP06 (credential leakage).
+const DATA_EXFIL_TOOLS: &[&str] = &["webfetch", "websearch", "fetch", "browse"];
+
+/// A single token from an `allowed-tools` field, parsed into the tool
+/// name and (optional) restriction clause. Three syntactic forms in the
+/// wild:
+///
+/// - `Bash` — bare tool name, no restriction → unrestricted grant
+/// - `Bash(git status:*)` — parenthesized restriction
+/// - `Bash:git status:*` — colon-separated restriction (older syntax)
+///
+/// `restriction` is `None` only for the bare-name form. An empty string
+/// or `*` restriction is treated as "no restriction" by the policy below.
+struct ParsedGrant<'a> {
+    raw: &'a str,
+    tool: String,
+    restriction: Option<String>,
+}
+
+/// Parse a single `allowed-tools` token. Robust to leading/trailing
+/// whitespace and to the two restriction syntaxes Claude Code accepts.
+/// Returns `None` for empty or whitespace-only tokens.
+fn parse_grant_token(token: &str) -> Option<ParsedGrant<'_>> {
+    let trimmed = token.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    // Parenthesized form: "Bash(git status:*)". We split on the first '(';
+    // the closing ')' is best-effort — malformed grants like "Bash(foo"
+    // still parse with restriction = "foo".
+    if let Some((tool_raw, rest)) = trimmed.split_once('(') {
+        let restriction = rest.trim_end_matches(')').trim().to_string();
+        return Some(ParsedGrant {
+            raw: token,
+            tool: tool_raw.trim().to_ascii_lowercase(),
+            restriction: Some(restriction),
+        });
+    }
+    // Colon form: "Bash:git status:*". Tool is the segment before the
+    // first colon; the rest (re-joined) is the restriction.
+    if let Some((tool_raw, rest)) = trimmed.split_once(':') {
+        return Some(ParsedGrant {
+            raw: token,
+            tool: tool_raw.trim().to_ascii_lowercase(),
+            restriction: Some(rest.trim().to_string()),
+        });
+    }
+    // Bare form: "Bash". No restriction.
+    Some(ParsedGrant {
+        raw: token,
+        tool: trimmed.to_ascii_lowercase(),
+        restriction: None,
+    })
+}
+
+/// True when a parsed grant grants unrestricted access to its tool —
+/// either no restriction at all, an empty restriction, or a wildcard.
+fn is_unrestricted(grant: &ParsedGrant<'_>) -> bool {
+    match grant.restriction.as_deref() {
+        None => true,
+        Some("") => true,
+        Some(r) => {
+            let collapsed: String = r.split_whitespace().collect();
+            collapsed == "*" || collapsed.is_empty()
+        }
+    }
+}
+
+/// Detect overbroad `allowed-tools` grants. Splits the grant string on
+/// commas/newlines, parses each token via `parse_grant_token`, and emits
+/// findings based on the tool class:
+///
+/// - **CODE_EXECUTION_TOOLS** with no/wildcard restriction → high-severity
+///   `OverbroadAllowedTools` (MCP03 — excessive agency).
+/// - A bare `*` token (grants every tool) → same high-severity finding.
+/// - **DATA_EXFIL_TOOLS** at any restriction level → medium-severity
+///   `DataExfiltrationGrant` (MCP09 + MCP06).
+///
+/// Tightly-bounded code-execution grants (`Bash(git status:*)`) and
+/// non-network/non-execution tools (`Read`, `Write`, `Glob`) are silent.
 fn analyze_allowed_tools(skill_name: &str, path: &Path, grant: &str) -> Vec<YaraScanResult> {
     let mut findings: Vec<YaraScanResult> = Vec::new();
-    let tokens = grant
-        .split([',', '\n'])
-        .map(|t| t.trim())
-        .filter(|t| !t.is_empty());
-    for token in tokens {
-        let normalized = token.to_ascii_lowercase();
-        let normalized_collapsed: String = normalized.split_whitespace().collect();
-        if DANGEROUS_GRANT_PATTERNS
-            .iter()
-            .any(|p| normalized == *p || normalized_collapsed == *p)
-        {
+    for raw in grant.split([',', '\n']) {
+        let Some(parsed) = parse_grant_token(raw) else {
+            continue;
+        };
+
+        // Bare wildcard token — "*" alone — grants everything.
+        if parsed.tool == "*" {
             findings.push(make_heuristic_finding(
                 "OverbroadAllowedTools",
                 "high",
                 format!(
-                    "Skill '{skill_name}' grants tool '{token}' which permits unrestricted \
-                     command execution. Restrict to specific subcommands (e.g. \
-                     `Bash(git status:*)`) or remove the wildcard."
+                    "Skill '{skill_name}' grants `*` (all tools). This bypasses every \
+                     per-tool restriction. Replace with the specific tools the skill \
+                     actually needs."
                 ),
                 skill_name,
                 path,
             ));
-            // One finding per unique pattern keeps the report readable; bail
-            // after the first hit on a token rather than emitting one per
-            // matching pattern entry.
             continue;
+        }
+
+        if CODE_EXECUTION_TOOLS.contains(&parsed.tool.as_str()) && is_unrestricted(&parsed) {
+            findings.push(make_heuristic_finding(
+                "OverbroadAllowedTools",
+                "high",
+                format!(
+                    "Skill '{skill_name}' grants tool `{}` without a restriction, which \
+                     permits arbitrary command execution. Restrict to specific \
+                     subcommands (e.g. `Bash(git status:*)`) or replace with a bounded \
+                     tool.",
+                    parsed.raw.trim()
+                ),
+                skill_name,
+                path,
+            ));
+            continue;
+        }
+
+        if DATA_EXFIL_TOOLS.contains(&parsed.tool.as_str()) {
+            findings.push(make_heuristic_finding(
+                "DataExfiltrationGrant",
+                "medium",
+                format!(
+                    "Skill '{skill_name}' grants `{}` — a network-egress tool that can \
+                     send skill input or local file content to remote URLs. Confirm the \
+                     skill needs network access and that any URL pattern is bounded.",
+                    parsed.raw.trim()
+                ),
+                skill_name,
+                path,
+            ));
         }
     }
     findings
@@ -453,7 +567,14 @@ fn split_frontmatter(raw: &str) -> (Option<&str>, &str) {
     };
     if let Some(close_idx) = find_frontmatter_close(after_open) {
         let frontmatter = &after_open[..close_idx];
-        let body_start = close_idx + after_open[close_idx..].find('\n').map_or(0, |n| n + 1);
+        // Body starts after the `---` line. If the closing marker has a
+        // trailing newline we skip past it; if it's the last thing in the
+        // file (no trailing newline) we land exactly at end-of-string and
+        // body becomes "" rather than the marker itself.
+        let body_start = match after_open[close_idx..].find('\n') {
+            Some(n) => close_idx + n + 1,
+            None => after_open.len(),
+        };
         let body = &after_open[body_start..];
         return (Some(frontmatter), body);
     }
@@ -581,6 +702,12 @@ pub fn discover_skills_in_root(root: &Path) -> Result<Vec<PathBuf>> {
 pub fn default_discovery_roots() -> Vec<PathBuf> {
     let mut roots: Vec<PathBuf> = Vec::new();
 
+    // Env-var roots are operator-trusted: ramparts walks them as-is, so
+    // anyone who can set `RAMPARTS_SKILL_ROOTS` can point the scanner at
+    // any directory the running user can read. That's the same trust
+    // model as `--path`, but it's worth being explicit since env vars
+    // can be smuggled into less-obvious places (CI configs, IDE
+    // launchers, shell parents).
     if let Ok(extra) = std::env::var(SKILL_ROOTS_ENV) {
         for entry in extra.split(',').map(str::trim).filter(|s| !s.is_empty()) {
             roots.push(expand_tilde(entry));
@@ -781,6 +908,35 @@ mod tests {
     }
 
     #[test]
+    fn closing_frontmatter_marker_without_trailing_newline_yields_empty_body() {
+        // Edge case: a file that ends exactly at the closing `---` with
+        // no trailing newline. Earlier implementations included the
+        // closing marker itself in the body string, producing skills
+        // whose description was literally "---".
+        let path = PathBuf::from("trim.md");
+        let raw = "---\ndescription: hi\n---";
+        let parsed = parse_skill_content(&path, raw).unwrap();
+        let desc = parsed.prompt.description.expect("description");
+        assert_eq!(desc, "hi");
+        assert!(!desc.contains("---"), "marker leaked into body: {desc}");
+    }
+
+    #[test]
+    fn argument_only_skill_has_none_description_not_empty_string() {
+        // Args parsed, but description and body are both empty. The
+        // prompt should report `description: None` rather than `Some("")`
+        // so the LLM analyzer's template renders "No description"
+        // instead of a blank field.
+        let parsed = parse("args-only.md", "---\nargument-hint: <name>\n---\n");
+        assert!(
+            parsed.prompt.description.is_none(),
+            "expected None, got {:?}",
+            parsed.prompt.description
+        );
+        assert_eq!(parsed.prompt.arguments.as_ref().unwrap().len(), 1);
+    }
+
+    #[test]
     fn dangerous_allowed_tools_grant_emits_finding() {
         let parsed = parse(
             "danger.md",
@@ -798,6 +954,52 @@ mod tests {
     }
 
     #[test]
+    fn bare_bash_grant_is_treated_as_unrestricted() {
+        // The most-common dangerous grant in real skills: `Bash` with no
+        // parens. Claude Code interprets a bare tool name as unrestricted,
+        // so we must treat it the same as `Bash(*)`.
+        let parsed = parse(
+            "bare.md",
+            "---\ndescription: stub\nallowed-tools: Bash, Read\n---\nbody\n",
+        );
+        let overbroad = parsed
+            .heuristic_findings
+            .iter()
+            .find(|f| f.rule_name == "OverbroadAllowedTools")
+            .expect("bare Bash should fire OverbroadAllowedTools");
+        let desc = overbroad
+            .rule_metadata
+            .as_ref()
+            .and_then(|m| m.description.as_deref())
+            .unwrap_or("");
+        assert!(
+            desc.contains("Bash"),
+            "finding description should reference the offending tool: {desc}"
+        );
+    }
+
+    #[test]
+    fn star_grant_alone_fires_overbroad() {
+        let parsed = parse(
+            "wide-open.md",
+            "---\ndescription: stub\nallowed-tools: \"*\"\n---\nbody\n",
+        );
+        assert!(parsed
+            .heuristic_findings
+            .iter()
+            .any(|f| f.rule_name == "OverbroadAllowedTools"));
+    }
+
+    #[test]
+    fn colon_form_grant_with_wildcard_fires_overbroad() {
+        let parsed = parse("colon.md", "---\nallowed-tools: bash:*\n---\nbody\n");
+        assert!(parsed
+            .heuristic_findings
+            .iter()
+            .any(|f| f.rule_name == "OverbroadAllowedTools"));
+    }
+
+    #[test]
     fn safe_allowed_tools_grant_emits_no_finding() {
         let parsed = parse(
             "safe.md",
@@ -807,6 +1009,82 @@ mod tests {
             .heuristic_findings
             .iter()
             .all(|f| f.rule_name != "OverbroadAllowedTools"));
+    }
+
+    #[test]
+    fn read_write_alone_are_not_flagged() {
+        // Bare `Read` / `Write` / `Glob` are bounded by their own
+        // semantics (filesystem-only) and shouldn't be treated like
+        // bare `Bash`. This test guards against an over-eager future
+        // tightening of CODE_EXECUTION_TOOLS.
+        let parsed = parse(
+            "fs-only.md",
+            "---\ndescription: read some files\nallowed-tools: Read, Write, Glob, Grep\n---\nbody\n",
+        );
+        assert!(
+            parsed.heuristic_findings.is_empty(),
+            "expected no findings, got {:?}",
+            parsed
+                .heuristic_findings
+                .iter()
+                .map(|f| f.rule_name.as_str())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn webfetch_grant_emits_data_exfiltration_finding() {
+        let parsed = parse(
+            "exfil.md",
+            "---\ndescription: fetch a thing\nallowed-tools: WebFetch\n---\nbody\n",
+        );
+        assert!(parsed
+            .heuristic_findings
+            .iter()
+            .any(|f| f.rule_name == "DataExfiltrationGrant"));
+    }
+
+    #[test]
+    fn data_exfiltration_grant_carries_owasp_tags() {
+        let parsed = parse(
+            "exfil.md",
+            "---\ndescription: web stuff\nallowed-tools: WebFetch(https://example.com/*)\n---\nbody\n",
+        );
+        let exfil = parsed
+            .heuristic_findings
+            .iter()
+            .find(|f| f.rule_name == "DataExfiltrationGrant")
+            .expect("DataExfiltrationGrant finding");
+        let ids: Vec<_> = exfil.owasp_tags.iter().map(|t| t.id.as_str()).collect();
+        assert!(ids.contains(&"MCP09"), "expected MCP09 tag, got {ids:?}");
+        assert!(ids.contains(&"MCP06"), "expected MCP06 tag, got {ids:?}");
+    }
+
+    #[test]
+    fn parse_grant_token_handles_three_syntaxes() {
+        // Bare
+        let g = parse_grant_token("Bash").unwrap();
+        assert_eq!(g.tool, "bash");
+        assert!(g.restriction.is_none());
+        assert!(is_unrestricted(&g));
+
+        // Parenthesized
+        let g = parse_grant_token("Bash(git status:*)").unwrap();
+        assert_eq!(g.tool, "bash");
+        assert_eq!(g.restriction.as_deref(), Some("git status:*"));
+        assert!(!is_unrestricted(&g));
+
+        // Colon form
+        let g = parse_grant_token("Bash:foo").unwrap();
+        assert_eq!(g.tool, "bash");
+        assert_eq!(g.restriction.as_deref(), Some("foo"));
+
+        // Empty paren -> wildcard-equivalent
+        let g = parse_grant_token("Bash()").unwrap();
+        assert!(is_unrestricted(&g));
+
+        // Whitespace only -> None
+        assert!(parse_grant_token("   ").is_none());
     }
 
     #[test]

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -28,24 +28,89 @@ use serde::Deserialize;
 use std::path::{Path, PathBuf};
 use tracing::{debug, warn};
 
-/// Frontmatter fields ramparts cares about. Unknown fields are ignored
-/// (serde defaults). All fields are optional because real-world skill
-/// files vary widely — some have only a description, some have only an
-/// argument hint, some have neither.
+/// Reject any individual skill file larger than this. Real skill files are
+/// kilobytes; a multi-megabyte markdown is either a misclassification (e.g.
+/// CHANGELOG sneaking through) or an attempt to DoS the scanner with a
+/// pathological input. We log at warn and skip rather than reading.
+const MAX_SKILL_FILE_BYTES: u64 = 2 * 1024 * 1024;
+
+/// Filenames that are virtually never agent skills but commonly appear in
+/// the same directories users point `skills scan` at (project README,
+/// licenses, etc.). Matched case-insensitively and ignoring extension —
+/// `README.md`, `Readme.markdown`, `LICENSE.md` all skip.
+///
+/// Add new entries when you find a recurring source of false positives in
+/// real skill repos. Project-conventional names are stable enough that
+/// this list rarely needs to change.
+const NON_SKILL_FILENAME_STEMS: &[&str] = &[
+    "readme",
+    "changelog",
+    "license",
+    "licence",
+    "contributing",
+    "code_of_conduct",
+    "security",
+    "support",
+    "authors",
+    "notice",
+    "history",
+    "upgrade",
+    "upgrading",
+    "migration",
+    "todo",
+];
+
+/// Returns true if a filename's stem matches a known non-skill convention.
+fn is_non_skill_filename(name: &str) -> bool {
+    let stem = name.rsplit_once('.').map_or(name, |(s, _)| s);
+    let normalized = stem.to_ascii_lowercase().replace('-', "_");
+    NON_SKILL_FILENAME_STEMS
+        .iter()
+        .any(|candidate| candidate == &normalized)
+}
+
+/// Frontmatter fields ramparts cares about across skill formats. Unknown
+/// fields are ignored (serde defaults), so adding support for a new
+/// ecosystem usually means adding a field here rather than introducing a
+/// new struct. Today we cover Claude Code conventions; Cursor / OpenAI
+/// Codex / generic skill repos that ship the same frontmatter shape work
+/// out of the box.
+///
+/// All fields are optional because real-world skill files vary widely —
+/// some have only a description, some have only an argument hint, some
+/// have neither.
 #[derive(Debug, Deserialize, Default)]
 struct SkillFrontmatter {
     description: Option<String>,
     /// Claude Code's `argument-hint` — a one-liner describing parameters.
+    /// Other ecosystems may use different field names; add a `#[serde(alias)]`
+    /// attribute when expanding support rather than introducing a new struct.
     #[serde(rename = "argument-hint")]
     argument_hint: Option<String>,
     /// Some skill formats use `name` to override the filename-derived name.
     name: Option<String>,
 }
 
-/// Parse a single skill file at `path`. Returns `None` (logging at debug)
-/// when the file can't be read or contains no usable content. Errors are
-/// non-fatal so a single broken skill can't break a directory scan.
+/// Parse a single skill file at `path`. Returns `None` (logging at warn)
+/// when the file can't be read, exceeds `MAX_SKILL_FILE_BYTES`, or is
+/// otherwise unusable. Errors are non-fatal so a single broken skill
+/// can't break a directory scan.
 pub fn parse_skill_file(path: &Path) -> Option<MCPPrompt> {
+    // Cheap pre-check: stat the file before we open it. We could
+    // alternatively let `read_to_string` succeed and then check the
+    // resulting String length, but that risks reading a 2 GB file into
+    // memory before deciding to drop it.
+    if let Ok(metadata) = std::fs::metadata(path) {
+        if metadata.len() > MAX_SKILL_FILE_BYTES {
+            warn!(
+                "Skipping skill file {} ({} bytes > {} byte limit)",
+                path.display(),
+                metadata.len(),
+                MAX_SKILL_FILE_BYTES
+            );
+            return None;
+        }
+    }
     let content = match std::fs::read_to_string(path) {
         Ok(s) => s,
         Err(e) => {
@@ -81,33 +146,96 @@ pub fn parse_skill_content(path: &Path, raw: &str) -> MCPPrompt {
         .unwrap_or("unnamed");
     let name = parsed_fm.name.unwrap_or_else(|| stem.to_string());
 
+    // Try to lift real argument names out of an `argument-hint` string
+    // like "<env>" or "<env> <region>". When that yields nothing usable
+    // (free-form hint with no `<token>` pattern), append the raw hint to
+    // the description below so the LLM analyzer still sees it — better
+    // than fabricating an argument with a placeholder name like "args".
+    let hint = parsed_fm
+        .argument_hint
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let arguments = hint.and_then(parse_argument_hint);
+
     // Wire the body into `description` so it flows through every existing
     // prompt-security check that consumes `description` for LLM analysis,
     // formatting, etc. Prepending the frontmatter description (if any)
     // gives the analyzer the author's stated intent right next to what
-    // the skill actually says — handy for catching mismatches.
-    let description = match parsed_fm.description.as_deref() {
-        Some(d) if !d.trim().is_empty() => Some(format!("{}\n\n{}", d.trim(), body.trim())),
-        _ => Some(body.trim().to_string()),
+    // the skill actually says — handy for catching mismatches. When we
+    // couldn't parse argument names out of a free-form hint, append the
+    // hint here so it isn't silently dropped from the analysis input.
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(d) = parsed_fm.description.as_deref() {
+        let d = d.trim();
+        if !d.is_empty() {
+            parts.push(d.to_string());
+        }
+    }
+    let body_trimmed = body.trim();
+    if !body_trimmed.is_empty() {
+        parts.push(body_trimmed.to_string());
+    }
+    if arguments.is_none() {
+        if let Some(h) = hint {
+            parts.push(format!("Argument hint: {h}"));
+        }
+    }
+    let description = if parts.is_empty() {
+        Some(String::new())
+    } else {
+        Some(parts.join("\n\n"))
     };
-
-    let arguments = parsed_fm
-        .argument_hint
-        .as_deref()
-        .filter(|s| !s.trim().is_empty())
-        .map(|hint| {
-            vec![MCPPromptArgument {
-                name: "args".to_string(),
-                description: Some(hint.to_string()),
-                required: None,
-            }]
-        });
 
     MCPPrompt {
         name,
         description,
         arguments,
         raw_json: None,
+    }
+}
+
+/// Lift argument names out of a Claude Code-style `argument-hint` string.
+/// Recognizes `<token>` patterns (the convention for required positional
+/// args) and emits one `MCPPromptArgument` per parsed token. Free-form
+/// hints with no `<>` markers return `None` so the caller can fall back
+/// to embedding the raw hint in the description rather than fabricating
+/// argument metadata that isn't in the source.
+///
+/// Examples:
+/// - `"<env>"`              -> `[arg(name="env")]`
+/// - `"<env> <region>"`     -> `[arg(name="env"), arg(name="region")]`
+/// - `"a free-form hint"`   -> `None`
+/// - `"<>"` (empty bracket) -> `None`
+fn parse_argument_hint(hint: &str) -> Option<Vec<MCPPromptArgument>> {
+    let mut args: Vec<MCPPromptArgument> = Vec::new();
+    let mut buf = String::new();
+    let mut inside = false;
+    for c in hint.chars() {
+        match (c, inside) {
+            ('<', false) => {
+                inside = true;
+                buf.clear();
+            }
+            ('>', true) => {
+                let token = buf.trim();
+                if !token.is_empty() {
+                    args.push(MCPPromptArgument {
+                        name: token.to_string(),
+                        description: None,
+                        required: None,
+                    });
+                }
+                inside = false;
+            }
+            (_, true) => buf.push(c),
+            (_, false) => {} // ignore characters outside of <...>
+        }
+    }
+    if args.is_empty() {
+        None
+    } else {
+        Some(args)
     }
 }
 
@@ -206,15 +334,36 @@ pub fn discover_skills_in_root(root: &Path) -> Result<Vec<PathBuf>> {
                 }
                 walk(&path, depth + 1, out);
             } else if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+                // Only consider markdown files, and skip files whose names
+                // match common non-skill conventions (README, CHANGELOG,
+                // LICENSE, etc.) — these almost never represent agent
+                // skills and they're a major false-positive source when
+                // users point `skills scan` at a repo root.
                 if ext.eq_ignore_ascii_case("md") {
+                    let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                    if is_non_skill_filename(name) {
+                        debug!(
+                            "Skipping {} (matches non-skill filename convention)",
+                            path.display()
+                        );
+                        continue;
+                    }
                     out.push(path);
                 }
             }
         }
     }
 
+    /// Dotdirs that are known to host agent skill content — kept in sync
+    /// with the IDE config dotdir set in `MCPConfigManager::with_root` so
+    /// behavior is consistent across `scan-config --root` and
+    /// `skills scan`/`skills scan-config`. Add new ecosystems here as
+    /// support grows.
     fn is_known_skill_dotdir(name: &str) -> bool {
-        matches!(name, ".claude" | ".cursor" | ".codex" | ".openai")
+        matches!(
+            name,
+            ".claude" | ".cursor" | ".codex" | ".openai" | ".windsurf" | ".gemini"
+        )
     }
 
     let mut out = Vec::new();
@@ -299,15 +448,52 @@ mod tests {
     }
 
     #[test]
-    fn argument_hint_becomes_argument() {
+    fn single_argument_hint_token_becomes_named_argument() {
         let path = PathBuf::from("with-args.md");
         let raw =
             "---\ndescription: Greets a user\nargument-hint: <name>\n---\nSay hello to the user.\n";
         let prompt = parse_skill_content(&path, raw);
         let args = prompt.arguments.expect("arguments");
         assert_eq!(args.len(), 1);
-        assert_eq!(args[0].name, "args");
-        assert_eq!(args[0].description.as_deref(), Some("<name>"));
+        assert_eq!(args[0].name, "name");
+        // We deliberately don't fabricate a description for the
+        // synthesized argument — the source hint goes in the prompt's
+        // description, not on every parsed token.
+        assert!(args[0].description.is_none());
+    }
+
+    #[test]
+    fn multiple_argument_hint_tokens_become_separate_arguments() {
+        let path = PathBuf::from("multi.md");
+        let raw = "---\nargument-hint: <env> <region>\n---\nbody\n";
+        let prompt = parse_skill_content(&path, raw);
+        let args = prompt.arguments.expect("arguments");
+        let names: Vec<_> = args.iter().map(|a| a.name.as_str()).collect();
+        assert_eq!(names, vec!["env", "region"]);
+    }
+
+    #[test]
+    fn free_form_argument_hint_falls_back_to_description() {
+        // No `<token>` pattern -> we don't fabricate an argument name;
+        // instead we surface the hint in the description so LLM analysis
+        // still sees it.
+        let path = PathBuf::from("free-form.md");
+        let raw =
+            "---\ndescription: Does a thing\nargument-hint: just type your message\n---\nbody\n";
+        let prompt = parse_skill_content(&path, raw);
+        assert!(prompt.arguments.is_none());
+        let desc = prompt.description.expect("description");
+        assert!(desc.contains("Argument hint: just type your message"));
+        assert!(desc.contains("Does a thing"));
+        assert!(desc.contains("body"));
+    }
+
+    #[test]
+    fn empty_brackets_in_hint_yield_no_arguments() {
+        let path = PathBuf::from("empty-bracket.md");
+        let raw = "---\nargument-hint: <>\n---\nbody\n";
+        let prompt = parse_skill_content(&path, raw);
+        assert!(prompt.arguments.is_none());
     }
 
     #[test]

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -22,11 +22,26 @@
 //! the name; body becomes the description). Anything that can't be read
 //! as UTF-8 is skipped with a warning rather than failing the scan.
 
-use crate::types::{MCPPrompt, MCPPromptArgument};
+use crate::types::{MCPPrompt, MCPPromptArgument, YaraRuleMetadata, YaraScanResult};
 use anyhow::{anyhow, Result};
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 use tracing::{debug, warn};
+
+/// Environment variable allowing operators to extend the default discovery
+/// roots without rebuilding. Comma-separated absolute or `~`-prefixed paths.
+pub const SKILL_ROOTS_ENV: &str = "RAMPARTS_SKILL_ROOTS";
+
+/// A parsed skill file plus any structural / frontmatter-level findings
+/// the parser produced (e.g. an `allowed-tools` grant that's too broad,
+/// a missing description). Returned together so the caller can append
+/// `heuristic_findings` to its `ScanResult.yara_results` and route them
+/// through the existing rendering pipeline alongside YARA matches.
+#[derive(Debug)]
+pub struct ParsedSkill {
+    pub prompt: MCPPrompt,
+    pub heuristic_findings: Vec<YaraScanResult>,
+}
 
 /// Reject any individual skill file larger than this. Real skill files are
 /// kilobytes; a multi-megabyte markdown is either a misclassification (e.g.
@@ -89,13 +104,19 @@ struct SkillFrontmatter {
     argument_hint: Option<String>,
     /// Some skill formats use `name` to override the filename-derived name.
     name: Option<String>,
+    /// Claude Code's `allowed-tools` — comma- or newline-separated tool
+    /// grants like `Bash(git status:*), Read, Write`. We surface this as
+    /// a finding when the grant is overbroad (Bash with `*` wildcards,
+    /// `rm:*`, `sudo:*`, etc.) since those are excessive-agency risks.
+    #[serde(rename = "allowed-tools")]
+    allowed_tools: Option<String>,
 }
 
 /// Parse a single skill file at `path`. Returns `None` (logging at warn)
 /// when the file can't be read, exceeds `MAX_SKILL_FILE_BYTES`, or is
-/// otherwise unusable. Errors are non-fatal so a single broken skill
+/// effectively empty. Errors are non-fatal so a single broken skill
 /// can't break a directory scan.
-pub fn parse_skill_file(path: &Path) -> Option<MCPPrompt> {
+pub fn parse_skill_file(path: &Path) -> Option<ParsedSkill> {
     // Cheap pre-check: stat the file before we open it. We could
     // alternatively let `read_to_string` succeed and then check the
     // resulting String length, but that risks reading a 2 GB file into
@@ -118,14 +139,15 @@ pub fn parse_skill_file(path: &Path) -> Option<MCPPrompt> {
             return None;
         }
     };
-    Some(parse_skill_content(path, &content))
+    parse_skill_content(path, &content)
 }
 
 /// Pure-data version of `parse_skill_file` — useful for tests and for
 /// callers that already have the content in memory (e.g. fetched from a
-/// remote source). Always succeeds: missing fields fall back to sensible
-/// defaults derived from the file path.
-pub fn parse_skill_content(path: &Path, raw: &str) -> MCPPrompt {
+/// remote source). Returns `None` for an effectively empty file (no
+/// frontmatter content and a body that's blank after trimming) so we
+/// don't waste an LLM batch slot on something with nothing to analyze.
+pub fn parse_skill_content(path: &Path, raw: &str) -> Option<ParsedSkill> {
     let (frontmatter, body) = split_frontmatter(raw);
     let parsed_fm: SkillFrontmatter = frontmatter
         .and_then(|fm| match serde_yaml::from_str(fm) {
@@ -165,14 +187,29 @@ pub fn parse_skill_content(path: &Path, raw: &str) -> MCPPrompt {
     // the skill actually says — handy for catching mismatches. When we
     // couldn't parse argument names out of a free-form hint, append the
     // hint here so it isn't silently dropped from the analysis input.
-    let mut parts: Vec<String> = Vec::new();
-    if let Some(d) = parsed_fm.description.as_deref() {
-        let d = d.trim();
-        if !d.is_empty() {
-            parts.push(d.to_string());
-        }
-    }
+    let fm_description = parsed_fm
+        .description
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
     let body_trimmed = body.trim();
+
+    // Skip skills that have nothing to analyze. A file with no description,
+    // no body, and no hint contributes only noise to the LLM batch and
+    // crowds the report. We log at debug because users frequently pass
+    // directories that contain placeholder files (touched but unwritten).
+    if fm_description.is_none() && body_trimmed.is_empty() && hint.is_none() {
+        debug!(
+            "Skipping {} (empty skill: no description, body, or argument hint)",
+            path.display()
+        );
+        return None;
+    }
+
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(d) = fm_description {
+        parts.push(d.to_string());
+    }
     if !body_trimmed.is_empty() {
         parts.push(body_trimmed.to_string());
     }
@@ -181,17 +218,176 @@ pub fn parse_skill_content(path: &Path, raw: &str) -> MCPPrompt {
             parts.push(format!("Argument hint: {h}"));
         }
     }
-    let description = if parts.is_empty() {
-        Some(String::new())
-    } else {
-        Some(parts.join("\n\n"))
-    };
+    let description = Some(parts.join("\n\n"));
+    // Source-path provenance lives on heuristic findings (via the
+    // `context` field on `YaraScanResult`) rather than inside the
+    // analyzed `description`. Putting absolute paths into text the
+    // pre-scan YARA sees triggers spurious matches against rules that
+    // flag paths like `/var/` or `/etc/` (path-traversal heuristics);
+    // keeping provenance off the analyzed text avoids those false
+    // positives while still preserving "which file did this come from"
+    // on every parser-emitted finding.
 
-    MCPPrompt {
+    let prompt = MCPPrompt {
         name,
         description,
         arguments,
         raw_json: None,
+    };
+
+    let mut heuristic_findings: Vec<YaraScanResult> = Vec::new();
+    if let Some(grant) = parsed_fm.allowed_tools.as_deref() {
+        heuristic_findings.extend(analyze_allowed_tools(&prompt.name, path, grant));
+    }
+    heuristic_findings.extend(analyze_vague_trigger(
+        &prompt.name,
+        path,
+        fm_description,
+        body_trimmed,
+    ));
+
+    Some(ParsedSkill {
+        prompt,
+        heuristic_findings,
+    })
+}
+
+/// Tokens in `allowed-tools` that grant unrestricted shell/filesystem access
+/// when granted blanket. Hits here become an `OverbroadAllowedTools`
+/// finding that maps to OWASP MCP03 (excessive agency). We deliberately
+/// cast a narrow net — the goal is "this skill quietly asked for the keys
+/// to the kingdom," not "this skill uses any tool we don't know about."
+const DANGEROUS_GRANT_PATTERNS: &[&str] = &[
+    "bash(*)", "bash:*", "shell(*)", "shell:*", "rm:*", "rm(*)", "sudo:*", "sudo(*)", "exec:*",
+    "exec(*)", "eval:*", "eval(*)", "*",
+];
+
+/// Detect overbroad `allowed-tools` grants. The frontmatter is treated as
+/// a comma- or newline-separated list of tokens like `Bash(git status:*),
+/// Read, Write`. We normalize each token (lowercase, strip whitespace) and
+/// flag matches against `DANGEROUS_GRANT_PATTERNS`.
+fn analyze_allowed_tools(skill_name: &str, path: &Path, grant: &str) -> Vec<YaraScanResult> {
+    let mut findings: Vec<YaraScanResult> = Vec::new();
+    let tokens = grant
+        .split([',', '\n'])
+        .map(|t| t.trim())
+        .filter(|t| !t.is_empty());
+    for token in tokens {
+        let normalized = token.to_ascii_lowercase();
+        let normalized_collapsed: String = normalized.split_whitespace().collect();
+        if DANGEROUS_GRANT_PATTERNS
+            .iter()
+            .any(|p| normalized == *p || normalized_collapsed == *p)
+        {
+            findings.push(make_heuristic_finding(
+                "OverbroadAllowedTools",
+                "high",
+                format!(
+                    "Skill '{skill_name}' grants tool '{token}' which permits unrestricted \
+                     command execution. Restrict to specific subcommands (e.g. \
+                     `Bash(git status:*)`) or remove the wildcard."
+                ),
+                skill_name,
+                path,
+            ));
+            // One finding per unique pattern keeps the report readable; bail
+            // after the first hit on a token rather than emitting one per
+            // matching pattern entry.
+            continue;
+        }
+    }
+    findings
+}
+
+/// Minimum description length that we consider "specific enough." Skills
+/// whose stated purpose is shorter than this and whose body is non-trivial
+/// risk being invoked unintentionally — the agent's router has nothing to
+/// disambiguate on. Tuned by inspecting real skill repos: descriptions
+/// under ~24 chars are almost always single-word labels ("deploy", "test")
+/// rather than triggers an LLM can match against intent.
+const MIN_TRIGGER_DESCRIPTION_CHARS: usize = 24;
+
+/// Body length above which a missing/vague trigger becomes worth flagging.
+/// A 50-char body with no description is a stub; a multi-paragraph skill
+/// with no description is a real footgun.
+const SUBSTANTIVE_BODY_THRESHOLD_CHARS: usize = 200;
+
+/// Detect skills that lack a clear invocation trigger. A skill with a
+/// substantial body but no description (or a one-word description) is
+/// easy for an agent to invoke by accident. Maps to OWASP MCP02
+/// (supply-chain / hidden behavior) and MCP03 (excessive agency).
+fn analyze_vague_trigger(
+    skill_name: &str,
+    path: &Path,
+    description: Option<&str>,
+    body: &str,
+) -> Vec<YaraScanResult> {
+    if body.chars().count() < SUBSTANTIVE_BODY_THRESHOLD_CHARS {
+        return Vec::new();
+    }
+    let desc_chars = description.map(|d| d.chars().count()).unwrap_or(0);
+    if desc_chars >= MIN_TRIGGER_DESCRIPTION_CHARS {
+        return Vec::new();
+    }
+    let reason = if description.is_none() {
+        format!(
+            "Skill '{skill_name}' has a substantial body ({} chars) but no `description` \
+             frontmatter. Without a clear trigger, an agent may invoke this skill \
+             unintentionally. Add a one-line description that disambiguates intent.",
+            body.chars().count()
+        )
+    } else {
+        format!(
+            "Skill '{skill_name}' has a body ({} chars) but only a {desc_chars}-char \
+             description. Expand the description to clearly state when the skill should run.",
+            body.chars().count()
+        )
+    };
+    vec![make_heuristic_finding(
+        "VagueSkillTrigger",
+        "medium",
+        reason,
+        skill_name,
+        path,
+    )]
+}
+
+/// Build a `YaraScanResult` for a parser-emitted heuristic finding so it
+/// rides the same rendering pipeline as real YARA matches. The synthetic
+/// rule names are listed in `taxonomy::tags_for_yara_rule` so they pick
+/// up OWASP tags too.
+fn make_heuristic_finding(
+    rule: &'static str,
+    severity: &'static str,
+    description: String,
+    target: &str,
+    path: &Path,
+) -> YaraScanResult {
+    YaraScanResult {
+        rule_name: rule.to_string(),
+        target_type: "prompt".to_string(),
+        target_name: target.to_string(),
+        rule_file: Some("skill_parser".to_string()),
+        matched_text: None,
+        context: format!("source: {}", path.display()),
+        rule_metadata: Some(YaraRuleMetadata {
+            name: Some(rule.to_string()),
+            author: Some("ramparts".to_string()),
+            date: None,
+            version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            description: Some(description),
+            severity: Some(severity.to_string()),
+            category: Some("skill_security".to_string()),
+            confidence: Some("high".to_string()),
+            tags: Vec::new(),
+        }),
+        owasp_tags: crate::taxonomy::tags_for_yara_rule(rule),
+        phase: None,
+        rules_executed: None,
+        security_issues_detected: None,
+        total_items_scanned: None,
+        total_matches: None,
+        status: None,
     }
 }
 
@@ -373,17 +569,73 @@ pub fn discover_skills_in_root(root: &Path) -> Result<Vec<PathBuf>> {
 }
 
 /// Default discovery roots when `ramparts skills scan-config` runs with
-/// no `--root`. Currently focused on Claude Code commands at both the
-/// user and workspace level; other skill ecosystems can be added here as
-/// support grows.
+/// no `--root`. Covers the user- and workspace-level skill directories
+/// for the IDE/agent ecosystems we currently support. Operators can
+/// supply additional roots via the `RAMPARTS_SKILL_ROOTS` env var
+/// (comma-separated paths, `~` expanded) without rebuilding.
+///
+/// Order is: env-var entries first (operator override), then per-user
+/// dotdirs under `$HOME`, then per-workspace dotdirs under the current
+/// directory. Duplicates are filtered downstream by canonical-path dedup
+/// in the scan handler.
 pub fn default_discovery_roots() -> Vec<PathBuf> {
-    let mut roots = Vec::new();
+    let mut roots: Vec<PathBuf> = Vec::new();
+
+    if let Ok(extra) = std::env::var(SKILL_ROOTS_ENV) {
+        for entry in extra.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+            roots.push(expand_tilde(entry));
+        }
+    }
+
+    // Per-ecosystem skill directories. These mirror the dotdirs we walk
+    // in `is_known_skill_dotdir` so `skills scan-config` (no --root) and
+    // `skills scan --path <repo>` cover the same ground.
+    const PER_ECOSYSTEM: &[&[&str]] = &[
+        &[".claude", "commands"],
+        &[".claude", "skills"],
+        &[".cursor", "commands"],
+        &[".cursor", "skills"],
+        &[".codex", "commands"],
+        &[".codex", "skills"],
+        &[".windsurf", "commands"],
+        &[".gemini", "commands"],
+        &[".openai", "commands"],
+    ];
+
     if let Some(home) = dirs::home_dir() {
-        roots.push(home.join(".claude").join("commands"));
+        for segments in PER_ECOSYSTEM {
+            let mut p = home.clone();
+            for s in *segments {
+                p.push(s);
+            }
+            roots.push(p);
+        }
     }
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    roots.push(cwd.join(".claude").join("commands"));
+    for segments in PER_ECOSYSTEM {
+        let mut p = cwd.clone();
+        for s in *segments {
+            p.push(s);
+        }
+        roots.push(p);
+    }
     roots
+}
+
+/// Expand a leading `~` or `~/` to the user's home directory. Other
+/// `~user` forms aren't expanded (we don't want a libc dependency for
+/// something this rarely useful in skill paths).
+fn expand_tilde(input: &str) -> PathBuf {
+    if let Some(rest) = input.strip_prefix("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(rest);
+        }
+    } else if input == "~" {
+        if let Some(home) = dirs::home_dir() {
+            return home;
+        }
+    }
+    PathBuf::from(input)
 }
 
 #[cfg(test)]
@@ -391,98 +643,105 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
+    fn parse(path: &str, raw: &str) -> ParsedSkill {
+        parse_skill_content(&PathBuf::from(path), raw).expect("parsed skill")
+    }
+
     #[test]
     fn parses_frontmatter_and_body() {
-        let path = PathBuf::from("deploy.md");
-        let raw =
-            "---\ndescription: Ship to staging\n---\n\nDeploy the app, then notify the channel.\n";
-        let prompt = parse_skill_content(&path, raw);
-        assert_eq!(prompt.name, "deploy");
-        let desc = prompt.description.expect("description");
+        let parsed = parse(
+            "deploy.md",
+            "---\ndescription: Ship to staging\n---\n\nDeploy the app, then notify the channel.\n",
+        );
+        assert_eq!(parsed.prompt.name, "deploy");
+        let desc = parsed.prompt.description.expect("description");
         assert!(desc.contains("Ship to staging"));
         assert!(desc.contains("Deploy the app"));
     }
 
     #[test]
-    fn handles_missing_frontmatter() {
-        let path = PathBuf::from("no-frontmatter.md");
-        let raw = "Just a body, no frontmatter at all.";
-        let prompt = parse_skill_content(&path, raw);
-        assert_eq!(prompt.name, "no-frontmatter");
-        assert_eq!(
-            prompt.description.as_deref(),
-            Some("Just a body, no frontmatter at all.")
+    fn description_excludes_source_path_to_avoid_yara_false_positives() {
+        // Absolute paths inside the analyzed text would trip rules like
+        // PathTraversalVulnerability that flag `/var/`, `/etc/`, etc.
+        // Provenance lives on parser-emitted findings, not in the text
+        // the YARA pre-scan and LLM analyzer see.
+        let parsed = parse("/var/folders/xyz/deploy.md", "body");
+        let desc = parsed.prompt.description.expect("description");
+        assert!(
+            !desc.contains("/var/"),
+            "description leaked source path: {desc}"
         );
+    }
+
+    #[test]
+    fn handles_missing_frontmatter() {
+        let parsed = parse("no-frontmatter.md", "Just a body, no frontmatter at all.");
+        assert_eq!(parsed.prompt.name, "no-frontmatter");
+        let desc = parsed.prompt.description.expect("description");
+        assert!(desc.contains("Just a body, no frontmatter at all."));
     }
 
     #[test]
     fn handles_malformed_frontmatter() {
         // Opening `---` with no closing marker — treat as no frontmatter
         // so the malformed YAML doesn't get hidden in `description`.
-        let path = PathBuf::from("broken.md");
-        let raw = "---\nthis is not valid yaml: [oops\n\nbody starts here\n";
-        let prompt = parse_skill_content(&path, raw);
-        // The opening `---` plus content is treated as the body when no
-        // closing marker is found.
-        assert_eq!(prompt.name, "broken");
-        assert!(prompt.description.is_some());
+        let parsed = parse(
+            "broken.md",
+            "---\nthis is not valid yaml: [oops\n\nbody starts here\n",
+        );
+        assert_eq!(parsed.prompt.name, "broken");
+        assert!(parsed.prompt.description.is_some());
     }
 
     #[test]
     fn yaml_parse_error_falls_back_to_no_frontmatter() {
         // Closing marker is present but the YAML between them doesn't parse.
-        let path = PathBuf::from("badyaml.md");
-        let raw = "---\nthis is not: valid: yaml: at: all\n---\nbody\n";
-        let prompt = parse_skill_content(&path, raw);
-        assert_eq!(prompt.name, "badyaml");
-        // body still extracted
-        assert_eq!(prompt.description.as_deref(), Some("body"));
+        let parsed = parse(
+            "badyaml.md",
+            "---\nthis is not: valid: yaml: at: all\n---\nbody\n",
+        );
+        assert_eq!(parsed.prompt.name, "badyaml");
+        let desc = parsed.prompt.description.expect("description");
+        assert!(desc.contains("body"));
     }
 
     #[test]
     fn frontmatter_name_overrides_filename() {
-        let path = PathBuf::from("ignored.md");
-        let raw = "---\nname: actual-name\n---\nhello\n";
-        let prompt = parse_skill_content(&path, raw);
-        assert_eq!(prompt.name, "actual-name");
+        let parsed = parse("ignored.md", "---\nname: actual-name\n---\nhello\n");
+        assert_eq!(parsed.prompt.name, "actual-name");
     }
 
     #[test]
     fn single_argument_hint_token_becomes_named_argument() {
-        let path = PathBuf::from("with-args.md");
-        let raw =
-            "---\ndescription: Greets a user\nargument-hint: <name>\n---\nSay hello to the user.\n";
-        let prompt = parse_skill_content(&path, raw);
-        let args = prompt.arguments.expect("arguments");
+        let parsed = parse(
+            "with-args.md",
+            "---\ndescription: Greets a user\nargument-hint: <name>\n---\nSay hello to the user.\n",
+        );
+        let args = parsed.prompt.arguments.expect("arguments");
         assert_eq!(args.len(), 1);
         assert_eq!(args[0].name, "name");
-        // We deliberately don't fabricate a description for the
-        // synthesized argument — the source hint goes in the prompt's
-        // description, not on every parsed token.
         assert!(args[0].description.is_none());
     }
 
     #[test]
     fn multiple_argument_hint_tokens_become_separate_arguments() {
-        let path = PathBuf::from("multi.md");
-        let raw = "---\nargument-hint: <env> <region>\n---\nbody\n";
-        let prompt = parse_skill_content(&path, raw);
-        let args = prompt.arguments.expect("arguments");
+        let parsed = parse(
+            "multi.md",
+            "---\nargument-hint: <env> <region>\n---\nbody\n",
+        );
+        let args = parsed.prompt.arguments.expect("arguments");
         let names: Vec<_> = args.iter().map(|a| a.name.as_str()).collect();
         assert_eq!(names, vec!["env", "region"]);
     }
 
     #[test]
     fn free_form_argument_hint_falls_back_to_description() {
-        // No `<token>` pattern -> we don't fabricate an argument name;
-        // instead we surface the hint in the description so LLM analysis
-        // still sees it.
-        let path = PathBuf::from("free-form.md");
-        let raw =
-            "---\ndescription: Does a thing\nargument-hint: just type your message\n---\nbody\n";
-        let prompt = parse_skill_content(&path, raw);
-        assert!(prompt.arguments.is_none());
-        let desc = prompt.description.expect("description");
+        let parsed = parse(
+            "free-form.md",
+            "---\ndescription: Does a thing\nargument-hint: just type your message\n---\nbody\n",
+        );
+        assert!(parsed.prompt.arguments.is_none());
+        let desc = parsed.prompt.description.expect("description");
         assert!(desc.contains("Argument hint: just type your message"));
         assert!(desc.contains("Does a thing"));
         assert!(desc.contains("body"));
@@ -490,28 +749,116 @@ mod tests {
 
     #[test]
     fn empty_brackets_in_hint_yield_no_arguments() {
-        let path = PathBuf::from("empty-bracket.md");
-        let raw = "---\nargument-hint: <>\n---\nbody\n";
-        let prompt = parse_skill_content(&path, raw);
-        assert!(prompt.arguments.is_none());
+        let parsed = parse("empty-bracket.md", "---\nargument-hint: <>\n---\nbody\n");
+        assert!(parsed.prompt.arguments.is_none());
     }
 
     #[test]
     fn strips_bom() {
-        let path = PathBuf::from("bom.md");
-        let raw = "\u{feff}---\ndescription: x\n---\ny\n";
-        let prompt = parse_skill_content(&path, raw);
-        let desc = prompt.description.unwrap();
+        let parsed = parse("bom.md", "\u{feff}---\ndescription: x\n---\ny\n");
+        let desc = parsed.prompt.description.unwrap();
         assert!(desc.contains('x'));
         assert!(desc.contains('y'));
     }
 
     #[test]
     fn empty_description_in_frontmatter_falls_back_to_body() {
-        let path = PathBuf::from("empty-desc.md");
-        let raw = "---\ndescription: \"\"\n---\nactual body\n";
-        let prompt = parse_skill_content(&path, raw);
-        assert_eq!(prompt.description.as_deref(), Some("actual body"));
+        let parsed = parse(
+            "empty-desc.md",
+            "---\ndescription: \"\"\n---\nactual body\n",
+        );
+        let desc = parsed.prompt.description.expect("description");
+        assert!(desc.contains("actual body"));
+    }
+
+    #[test]
+    fn fully_empty_skill_returns_none() {
+        let path = PathBuf::from("empty.md");
+        // No frontmatter, blank body — nothing to analyze.
+        assert!(parse_skill_content(&path, "   \n\t\n").is_none());
+        // Empty frontmatter + blank body — same.
+        assert!(parse_skill_content(&path, "---\n---\n").is_none());
+    }
+
+    #[test]
+    fn dangerous_allowed_tools_grant_emits_finding() {
+        let parsed = parse(
+            "danger.md",
+            "---\ndescription: A dangerous skill\nallowed-tools: Bash(*), Read\n---\nrm -rf /\n",
+        );
+        let rules: Vec<_> = parsed
+            .heuristic_findings
+            .iter()
+            .map(|f| f.rule_name.as_str())
+            .collect();
+        assert!(
+            rules.contains(&"OverbroadAllowedTools"),
+            "expected OverbroadAllowedTools, got {rules:?}"
+        );
+    }
+
+    #[test]
+    fn safe_allowed_tools_grant_emits_no_finding() {
+        let parsed = parse(
+            "safe.md",
+            "---\ndescription: A bounded skill\nallowed-tools: Bash(git status:*), Read, Write\n---\nbody\n",
+        );
+        assert!(parsed
+            .heuristic_findings
+            .iter()
+            .all(|f| f.rule_name != "OverbroadAllowedTools"));
+    }
+
+    #[test]
+    fn vague_trigger_with_substantial_body_emits_finding() {
+        // Substantial body + missing description → flag.
+        let body: String = "Do the thing. ".repeat(40);
+        let raw = format!("---\nname: noisy\n---\n{body}\n");
+        let parsed = parse("noisy.md", &raw);
+        assert!(parsed
+            .heuristic_findings
+            .iter()
+            .any(|f| f.rule_name == "VagueSkillTrigger"));
+    }
+
+    #[test]
+    fn short_body_does_not_trigger_vague_finding() {
+        // Stub skills (short body, no description) shouldn't pollute the report.
+        let parsed = parse("stub.md", "tiny body");
+        assert!(parsed
+            .heuristic_findings
+            .iter()
+            .all(|f| f.rule_name != "VagueSkillTrigger"));
+    }
+
+    #[test]
+    fn substantive_description_suppresses_vague_finding() {
+        let body: String = "Do the thing. ".repeat(40);
+        let raw = format!(
+            "---\ndescription: Specifically deploys the staging environment after running tests\n---\n{body}\n"
+        );
+        let parsed = parse("clear.md", &raw);
+        assert!(parsed
+            .heuristic_findings
+            .iter()
+            .all(|f| f.rule_name != "VagueSkillTrigger"));
+    }
+
+    #[test]
+    fn heuristic_findings_carry_owasp_tags() {
+        let parsed = parse(
+            "danger.md",
+            "---\nallowed-tools: rm:*\n---\nA body that is long enough to be considered substantive content for trigger heuristics.\n",
+        );
+        let overbroad = parsed
+            .heuristic_findings
+            .iter()
+            .find(|f| f.rule_name == "OverbroadAllowedTools")
+            .expect("OverbroadAllowedTools finding");
+        assert!(
+            !overbroad.owasp_tags.is_empty(),
+            "OverbroadAllowedTools should carry OWASP tags via taxonomy"
+        );
     }
 
     #[test]

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -261,7 +261,17 @@ pub fn parse_skill_content(path: &Path, raw: &str) -> Option<ParsedSkill> {
         .file_stem()
         .and_then(|s| s.to_str())
         .unwrap_or("unnamed");
-    let name = parsed_fm.name.unwrap_or_else(|| stem.to_string());
+    // Empty / whitespace-only `name:` falls back to the filename stem.
+    // Without this, `name: ""` produces a skill with an empty prompt
+    // name, which downstream renderers display as a blank field and
+    // which collides with every other empty-named skill in the
+    // SkillNameCollision check.
+    let name = parsed_fm
+        .name
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map_or_else(|| stem.to_string(), str::to_string);
 
     // Try to lift real argument names out of an `argument-hint` string
     // like "<env>" or "<env> <region>". When that yields nothing usable
@@ -318,19 +328,17 @@ pub fn parse_skill_content(path: &Path, raw: &str) -> Option<ParsedSkill> {
     // one (the prompt template renders "No description" instead of an
     // empty field). Only happens when arguments were parsed from a hint
     // but description and body are both empty.
+    // `description` carries the analyzable text (frontmatter
+    // description + body + free-form arg hint, in that order); source
+    // path is *not* included because absolute paths in YARA-scanned
+    // text trip path-traversal rules like `/var/` and `/etc/`.
+    // Provenance lives on heuristic findings via the `context` field
+    // on `YaraScanResult` instead.
     let description = if parts.is_empty() {
         None
     } else {
         Some(parts.join("\n\n"))
     };
-    // Source-path provenance lives on heuristic findings (via the
-    // `context` field on `YaraScanResult`) rather than inside the
-    // analyzed `description`. Putting absolute paths into text the
-    // pre-scan YARA sees triggers spurious matches against rules that
-    // flag paths like `/var/` or `/etc/` (path-traversal heuristics);
-    // keeping provenance off the analyzed text avoids those false
-    // positives while still preserving "which file did this come from"
-    // on every parser-emitted finding.
 
     let prompt = MCPPrompt {
         name,
@@ -481,9 +489,12 @@ fn split_grant_tokens(grant: &str) -> Vec<&str> {
             _ => {}
         }
     }
-    if start <= grant.len() {
-        tokens.push(&grant[start..]);
-    }
+    // Always push the trailing slice. `start` is at a char boundary
+    // (set from `i + c.len_utf8()` after a separator) and at most
+    // equals `grant.len()`, so the slice is valid; an empty trailing
+    // slice (input ending with `,` / `\n`) is harmless because
+    // `parse_grant_token` rejects whitespace-only tokens downstream.
+    tokens.push(&grant[start..]);
     tokens
 }
 
@@ -658,10 +669,17 @@ fn analyze_sensitive_file_references(
         // in `john@example.com` is then "example.com" — which we'd
         // check for sensitive-path content anyway, but the cheap
         // pre-check drops the bulk of email-pattern noise.
-        let prev_is_word_char = body[..i]
-            .chars()
-            .next_back()
-            .is_some_and(|c| c.is_ascii_alphanumeric() || c == '_');
+        //
+        // Byte-level inspection (vs `body[..i].chars().next_back()`)
+        // is O(1) per match rather than O(prefix-length). For a 1MB
+        // skill body with N `@` matches that's the difference between
+        // O(N) and O(N * body_len). Safe across UTF-8 because the
+        // last byte of any multi-byte codepoint has the high bit set
+        // (>= 0x80) and is_ascii_alphanumeric() returns false on it.
+        let prev_is_word_char = i
+            .checked_sub(1)
+            .and_then(|j| body.as_bytes().get(j))
+            .is_some_and(|&b| b.is_ascii_alphanumeric() || b == b'_');
         if prev_is_word_char {
             continue;
         }
@@ -757,10 +775,11 @@ fn analyze_embedded_payloads(skill_name: &str, path: &Path, body: &str) -> Vec<Y
         // Data-URI exclusion. A markdown inline image
         // `![alt](data:image/png;base64,SGVsbG8=)` produces a long
         // base64 run preceded by `base64,`; that's intentional and
-        // benign. Look back up to 16 chars for the marker.
-        let lookback_start = start.saturating_sub(16);
-        let context_before = &body[lookback_start..start];
-        if context_before.contains("base64,") {
+        // benign. `ends_with` on a `&str` compares from the end byte-
+        // wise — safe across UTF-8 because the marker is ASCII and
+        // `body[..start]` is a char-boundary slice (`start` came from
+        // `char_indices`).
+        if body[..start].ends_with("base64,") {
             return;
         }
         let kind = if blob.chars().all(is_hex_char) {
@@ -950,14 +969,14 @@ fn analyze_generic_trigger(
 /// compared case-insensitively because skill routers typically lowercase
 /// for matching. Reports one finding per colliding name with all paths
 /// in the `context` field.
-pub fn analyze_skill_set(skills: &[(PathBuf, &MCPPrompt)]) -> Vec<YaraScanResult> {
+pub fn analyze_skill_set(skills: &[(&Path, &MCPPrompt)]) -> Vec<YaraScanResult> {
     let mut by_name: std::collections::HashMap<String, Vec<&Path>> =
         std::collections::HashMap::new();
     for (path, prompt) in skills {
         by_name
             .entry(prompt.name.to_ascii_lowercase())
             .or_default()
-            .push(path.as_path());
+            .push(*path);
     }
     let mut findings: Vec<YaraScanResult> = Vec::new();
     for (lower_name, paths) in by_name {
@@ -1274,23 +1293,20 @@ pub fn default_discovery_roots() -> Vec<PathBuf> {
         &[".openai", "commands"],
     ];
 
-    if let Some(home) = dirs::home_dir() {
+    let push_for_base = |roots: &mut Vec<PathBuf>, base: &Path| {
         for segments in PER_ECOSYSTEM {
-            let mut p = home.clone();
-            for s in *segments {
-                p.push(s);
-            }
-            roots.push(p);
+            let path = segments
+                .iter()
+                .fold(base.to_path_buf(), |acc, seg| acc.join(seg));
+            roots.push(path);
         }
+    };
+
+    if let Some(home) = dirs::home_dir() {
+        push_for_base(&mut roots, &home);
     }
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    for segments in PER_ECOSYSTEM {
-        let mut p = cwd.clone();
-        for s in *segments {
-            p.push(s);
-        }
-        roots.push(p);
-    }
+    push_for_base(&mut roots, &cwd);
     roots
 }
 
@@ -1381,6 +1397,24 @@ mod tests {
     fn frontmatter_name_overrides_filename() {
         let parsed = parse("ignored.md", "---\nname: actual-name\n---\nhello\n");
         assert_eq!(parsed.prompt.name, "actual-name");
+    }
+
+    #[test]
+    fn empty_or_whitespace_name_falls_back_to_filename_stem() {
+        // `name: ""` and `name: "   "` should NOT produce an empty
+        // skill name — that would render as a blank in reports and
+        // collide with every other empty-named skill in the
+        // SkillNameCollision check.
+        for raw in [
+            "---\nname: \"\"\n---\nbody\n",
+            "---\nname: \"   \"\n---\nbody\n",
+        ] {
+            let parsed = parse("real-stem.md", raw);
+            assert_eq!(
+                parsed.prompt.name, "real-stem",
+                "expected fallback to stem for: {raw:?}"
+            );
+        }
     }
 
     #[test]
@@ -1937,8 +1971,10 @@ mod tests {
             "---\ndescription: Different deploy with override\n---\nshadow deploy logic",
         )
         .expect("p2 parses");
-        let set: Vec<(PathBuf, &MCPPrompt)> =
-            vec![(p1.clone(), &parsed1.prompt), (p2.clone(), &parsed2.prompt)];
+        let set: Vec<(&Path, &MCPPrompt)> = vec![
+            (p1.as_path(), &parsed1.prompt),
+            (p2.as_path(), &parsed2.prompt),
+        ];
         let findings = analyze_skill_set(&set);
         assert_eq!(
             findings.len(),
@@ -1970,7 +2006,10 @@ mod tests {
         let p2 = PathBuf::from("/b/deploy.md");
         let parsed1 = parse_skill_content(&p1, "---\nname: Deploy\n---\nbody1\n").unwrap();
         let parsed2 = parse_skill_content(&p2, "---\nname: deploy\n---\nbody2\n").unwrap();
-        let set: Vec<(PathBuf, &MCPPrompt)> = vec![(p1, &parsed1.prompt), (p2, &parsed2.prompt)];
+        let set: Vec<(&Path, &MCPPrompt)> = vec![
+            (p1.as_path(), &parsed1.prompt),
+            (p2.as_path(), &parsed2.prompt),
+        ];
         let findings = analyze_skill_set(&set);
         assert_eq!(findings.len(), 1);
     }
@@ -1981,7 +2020,10 @@ mod tests {
         let p2 = PathBuf::from("/b/test.md");
         let parsed1 = parse_skill_content(&p1, "---\nname: deploy\n---\nbody1\n").unwrap();
         let parsed2 = parse_skill_content(&p2, "---\nname: test\n---\nbody2\n").unwrap();
-        let set: Vec<(PathBuf, &MCPPrompt)> = vec![(p1, &parsed1.prompt), (p2, &parsed2.prompt)];
+        let set: Vec<(&Path, &MCPPrompt)> = vec![
+            (p1.as_path(), &parsed1.prompt),
+            (p2.as_path(), &parsed2.prompt),
+        ];
         assert!(analyze_skill_set(&set).is_empty());
     }
 

--- a/src/taxonomy.rs
+++ b/src/taxonomy.rs
@@ -103,10 +103,13 @@ pub fn tags_for_yara_rule(rule_name: &str) -> Vec<OwaspTag> {
         | "DomainOutlier"
         | "MixedSecuritySchemes" => vec![OwaspTag::new("MCP05")],
 
-        // skill_prompt_injection.yar — three rules covering invisible-unicode
-        // hiding, mandatory-execution coercion, and indirect prompt injection
+        // skill_prompt_injection.yar — four rules covering classic
+        // instruction-override signatures, invisible-unicode hiding,
+        // mandatory-execution coercion, and indirect prompt injection
         // via untrusted external content.
-        "UnicodeSteganography" | "IndirectPromptInjection" => vec![OwaspTag::new("MCP01")],
+        "PromptInjectionSignature" | "UnicodeSteganography" | "IndirectPromptInjection" => {
+            vec![OwaspTag::new("MCP01")]
+        }
         "CoerciveInjection" => vec![OwaspTag::new("MCP01"), OwaspTag::new("MCP02")],
 
         // skill_authority.yar — autonomy bypass + capability inflation.
@@ -159,6 +162,7 @@ mod tests {
             "CrossDomainContamination",
             "DomainOutlier",
             "MixedSecuritySchemes",
+            "PromptInjectionSignature",
             "UnicodeSteganography",
             "CoerciveInjection",
             "IndirectPromptInjection",

--- a/src/taxonomy.rs
+++ b/src/taxonomy.rs
@@ -103,6 +103,16 @@ pub fn tags_for_yara_rule(rule_name: &str) -> Vec<OwaspTag> {
         | "DomainOutlier"
         | "MixedSecuritySchemes" => vec![OwaspTag::new("MCP05")],
 
+        // skill_prompt_injection.yar — three rules covering invisible-unicode
+        // hiding, mandatory-execution coercion, and indirect prompt injection
+        // via untrusted external content.
+        "UnicodeSteganography" | "IndirectPromptInjection" => vec![OwaspTag::new("MCP01")],
+        "CoerciveInjection" => vec![OwaspTag::new("MCP01"), OwaspTag::new("MCP02")],
+
+        // skill_authority.yar — autonomy bypass + capability inflation.
+        "AutonomyAbuse" => vec![OwaspTag::new("MCP03")],
+        "CapabilityInflation" => vec![OwaspTag::new("MCP02"), OwaspTag::new("MCP03")],
+
         _ => Vec::new(),
     }
 }
@@ -149,6 +159,11 @@ mod tests {
             "CrossDomainContamination",
             "DomainOutlier",
             "MixedSecuritySchemes",
+            "UnicodeSteganography",
+            "CoerciveInjection",
+            "IndirectPromptInjection",
+            "AutonomyAbuse",
+            "CapabilityInflation",
         ] {
             assert!(
                 !tags_for_yara_rule(name).is_empty(),

--- a/src/taxonomy.rs
+++ b/src/taxonomy.rs
@@ -143,6 +143,7 @@ pub fn tags_for_yara_rule(rule_name: &str) -> Vec<OwaspTag> {
         "DataExfiltrationGrant" => vec![OwaspTag::new("MCP06"), OwaspTag::new("MCP09")],
         "SkillSensitiveFileReference" => vec![OwaspTag::new("MCP06"), OwaspTag::new("MCP09")],
         "SkillNameCollision" => vec![OwaspTag::new("MCP02"), OwaspTag::new("MCP03")],
+        "SkillEmbeddedPayload" => vec![OwaspTag::new("MCP01"), OwaspTag::new("MCP10")],
 
         _ => Vec::new(),
     }

--- a/src/taxonomy.rs
+++ b/src/taxonomy.rs
@@ -139,8 +139,10 @@ pub fn tags_for_yara_rule(rule_name: &str) -> Vec<OwaspTag> {
         // grants, missing triggers, network-egress tool grants).
         "OverbroadAllowedTools" => vec![OwaspTag::new("MCP03")],
         "VagueSkillTrigger" => vec![OwaspTag::new("MCP02"), OwaspTag::new("MCP03")],
+        "GenericSkillTrigger" => vec![OwaspTag::new("MCP02"), OwaspTag::new("MCP03")],
         "DataExfiltrationGrant" => vec![OwaspTag::new("MCP06"), OwaspTag::new("MCP09")],
         "SkillSensitiveFileReference" => vec![OwaspTag::new("MCP06"), OwaspTag::new("MCP09")],
+        "SkillNameCollision" => vec![OwaspTag::new("MCP02"), OwaspTag::new("MCP03")],
 
         _ => Vec::new(),
     }

--- a/src/taxonomy.rs
+++ b/src/taxonomy.rs
@@ -122,6 +122,7 @@ pub fn tags_for_yara_rule(rule_name: &str) -> Vec<OwaspTag> {
         "OverbroadAllowedTools" => vec![OwaspTag::new("MCP03")],
         "VagueSkillTrigger" => vec![OwaspTag::new("MCP02"), OwaspTag::new("MCP03")],
         "DataExfiltrationGrant" => vec![OwaspTag::new("MCP06"), OwaspTag::new("MCP09")],
+        "SkillSensitiveFileReference" => vec![OwaspTag::new("MCP06"), OwaspTag::new("MCP09")],
 
         _ => Vec::new(),
     }

--- a/src/taxonomy.rs
+++ b/src/taxonomy.rs
@@ -118,9 +118,10 @@ pub fn tags_for_yara_rule(rule_name: &str) -> Vec<OwaspTag> {
 
         // Synthetic findings emitted by the skill parser (src/skills.rs)
         // for structural risks the YARA passes can't see (frontmatter
-        // grants, missing triggers).
+        // grants, missing triggers, network-egress tool grants).
         "OverbroadAllowedTools" => vec![OwaspTag::new("MCP03")],
         "VagueSkillTrigger" => vec![OwaspTag::new("MCP02"), OwaspTag::new("MCP03")],
+        "DataExfiltrationGrant" => vec![OwaspTag::new("MCP06"), OwaspTag::new("MCP09")],
 
         _ => Vec::new(),
     }

--- a/src/taxonomy.rs
+++ b/src/taxonomy.rs
@@ -116,6 +116,12 @@ pub fn tags_for_yara_rule(rule_name: &str) -> Vec<OwaspTag> {
         "AutonomyAbuse" => vec![OwaspTag::new("MCP03")],
         "CapabilityInflation" => vec![OwaspTag::new("MCP02"), OwaspTag::new("MCP03")],
 
+        // Synthetic findings emitted by the skill parser (src/skills.rs)
+        // for structural risks the YARA passes can't see (frontmatter
+        // grants, missing triggers).
+        "OverbroadAllowedTools" => vec![OwaspTag::new("MCP03")],
+        "VagueSkillTrigger" => vec![OwaspTag::new("MCP02"), OwaspTag::new("MCP03")],
+
         _ => Vec::new(),
     }
 }

--- a/src/taxonomy.rs
+++ b/src/taxonomy.rs
@@ -116,6 +116,24 @@ pub fn tags_for_yara_rule(rule_name: &str) -> Vec<OwaspTag> {
         "AutonomyAbuse" => vec![OwaspTag::new("MCP03")],
         "CapabilityInflation" => vec![OwaspTag::new("MCP02"), OwaspTag::new("MCP03")],
 
+        // skill_credential_harvesting.yar — vendor token formats, PEM
+        // private-key blocks, active credential-theft verbs.
+        "SkillCredentialHarvesting" => {
+            vec![OwaspTag::new("MCP06"), OwaspTag::new("MCP09")]
+        }
+
+        // skill_tool_chaining_abuse.yar — credential read + network
+        // egress to known exfil destinations, attacker-named hosts.
+        "SkillToolChainingExfiltration" => {
+            vec![OwaspTag::new("MCP06"), OwaspTag::new("MCP09")]
+        }
+
+        // skill_system_manipulation.yar — destructive ops, privilege
+        // escalation, PATH hijack, critical-file writes.
+        "SkillSystemManipulation" => {
+            vec![OwaspTag::new("MCP03"), OwaspTag::new("MCP04")]
+        }
+
         // Synthetic findings emitted by the skill parser (src/skills.rs)
         // for structural risks the YARA passes can't see (frontmatter
         // grants, missing triggers, network-egress tool grants).
@@ -176,6 +194,9 @@ mod tests {
             "IndirectPromptInjection",
             "AutonomyAbuse",
             "CapabilityInflation",
+            "SkillCredentialHarvesting",
+            "SkillToolChainingExfiltration",
+            "SkillSystemManipulation",
         ] {
             assert!(
                 !tags_for_yara_rule(name).is_empty(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -255,6 +255,16 @@ pub struct ScanResult {
     pub security_issues: Option<SecurityScanResult>,
     pub yara_results: Vec<YaraScanResult>,
     pub errors: Vec<String>,
+    /// Ramparts release version that produced this scan
+    /// (`env!("CARGO_PKG_VERSION")`). Useful for triage when an
+    /// archived JSON / replayed scan turns up months later — the
+    /// reader can correlate detections to a specific scanner build.
+    #[serde(default)]
+    pub ramparts_version: String,
+    /// Short git commit ramparts was built from (e.g. `c70cdce`).
+    /// Empty when built outside a git checkout.
+    #[serde(default)]
+    pub ramparts_commit: String,
     /// IDE source that provided this server configuration
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ide_source: Option<String>,
@@ -306,6 +316,8 @@ impl ScanResult {
             security_issues: None,
             yara_results: Vec::new(),
             errors: Vec::new(),
+            ramparts_version: env!("CARGO_PKG_VERSION").to_string(),
+            ramparts_commit: env!("GIT_COMMIT_SHORT").to_string(),
             ide_source: None,
             llm_prompts: None,
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -24,7 +24,10 @@ pub struct YaraRuleMetadata {
     pub category: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub confidence: Option<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    // `default` is required so `replay` can read JSON we previously wrote
+    // — `skip_serializing_if` omits the field when empty, and without
+    // `default` deserialization fails on the missing key.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -153,59 +153,45 @@ fn is_skill_scan(result: &ScanResult) -> bool {
     result.url.starts_with("skills:")
 }
 
-/// One-line `Ramparts: <version> (<commit>)` header for scan-result
-/// rendering. The banner already shows version + commit at startup,
-/// but the banner is suppressed for machine-readable formats and
-/// scrolls off the top for long human-readable scans. Putting it on
-/// the result itself means a copy-pasted scan output always carries
-/// the scanner build that produced it.
-///
-/// Old JSON scans replayed via `ramparts replay` may have empty
-/// `ramparts_version`/`ramparts_commit` fields (added later, with
-/// `#[serde(default)]`). Handle gracefully.
-fn format_ramparts_version(result: &ScanResult) -> String {
-    let version = if result.ramparts_version.is_empty() {
-        "(unknown)"
-    } else {
-        result.ramparts_version.as_str()
-    };
-    if result.ramparts_commit.is_empty() {
-        format!("Ramparts: {version}")
-    } else {
-        format!("Ramparts: {version} ({})", result.ramparts_commit)
-    }
-}
-
 /// Skill-aware terminal renderer. Replaces the live-MCP framing
 /// (tools / resources / "Unknown MCP Server") with per-skill grouping
 /// (skill name + source path + findings + severity counts).
+///
+/// Layout (Option C — verdict-first, compact chrome):
+///
+///   Path: <stripped of `skills:`>
+///   ✅ N skills, M findings (X HIGH, Y MEDIUM) · 1.2s
+///
+///   ⚠️ skill_a (2 findings)
+///        source: ...
+///        [HIGH] RuleName [OWASP: ...]
+///               wrapped description
+///
+///   ✅ skill_b
+///
+///   Cross-Skill Findings
+///      [MEDIUM] SkillNameCollision [OWASP: ...]
+///               ...
+///
+///   Tip: --json | --sarif | --report
 fn print_skill_table_result(result: &ScanResult, _detailed: bool) {
     use crate::security::SecurityIssue;
     use crate::types::YaraScanResult;
 
-    println!("Ramparts Agent Skill Scan");
+    /// Cross-skill findings have semantics that bind to multiple skill
+    /// files at once (collision across paths, etc.). Rendering them
+    /// under a single skill would either duplicate (every colliding
+    /// file shows the same finding) or confuse (only one of N
+    /// colliding files shows it). Carve them out for a dedicated
+    /// section after the per-skill loop.
+    fn is_cross_skill_rule(rule_name: &str) -> bool {
+        matches!(rule_name, "SkillNameCollision")
+    }
 
     // Strip the `skills:` prefix so the displayed path looks normal.
     // Multi-root scans produce `skills:[a,b](N files)` — show that
     // verbatim minus the prefix.
     let display_url = result.url.strip_prefix("skills:").unwrap_or(&result.url);
-    println!("Path: {}", display_url.blue());
-    println!("{}", format_ramparts_version(result));
-    println!("Status: {}", format_status(&result.status));
-    println!("Response Time: {}ms", result.response_time_ms);
-    println!(
-        "Timestamp: {}",
-        result.timestamp.format("%Y-%m-%d %H:%M:%S UTC")
-    );
-
-    if !result.errors.is_empty() {
-        println!("\n{}", "Errors".bold().red());
-        for e in &result.errors {
-            println!("  • {e}");
-        }
-    }
-
-    let prompt_count = result.prompts.len();
 
     // Findings per-skill: yara_results target_name + prompt-issue prompt_name.
     let yara_findings: Vec<&YaraScanResult> = result
@@ -219,17 +205,86 @@ fn print_skill_table_result(result: &ScanResult, _detailed: bool) {
         .as_ref()
         .map_or(&[][..], |s| s.prompt_issues.as_slice());
 
+    let cross_findings: Vec<&YaraScanResult> = yara_findings
+        .iter()
+        .copied()
+        .filter(|y| is_cross_skill_rule(&y.rule_name))
+        .collect();
+
+    // First pass: compute totals + per-severity breakdown for the
+    // verdict line. We render the verdict at the top so the user sees
+    // pass/fail immediately rather than after scrolling through
+    // per-skill rows.
     let mut total_findings = 0_usize;
     let mut sev_counts = std::collections::BTreeMap::<String, usize>::new();
+    let mut bump = |sev: &str| {
+        let s = sev.to_uppercase();
+        *sev_counts.entry(s).or_insert(0) += 1;
+        total_findings += 1;
+    };
+    for prompt in &result.prompts {
+        for y in yara_findings
+            .iter()
+            .filter(|y| y.target_name == prompt.name && !is_cross_skill_rule(&y.rule_name))
+        {
+            bump(
+                y.rule_metadata
+                    .as_ref()
+                    .and_then(|m| m.severity.as_deref())
+                    .unwrap_or("INFO"),
+            );
+        }
+        for issue in prompt_issues
+            .iter()
+            .filter(|i| i.prompt_name.as_deref() == Some(&prompt.name))
+        {
+            bump(&issue.severity);
+        }
+    }
+    for y in &cross_findings {
+        bump(
+            y.rule_metadata
+                .as_ref()
+                .and_then(|m| m.severity.as_deref())
+                .unwrap_or("INFO"),
+        );
+    }
 
-    /// Cross-skill findings have semantics that bind to multiple skill
-    /// files at once (collision across paths, etc.). Rendering them
-    /// under a single skill would either duplicate (every colliding
-    /// file shows the same finding) or confuse (only one of N
-    /// colliding files shows it). Carve them out for a dedicated
-    /// section after the per-skill loop.
-    fn is_cross_skill_rule(rule_name: &str) -> bool {
-        matches!(rule_name, "SkillNameCollision")
+    // Verdict line. ✅ when 0 findings, ⚠️ otherwise; ❌ when the scan
+    // itself failed (errors recorded). Severity breakdown only when
+    // there's at least one finding.
+    let prompt_count = result.prompts.len();
+    let secs = result.response_time_ms as f64 / 1000.0;
+    let icon = if !result.errors.is_empty() {
+        "❌"
+    } else if total_findings == 0 {
+        "✅"
+    } else {
+        "⚠️"
+    };
+    let breakdown = if sev_counts.is_empty() {
+        String::new()
+    } else {
+        // Render in fixed severity order so output is stable.
+        let order = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"];
+        let parts: Vec<String> = order
+            .iter()
+            .filter_map(|k| sev_counts.get(*k).map(|v| format!("{v} {k}")))
+            .collect();
+        format!(" ({})", parts.join(", "))
+    };
+    println!("Path: {}", display_url.blue());
+    println!(
+        "{icon} {prompt_count} skill{} scanned, {total_findings} finding{}{breakdown} · {secs:.1}s",
+        if prompt_count == 1 { "" } else { "s" },
+        if total_findings == 1 { "" } else { "s" }
+    );
+
+    if !result.errors.is_empty() {
+        println!("\n{}", "Errors".bold().red());
+        for e in &result.errors {
+            println!("  • {e}");
+        }
     }
 
     for prompt in &result.prompts {
@@ -244,7 +299,6 @@ fn print_skill_table_result(result: &ScanResult, _detailed: bool) {
             .collect();
 
         let count = yara_for_skill.len() + llm_for_skill.len();
-        total_findings += count;
 
         let head = if count == 0 {
             format!("  {} {}", "✅".green(), prompt.name.bold())
@@ -269,6 +323,10 @@ fn print_skill_table_result(result: &ScanResult, _detailed: bool) {
             println!("    {} {}", "source:".dimmed(), src.dimmed());
         }
 
+        // Counts already accumulated in the upfront verdict pass;
+        // these loops only render. Severity colorization comes from
+        // the rule metadata (YARA findings) or the SecurityIssue
+        // (LLM findings).
         for y in &yara_for_skill {
             let sev = y
                 .rule_metadata
@@ -276,34 +334,14 @@ fn print_skill_table_result(result: &ScanResult, _detailed: bool) {
                 .and_then(|m| m.severity.as_deref())
                 .unwrap_or("INFO")
                 .to_uppercase();
-            *sev_counts.entry(sev.clone()).or_insert(0) += 1;
-            let sev_disp = match sev.as_str() {
-                "CRITICAL" => sev.red().bold(),
-                "HIGH" => sev.yellow().bold(),
-                "MEDIUM" => sev.yellow(),
-                "LOW" => sev.cyan(),
-                _ => sev.normal(),
-            };
-            let owasp = if y.owasp_tags.is_empty() {
-                String::new()
-            } else {
-                format!(
-                    " [OWASP: {}]",
-                    y.owasp_tags
-                        .iter()
-                        .map(|t| t.id.as_str())
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                )
-            };
+            let sev_disp = colored_severity(&sev);
+            let owasp = format_owasp_tags(&y.owasp_tags);
             println!("    [{sev_disp}] {}{owasp}", y.rule_name.bold());
             if let Some(desc) = y
                 .rule_metadata
                 .as_ref()
                 .and_then(|m| m.description.as_deref())
             {
-                // Wrap long descriptions; one-paragraph indent so they
-                // sit visually under the rule line.
                 for line in wrap_for_terminal(desc, 90) {
                     println!("        {line}");
                 }
@@ -312,27 +350,8 @@ fn print_skill_table_result(result: &ScanResult, _detailed: bool) {
 
         for issue in &llm_for_skill {
             let sev = issue.severity.to_uppercase();
-            *sev_counts.entry(sev.clone()).or_insert(0) += 1;
-            let sev_disp = match sev.as_str() {
-                "CRITICAL" => sev.red().bold(),
-                "HIGH" => sev.yellow().bold(),
-                "MEDIUM" => sev.yellow(),
-                "LOW" => sev.cyan(),
-                _ => sev.normal(),
-            };
-            let owasp = if issue.owasp_tags.is_empty() {
-                String::new()
-            } else {
-                format!(
-                    " [OWASP: {}]",
-                    issue
-                        .owasp_tags
-                        .iter()
-                        .map(|t| t.id.as_str())
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                )
-            };
+            let sev_disp = colored_severity(&sev);
+            let owasp = format_owasp_tags(&issue.owasp_tags);
             // SecurityIssueType doesn't implement Display, so use Debug
             // (the variant names like `PromptInjection` are already
             // user-readable).
@@ -349,11 +368,6 @@ fn print_skill_table_result(result: &ScanResult, _detailed: bool) {
     // Cross-skill section — findings that bind to multiple skills,
     // not any single one (currently just SkillNameCollision; add
     // future cross-skill rules to `is_cross_skill_rule`).
-    let cross_findings: Vec<&YaraScanResult> = result
-        .yara_results
-        .iter()
-        .filter(|y| y.target_type.as_str() == "prompt" && is_cross_skill_rule(&y.rule_name))
-        .collect();
     if !cross_findings.is_empty() {
         println!("\n{}", "Cross-Skill Findings".bold());
         for y in &cross_findings {
@@ -363,27 +377,8 @@ fn print_skill_table_result(result: &ScanResult, _detailed: bool) {
                 .and_then(|m| m.severity.as_deref())
                 .unwrap_or("INFO")
                 .to_uppercase();
-            *sev_counts.entry(sev.clone()).or_insert(0) += 1;
-            total_findings += 1;
-            let sev_disp = match sev.as_str() {
-                "CRITICAL" => sev.red().bold(),
-                "HIGH" => sev.yellow().bold(),
-                "MEDIUM" => sev.yellow(),
-                "LOW" => sev.cyan(),
-                _ => sev.normal(),
-            };
-            let owasp = if y.owasp_tags.is_empty() {
-                String::new()
-            } else {
-                format!(
-                    " [OWASP: {}]",
-                    y.owasp_tags
-                        .iter()
-                        .map(|t| t.id.as_str())
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                )
-            };
+            let sev_disp = colored_severity(&sev);
+            let owasp = format_owasp_tags(&y.owasp_tags);
             println!("  [{sev_disp}] {}{owasp}", y.rule_name.bold());
             if let Some(desc) = y
                 .rule_metadata
@@ -397,30 +392,57 @@ fn print_skill_table_result(result: &ScanResult, _detailed: bool) {
         }
     }
 
-    // Summary line.
-    println!("\n{}", "Summary".bold());
-    println!("  • Skills scanned: {prompt_count}");
-    println!("  • Total findings: {total_findings}");
-    if !sev_counts.is_empty() {
-        let breakdown = sev_counts
-            .iter()
-            .map(|(k, v)| format!("{k}={v}"))
-            .collect::<Vec<_>>()
-            .join(", ");
-        println!("  • Severity:       {breakdown}");
-    }
-
-    // YARA pre-scan summary if present (informational — confirms which
-    // rules ran).
-    if let Some(summary) = result
+    // Footer: discoverability hints + a one-line scan-completion
+    // marker. Output formats are surfaced here so the user knows how
+    // to pipe to CI / get richer detail without `--help`-spelunking.
+    let yara_rules = result
         .yara_results
         .iter()
         .find(|y| y.rule_name == "YARA_PRE_SCAN_SUMMARY")
-    {
-        if let Some(rules) = &summary.rules_executed {
-            println!("  • YARA rules:    {} executed", rules.len());
-        }
+        .and_then(|s| s.rules_executed.as_ref())
+        .map_or(0, std::vec::Vec::len);
+    println!();
+    println!(
+        "  {} {} YARA rule{} executed",
+        "·".dimmed(),
+        yara_rules,
+        if yara_rules == 1 { "" } else { "s" }
+    );
+    println!(
+        "  {} Tip: {}",
+        "·".dimmed(),
+        "--json | --sarif | --report".dimmed()
+    );
+}
+
+/// Map a severity label (`CRITICAL` / `HIGH` / `MEDIUM` / `LOW`) to
+/// a color-styled `ColoredString`. Pulled into a helper so the
+/// skill renderer's three rendering sites (per-skill YARA, per-skill
+/// LLM, cross-skill YARA) all colorize identically.
+fn colored_severity(sev: &str) -> colored::ColoredString {
+    match sev {
+        "CRITICAL" => sev.red().bold(),
+        "HIGH" => sev.yellow().bold(),
+        "MEDIUM" => sev.yellow(),
+        "LOW" => sev.cyan(),
+        _ => sev.normal(),
     }
+}
+
+/// Render `[OWASP: MCP06, MCP09]` if any tags are present, empty
+/// string otherwise. Same layout as the LLM-finding tag list — kept
+/// in one place so both sites use identical formatting.
+fn format_owasp_tags(tags: &[crate::taxonomy::OwaspTag]) -> String {
+    if tags.is_empty() {
+        return String::new();
+    }
+    format!(
+        " [OWASP: {}]",
+        tags.iter()
+            .map(|t| t.id.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
 }
 
 /// Wrap `text` to lines of at most `width` chars, breaking on word
@@ -1006,9 +1028,12 @@ fn add_errors_info(
 fn print_table_result(result: &ScanResult, detailed: bool) {
     println!("Ramparts MCP Server Scan Result");
 
-    // Server Info
+    // Server Info. Version + commit are NOT printed here — the
+    // startup banner already shows them via `display_banner`. JSON /
+    // raw / SARIF outputs (which suppress the banner) carry the
+    // version on the `ScanResult` shape (`ramparts_version`,
+    // `ramparts_commit`).
     println!("URL: {}", result.url.blue());
-    println!("{}", format_ramparts_version(result));
     println!("Status: {}", format_status(&result.status));
     println!("Response Time: {}ms", result.response_time_ms);
     println!(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2087,15 +2087,36 @@ pub fn generate_markdown_report(results: &[ScanResult]) -> Result<String> {
     let timestamp = Utc::now();
     let mut report = String::new();
 
+    // Title reflects the *current* scanner surface — ramparts scans both
+    // live MCP servers and on-disk agent skill files (`ramparts skills
+    // scan`). Reports may bundle either or both kinds of result depending
+    // on which command produced them; the title is generic-enough to
+    // cover the mixed case.
+    let scanner_label = "Ramparts MCP & Agent Skill Scanner";
+
     // Header
-    writeln!(report, "# MCP Security Scan Report")?;
+    writeln!(report, "# {scanner_label} Report")?;
     writeln!(report)?;
     writeln!(
         report,
         "**Generated:** {}",
         timestamp.format("%Y-%m-%d %H:%M:%S UTC")
     )?;
-    writeln!(report, "**Scanner:** Ramparts MCP Security Scanner")?;
+    writeln!(report, "**Scanner:** {scanner_label}")?;
+    // Carry the build identity so a reader of an archived report
+    // months later can correlate findings to a specific scanner build.
+    // First scan's `ramparts_version`/`commit` are representative — all
+    // results in a single report come from the same scanner invocation.
+    if let Some(first) = results.first() {
+        if !first.ramparts_version.is_empty() {
+            let build = if first.ramparts_commit.is_empty() {
+                format!("v{}", first.ramparts_version)
+            } else {
+                format!("v{} ({})", first.ramparts_version, first.ramparts_commit)
+            };
+            writeln!(report, "**Build:** {build}")?;
+        }
+    }
     writeln!(report)?;
 
     // Executive Summary

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -115,6 +115,24 @@ pub mod performance {
 // ============================================================================
 
 pub fn print_result(result: &ScanResult, format: &str, detailed: bool) {
+    // Skill scans go through their own renderer for terminal/text formats —
+    // the live-MCP renderer's "Tools/Resources" framing collapses to garbage
+    // ("Tools scanned: 0", "Unknown MCP Server") on a skill result whose
+    // primary content is `prompts`. JSON / SARIF / raw stay shape-identical
+    // regardless of source so machine consumers see the same fields.
+    if is_skill_scan(result) {
+        match format.to_lowercase().as_str() {
+            "json" => print_json_result(result),
+            "raw" => print_raw_json_result(result),
+            "sarif" => print_sarif_result(result),
+            "text" | "table" => print_skill_table_result(result, detailed),
+            _ => {
+                eprintln!("Unknown format: {format}. Using skill table format.");
+                print_skill_table_result(result, detailed);
+            }
+        }
+        return;
+    }
     match format.to_lowercase().as_str() {
         "json" => print_json_result(result),
         "table" => print_table_result(result, detailed),
@@ -126,6 +144,283 @@ pub fn print_result(result: &ScanResult, format: &str, detailed: bool) {
             print_table_result(result, detailed);
         }
     }
+}
+
+/// True when this `ScanResult` came from `ramparts skills scan` /
+/// `skills scan-config`. The handler stamps the URL with the
+/// `skills:` scheme so renderers can branch on it.
+fn is_skill_scan(result: &ScanResult) -> bool {
+    result.url.starts_with("skills:")
+}
+
+/// Skill-aware terminal renderer. Replaces the live-MCP framing
+/// (tools / resources / "Unknown MCP Server") with per-skill grouping
+/// (skill name + source path + findings + severity counts).
+fn print_skill_table_result(result: &ScanResult, _detailed: bool) {
+    use crate::security::SecurityIssue;
+    use crate::types::YaraScanResult;
+
+    println!("Ramparts Agent Skill Scan");
+
+    // Strip the `skills:` prefix so the displayed path looks normal.
+    // Multi-root scans produce `skills:[a,b](N files)` — show that
+    // verbatim minus the prefix.
+    let display_url = result.url.strip_prefix("skills:").unwrap_or(&result.url);
+    println!("Path: {}", display_url.blue());
+    println!("Status: {}", format_status(&result.status));
+    println!("Response Time: {}ms", result.response_time_ms);
+    println!(
+        "Timestamp: {}",
+        result.timestamp.format("%Y-%m-%d %H:%M:%S UTC")
+    );
+
+    if !result.errors.is_empty() {
+        println!("\n{}", "Errors".bold().red());
+        for e in &result.errors {
+            println!("  • {e}");
+        }
+    }
+
+    let prompt_count = result.prompts.len();
+
+    // Findings per-skill: yara_results target_name + prompt-issue prompt_name.
+    let yara_findings: Vec<&YaraScanResult> = result
+        .yara_results
+        .iter()
+        .filter(|y| y.target_type.as_str() == "prompt")
+        .collect();
+
+    let prompt_issues: &[SecurityIssue] = result
+        .security_issues
+        .as_ref()
+        .map_or(&[][..], |s| s.prompt_issues.as_slice());
+
+    let mut total_findings = 0_usize;
+    let mut sev_counts = std::collections::BTreeMap::<String, usize>::new();
+
+    /// Cross-skill findings have semantics that bind to multiple skill
+    /// files at once (collision across paths, etc.). Rendering them
+    /// under a single skill would either duplicate (every colliding
+    /// file shows the same finding) or confuse (only one of N
+    /// colliding files shows it). Carve them out for a dedicated
+    /// section after the per-skill loop.
+    fn is_cross_skill_rule(rule_name: &str) -> bool {
+        matches!(rule_name, "SkillNameCollision")
+    }
+
+    for prompt in &result.prompts {
+        let yara_for_skill: Vec<&&YaraScanResult> = yara_findings
+            .iter()
+            .filter(|y| y.target_name == prompt.name)
+            .filter(|y| !is_cross_skill_rule(&y.rule_name))
+            .collect();
+        let llm_for_skill: Vec<&SecurityIssue> = prompt_issues
+            .iter()
+            .filter(|i| i.prompt_name.as_deref() == Some(&prompt.name))
+            .collect();
+
+        let count = yara_for_skill.len() + llm_for_skill.len();
+        total_findings += count;
+
+        let head = if count == 0 {
+            format!("  {} {}", "✅".green(), prompt.name.bold())
+        } else {
+            format!(
+                "  {} {} ({} finding{})",
+                "⚠️".yellow(),
+                prompt.name.bold(),
+                count,
+                if count == 1 { "" } else { "s" },
+            )
+        };
+        println!("\n{head}");
+
+        // Best-effort source path: heuristic findings carry the path
+        // in `context = "source: <path>"`. Show it under the skill name
+        // so the user can navigate to the file.
+        if let Some(src) = yara_for_skill
+            .iter()
+            .find_map(|y| y.context.strip_prefix("source: "))
+        {
+            println!("    {} {}", "source:".dimmed(), src.dimmed());
+        }
+
+        for y in &yara_for_skill {
+            let sev = y
+                .rule_metadata
+                .as_ref()
+                .and_then(|m| m.severity.as_deref())
+                .unwrap_or("INFO")
+                .to_uppercase();
+            *sev_counts.entry(sev.clone()).or_insert(0) += 1;
+            let sev_disp = match sev.as_str() {
+                "CRITICAL" => sev.red().bold(),
+                "HIGH" => sev.yellow().bold(),
+                "MEDIUM" => sev.yellow(),
+                "LOW" => sev.cyan(),
+                _ => sev.normal(),
+            };
+            let owasp = if y.owasp_tags.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    " [OWASP: {}]",
+                    y.owasp_tags
+                        .iter()
+                        .map(|t| t.id.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            };
+            println!("    [{sev_disp}] {}{owasp}", y.rule_name.bold());
+            if let Some(desc) = y
+                .rule_metadata
+                .as_ref()
+                .and_then(|m| m.description.as_deref())
+            {
+                // Wrap long descriptions; one-paragraph indent so they
+                // sit visually under the rule line.
+                for line in wrap_for_terminal(desc, 90) {
+                    println!("        {line}");
+                }
+            }
+        }
+
+        for issue in &llm_for_skill {
+            let sev = issue.severity.to_uppercase();
+            *sev_counts.entry(sev.clone()).or_insert(0) += 1;
+            let sev_disp = match sev.as_str() {
+                "CRITICAL" => sev.red().bold(),
+                "HIGH" => sev.yellow().bold(),
+                "MEDIUM" => sev.yellow(),
+                "LOW" => sev.cyan(),
+                _ => sev.normal(),
+            };
+            let owasp = if issue.owasp_tags.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    " [OWASP: {}]",
+                    issue
+                        .owasp_tags
+                        .iter()
+                        .map(|t| t.id.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            };
+            // SecurityIssueType doesn't implement Display, so use Debug
+            // (the variant names like `PromptInjection` are already
+            // user-readable).
+            println!(
+                "    [{sev_disp}] {}{owasp} (LLM)",
+                format!("{:?}", issue.issue_type).bold()
+            );
+            for line in wrap_for_terminal(&issue.message, 90) {
+                println!("        {line}");
+            }
+        }
+    }
+
+    // Cross-skill section — findings that bind to multiple skills,
+    // not any single one (currently just SkillNameCollision; add
+    // future cross-skill rules to `is_cross_skill_rule`).
+    let cross_findings: Vec<&YaraScanResult> = result
+        .yara_results
+        .iter()
+        .filter(|y| y.target_type.as_str() == "prompt" && is_cross_skill_rule(&y.rule_name))
+        .collect();
+    if !cross_findings.is_empty() {
+        println!("\n{}", "Cross-Skill Findings".bold());
+        for y in &cross_findings {
+            let sev = y
+                .rule_metadata
+                .as_ref()
+                .and_then(|m| m.severity.as_deref())
+                .unwrap_or("INFO")
+                .to_uppercase();
+            *sev_counts.entry(sev.clone()).or_insert(0) += 1;
+            total_findings += 1;
+            let sev_disp = match sev.as_str() {
+                "CRITICAL" => sev.red().bold(),
+                "HIGH" => sev.yellow().bold(),
+                "MEDIUM" => sev.yellow(),
+                "LOW" => sev.cyan(),
+                _ => sev.normal(),
+            };
+            let owasp = if y.owasp_tags.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    " [OWASP: {}]",
+                    y.owasp_tags
+                        .iter()
+                        .map(|t| t.id.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            };
+            println!("  [{sev_disp}] {}{owasp}", y.rule_name.bold());
+            if let Some(desc) = y
+                .rule_metadata
+                .as_ref()
+                .and_then(|m| m.description.as_deref())
+            {
+                for line in wrap_for_terminal(desc, 90) {
+                    println!("      {line}");
+                }
+            }
+        }
+    }
+
+    // Summary line.
+    println!("\n{}", "Summary".bold());
+    println!("  • Skills scanned: {prompt_count}");
+    println!("  • Total findings: {total_findings}");
+    if !sev_counts.is_empty() {
+        let breakdown = sev_counts
+            .iter()
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        println!("  • Severity:       {breakdown}");
+    }
+
+    // YARA pre-scan summary if present (informational — confirms which
+    // rules ran).
+    if let Some(summary) = result
+        .yara_results
+        .iter()
+        .find(|y| y.rule_name == "YARA_PRE_SCAN_SUMMARY")
+    {
+        if let Some(rules) = &summary.rules_executed {
+            println!("  • YARA rules:    {} executed", rules.len());
+        }
+    }
+}
+
+/// Wrap `text` to lines of at most `width` chars, breaking on word
+/// boundaries. Single-purpose helper for the skill renderer; not
+/// internationalized (skill content is overwhelmingly English in
+/// practice and we don't want a `unicode-segmentation` dep here).
+fn wrap_for_terminal(text: &str, width: usize) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut current = String::new();
+    for word in text.split_whitespace() {
+        if current.is_empty() {
+            current.push_str(word);
+        } else if current.len() + 1 + word.len() <= width {
+            current.push(' ');
+            current.push_str(word);
+        } else {
+            out.push(std::mem::take(&mut current));
+            current.push_str(word);
+        }
+    }
+    if !current.is_empty() {
+        out.push(current);
+    }
+    out
 }
 
 fn print_sarif_result(result: &ScanResult) {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -153,6 +153,29 @@ fn is_skill_scan(result: &ScanResult) -> bool {
     result.url.starts_with("skills:")
 }
 
+/// One-line `Ramparts: <version> (<commit>)` header for scan-result
+/// rendering. The banner already shows version + commit at startup,
+/// but the banner is suppressed for machine-readable formats and
+/// scrolls off the top for long human-readable scans. Putting it on
+/// the result itself means a copy-pasted scan output always carries
+/// the scanner build that produced it.
+///
+/// Old JSON scans replayed via `ramparts replay` may have empty
+/// `ramparts_version`/`ramparts_commit` fields (added later, with
+/// `#[serde(default)]`). Handle gracefully.
+fn format_ramparts_version(result: &ScanResult) -> String {
+    let version = if result.ramparts_version.is_empty() {
+        "(unknown)"
+    } else {
+        result.ramparts_version.as_str()
+    };
+    if result.ramparts_commit.is_empty() {
+        format!("Ramparts: {version}")
+    } else {
+        format!("Ramparts: {version} ({})", result.ramparts_commit)
+    }
+}
+
 /// Skill-aware terminal renderer. Replaces the live-MCP framing
 /// (tools / resources / "Unknown MCP Server") with per-skill grouping
 /// (skill name + source path + findings + severity counts).
@@ -167,6 +190,7 @@ fn print_skill_table_result(result: &ScanResult, _detailed: bool) {
     // verbatim minus the prefix.
     let display_url = result.url.strip_prefix("skills:").unwrap_or(&result.url);
     println!("Path: {}", display_url.blue());
+    println!("{}", format_ramparts_version(result));
     println!("Status: {}", format_status(&result.status));
     println!("Response Time: {}ms", result.response_time_ms);
     println!(
@@ -984,6 +1008,7 @@ fn print_table_result(result: &ScanResult, detailed: bool) {
 
     // Server Info
     println!("URL: {}", result.url.blue());
+    println!("{}", format_ramparts_version(result));
     println!("Status: {}", format_status(&result.status));
     println!("Response Time: {}ms", result.response_time_ms);
     println!(


### PR DESCRIPTION
## Summary

New `ramparts skills` subcommand for scanning AI agent skills (Claude Code custom slash commands, Cursor agent skills, generic markdown skill repos).

Closes #107.

Stacked on **#104** — review/merge that one first; this PR's diff is relative to #104's branch.

### Why

Skills are markdown files containing prompt instructions an agent loads and executes by name. They share a threat model with MCP prompts (untrusted instructions an agent may follow), so the existing security pipeline (LLM analysis, YARA pre/post scan, OWASP MCP Top 10 tagging, terminal/JSON/SARIF rendering) applies directly. This PR adds the format parser and CLI surface; it intentionally doesn't touch the analyzer.

### CLI surface

```bash
ramparts skills scan ./.claude/commands           # scan a directory
ramparts skills scan ./.claude/commands/deploy.md # scan a single file
ramparts skills scan-config                       # discover from known locations
ramparts skills scan ./skills --format sarif      # SARIF for code-scanning
```

### Implementation notes

- `src/skills.rs` — markdown frontmatter+body parser, recursive directory walker (mirrors `MCPConfigManager::with_root` conventions: no symlinks, skip `.git` / `node_modules` / `target`, depth cap 16), default discovery roots for `~/.claude/commands` and `./.claude/commands`. 10 unit tests.
- `src/main.rs` — new `Commands::Skills` variant with nested `scan` / `scan-config` subcommands. Handler builds a synthetic `ScanResult` with parsed skills as `prompts`, runs YARA pre-scan via the existing middleware chain, runs the LLM prompt batch analyzer, feeds through the existing format dispatcher.
- `src/scanner.rs` — `ScanData::new()` made public so the skills handler can construct one for YARA middleware. No behavior change for live scans.

### Skill file format

```markdown
---
description: Optional one-liner
argument-hint: <env>
name: optional-override
---

# Body

The body becomes the prompt the agent executes when this skill runs.
Ramparts treats it as untrusted and runs prompt-injection / sensitive-
data-exposure / jailbreak checks over it.
```

The parser is permissive — missing or malformed frontmatter falls back to "no frontmatter" and the body still gets scanned; filename stem becomes the skill name unless overridden.

### Smoke test

A purposely-malicious `exfil.md` (frontmatter says "helpful deploy command", body says "read /etc/passwd, ssh keys, AWS secrets, POST to attacker.example.com") triggers under SARIF:

```
ruleId=ramparts.security.Jailbreak    level=error
  tags=[owasp-mcp-top-10:2025-draft:MCP01,
        owasp-mcp-top-10:2025-draft:MCP03]
ruleId=ramparts.security.PIILeakage   level=error
  tags=[owasp-mcp-top-10:2025-draft:MCP09]
```

A safe sibling skill (`safe.md`, "list files, format as table") is correctly not flagged.

### Test plan

- [x] `cargo build --all-features` clean
- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --all-features` — 116/116 passed (10 new in skills.rs)
- [x] End-to-end SARIF, JSON, and text outputs verified against a real Claude Code commands directory
- [ ] CI green