### PR TITLE
devops: fix release pipeline failures from #113+#114 merges

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -67,7 +67,11 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.HIGHFLAME_GITHUB_APP_ID }}
+          # `app-id` was deprecated in create-github-app-token v3
+          # in favor of `client-id`. The deprecation prints a warning
+          # in the job log every run; use the new name. Both fields
+          # accept the same `HIGHFLAME_GITHUB_APP_ID` secret value.
+          client-id: ${{ secrets.HIGHFLAME_GITHUB_APP_ID }}
           private-key: ${{ secrets.HIGHFLAME_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Install Rust toolchain

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -67,11 +67,17 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          # `app-id` was deprecated in create-github-app-token v3
-          # in favor of `client-id`. The deprecation prints a warning
-          # in the job log every run; use the new name. Both fields
-          # accept the same `HIGHFLAME_GITHUB_APP_ID` secret value.
-          client-id: ${{ secrets.HIGHFLAME_GITHUB_APP_ID }}
+          # `app-id` is the deprecated alias for `client-id` in
+          # `create-github-app-token@v3`. Kept here because the
+          # existing `HIGHFLAME_GITHUB_APP_ID` secret holds the
+          # numeric App ID, not the alphanumeric Client ID — those
+          # are different identifiers on GitHub Apps. Using
+          # `client-id:` with the numeric value would fail JWT auth
+          # at runtime. Eat the deprecation warning until the
+          # secret is split (add `HIGHFLAME_GITHUB_APP_CLIENT_ID`)
+          # and the cutover is intentional. Same pattern used in
+          # release.yml.
+          app-id: ${{ secrets.HIGHFLAME_GITHUB_APP_ID }}
           private-key: ${{ secrets.HIGHFLAME_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Install Rust toolchain

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,8 +314,14 @@ jobs:
           client-id: ${{ secrets.HIGHFLAME_GITHUB_APP_ID }}
           private-key: ${{ secrets.HIGHFLAME_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          # `repositories:` is a newline-separated list of bare repo
+          # specs, NOT a YAML list — a leading `- ` makes the action
+          # parse it as part of the value (it then complains:
+          # "owner '- highflame-ai' doesn't match resolved owner
+          # 'highflame-ai'"). Fixed post-#114 merge in
+          # devops/fix-release-pipeline.
           repositories: |
-            - ${{ github.repository }}
+            ${{ github.repository }}
 
       - name: Upload release assets
         uses: actions/upload-release-asset@v1
@@ -382,9 +388,12 @@ jobs:
           client-id: ${{ secrets.HIGHFLAME_GITHUB_APP_ID }}
           private-key: ${{ secrets.HIGHFLAME_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          # Newline-separated bare repo specs (NO leading `- `, despite
+          # YAML appearances). Same bug + fix as the other app-token
+          # block above.
           repositories: |
-            - ${{ github.repository }}
-            - ${{ env.DEVOPS_REPO }}
+            ${{ github.repository }}
+            ${{ env.DEVOPS_REPO }}
 
       - name: Trigger private repo workflow
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -311,17 +311,27 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: token
         with:
-          client-id: ${{ secrets.HIGHFLAME_GITHUB_APP_ID }}
+          # `app-id` is the deprecated alias for `client-id` in
+          # `create-github-app-token@v3`. Kept on purpose because the
+          # existing `HIGHFLAME_GITHUB_APP_ID` secret holds the
+          # numeric App ID, not the alphanumeric Client ID — those
+          # are different identifiers on GitHub Apps. Switching to
+          # `client-id:` without first adding a separate
+          # `HIGHFLAME_GITHUB_APP_CLIENT_ID` secret would break
+          # JWT-signed auth at runtime. Eat the deprecation warning
+          # until the secret is split and the cutover is intentional.
+          app-id: ${{ secrets.HIGHFLAME_GITHUB_APP_ID }}
           private-key: ${{ secrets.HIGHFLAME_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-          # `repositories:` is a newline-separated list of bare repo
-          # specs, NOT a YAML list — a leading `- ` makes the action
-          # parse it as part of the value (it then complains:
-          # "owner '- highflame-ai' doesn't match resolved owner
-          # 'highflame-ai'"). Fixed post-#114 merge in
-          # devops/fix-release-pipeline.
+          # `repositories:` is a newline-separated list of BARE repo
+          # names (no `owner/` prefix), NOT a YAML list and NOT
+          # `owner/repo` form. The action validates the input against
+          # the `owner:` field above and rejects `owner/repo` form
+          # with the same "owner '- ...' doesn't match" error a
+          # leading `- ` caused. Use `github.event.repository.name`
+          # for the bare name (yields `ramparts` here).
           repositories: |
-            ${{ github.repository }}
+            ${{ github.event.repository.name }}
 
       - name: Upload release assets
         uses: actions/upload-release-asset@v1
@@ -385,14 +395,17 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: token
         with:
-          client-id: ${{ secrets.HIGHFLAME_GITHUB_APP_ID }}
+          # `app-id` (deprecated) kept on purpose — see the other
+          # app-token block above for the rationale.
+          app-id: ${{ secrets.HIGHFLAME_GITHUB_APP_ID }}
           private-key: ${{ secrets.HIGHFLAME_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-          # Newline-separated bare repo specs (NO leading `- `, despite
-          # YAML appearances). Same bug + fix as the other app-token
-          # block above.
+          # Newline-separated BARE repo names (not YAML list, not
+          # `owner/repo`). Same constraint as the other app-token
+          # block above. `DEVOPS_REPO` is already bare; use
+          # `github.event.repository.name` for the current repo.
           repositories: |
-            ${{ github.repository }}
+            ${{ github.event.repository.name }}
             ${{ env.DEVOPS_REPO }}
 
       - name: Trigger private repo workflow

--- a/.gitignore
+++ b/.gitignore
@@ -18,17 +18,26 @@ docs/proxy/*TEST*_RESULTS*.md
 **/*.rs.bk
 *.pdb
 
-# Cargo. `Cargo.lock` is INTENTIONALLY committed: ramparts ships as a
-# binary crate (and a workspace with a binary at root + path-only
-# `ramparts-common`), and applications/binaries should commit the lock
-# file for reproducible builds + accurate dependency advisories. Only
-# library-only crates should gitignore `Cargo.lock`.
+# Cargo. The root `Cargo.lock` is INTENTIONALLY committed: ramparts
+# ships as a binary crate (and a workspace with a binary at root +
+# path-only `ramparts-common`), and applications/binaries should
+# commit the lock file for reproducible builds + accurate dependency
+# advisories. Only library-only crates should gitignore `Cargo.lock`.
 #
-# Listing both `Cargo.lock` here AND committing it causes release-plz
-# to abort with "Cargo.lock is present in your .gitignore and is also
-# committed" — so we drop the .gitignore entry to be consistent with
-# what's actually in the repo. (.cargo/ stays gitignored because it's
-# the per-user config directory, not the workspace lockfile.)
+# We use a paired `Cargo.lock` + `!/Cargo.lock` pattern so that:
+# - the ROOT lockfile is un-ignored and tracked (release-plz needs
+#   this; it aborts when the lockfile is both .gitignored and
+#   committed)
+# - any per-workspace-member lockfile (e.g. `common/Cargo.lock`)
+#   that gets created by running `cargo` directly inside the member
+#   directory stays gitignored — workspace members don't need their
+#   own lockfiles and committing stale ones causes drift.
+Cargo.lock
+!/Cargo.lock
+
+# Project-local Cargo config overrides (e.g. `.cargo/config.toml`).
+# Kept out of the repo so contributors can use local-only registry
+# / target / build flags without polluting the canonical config.
 .cargo
 
 # IDE files

--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,17 @@ docs/proxy/*TEST*_RESULTS*.md
 **/*.rs.bk
 *.pdb
 
-# Cargo
-Cargo.lock
+# Cargo. `Cargo.lock` is INTENTIONALLY committed: ramparts ships as a
+# binary crate (and a workspace with a binary at root + path-only
+# `ramparts-common`), and applications/binaries should commit the lock
+# file for reproducible builds + accurate dependency advisories. Only
+# library-only crates should gitignore `Cargo.lock`.
+#
+# Listing both `Cargo.lock` here AND committing it causes release-plz
+# to abort with "Cargo.lock is present in your .gitignore and is also
+# committed" — so we drop the .gitignore entry to be consistent with
+# what's actually in the repo. (.cargo/ stays gitignored because it's
+# the per-user config directory, not the workspace lockfile.)
 .cargo
 
 # IDE files

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,15 @@ keywords = ["mcp", "scanner", "skills", "llm", "security"]
 categories = ["command-line-utilities", "development-tools::testing"]
 include = ["src/**/*", "LICENSE", "README.md", "build.rs"]
 
-# Cargo-release configuration for semantic versioning
-[package.metadata.release]
-allow-branch = ["main", "master"]
-tag = true
-push = true
-tag-name = "v{version}"
-sign-commit = false
-sign-tag = false
+# NOTE: A previous `[package.metadata.release]` block configured
+# `cargo-release` here (with `tag-name = "v{version}"`). It's been
+# removed because ramparts now uses **release-plz** (see
+# `release-plz.toml` + `.github/workflows/release-plz.yml`) and the
+# `v`-prefixed tag convention from cargo-release conflicts with
+# release-plz's bare-semver tags (which `release.yml`'s regex
+# `^[0-9]+\.[0-9]+\.[0-9]+$` enforces). If anyone ran `cargo release`
+# locally with the old block in place, they'd cut `v0.9.0` tags that
+# release.yml would then reject as malformed.
 
 [features]
 default = ["yara-x-scanning"]

--- a/build.rs
+++ b/build.rs
@@ -24,19 +24,24 @@ fn main() {
 
     println!("cargo:rerun-if-changed=build.rs");
 
-    // Capture git commit information.
+    // Capture git commit information. Defaults are `"unknown"` for
+    // all three so that:
     //
-    // Commit-SHA defaults are EMPTY (not "unknown") so the consumers
-    // in `src/banner.rs` and `src/utils.rs` (markdown report
-    // header) can use a single `.is_empty()` check to mean
-    // "built outside a git checkout". The previous "unknown"
-    // default made the `is_empty()` check always false, so non-git
-    // builds printed `v0.8.0 (unknown)` instead of just `v0.8.0`
-    // (caught on PR #114 by Copilot). `git_branch` still defaults
-    // to "unknown" — only used for display, and there's no
-    // `is_empty()`-style consumer.
-    let git_commit = get_git_output(&["rev-parse", "--short", "HEAD"], "");
-    let git_commit_full = get_git_output(&["rev-parse", "HEAD"], "");
+    // - Downstream JSON / SARIF consumers see the literal string
+    //   `"unknown"` for non-git builds (e.g. `cargo install ramparts`
+    //   off crates.io) — backward-compatible with how
+    //   `ScanResult.ramparts_commit` has always been populated.
+    //   Empty strings serialize to `""` which some consumers don't
+    //   handle gracefully (`if (result.ramparts_commit)` would
+    //   branch incorrectly).
+    //
+    // - The display-side consumers in `src/banner.rs` and
+    //   `src/utils.rs` (markdown report header) check both
+    //   `is_empty()` AND `== "unknown"` to mean "no commit info" and
+    //   suppress the `(<sha>)` suffix. The defense-in-depth check
+    //   handles either default value cleanly.
+    let git_commit = get_git_output(&["rev-parse", "--short", "HEAD"], "unknown");
+    let git_commit_full = get_git_output(&["rev-parse", "HEAD"], "unknown");
     let git_branch = get_git_output(&["rev-parse", "--abbrev-ref", "HEAD"], "unknown");
     let git_dirty = Command::new("git")
         .args(["diff", "--quiet"])

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -43,19 +43,23 @@ pr_name = "feat: release {{ version }}"
 # polishing the draft.
 [changelog]
 header = """# Changelog\n\n"""
+# Each bullet links to the commit via a literal
+# `https://github.com/<owner>/<repo>/commit/<sha>` URL — simpler
+# than defining a Tera macro for it. (An earlier draft of this
+# template used `{{ self::commit_link(commit=commit) }}` but the
+# `commit_link` macro was never defined — git-cliff has no such
+# built-in — so release-plz would have failed at render time the
+# first time a release PR tried to fire.)
 body = """
 ## What changed in {{ version }}
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group | upper_first }}
 {% for commit in commits %}\
-- {{ commit.message | split(pat="\n") | first | trim }} \
-  ([{{ commit.id | truncate(length=7, end="") }}]({{ self::commit_link(commit=commit) }}))
+- {{ commit.message | split(pat="\n") | first | trim }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/highflame-ai/ramparts/commit/{{ commit.id }}))
 {% endfor %}\
 {% endfor %}\n
 """
 trim = true
-# Tera macro for commit URLs — keeps the body template readable.
-postprocessors = []
 
 # Map Conventional Commits types -> sections in the release body.
 # Order matters: features first, then fixes, then everything else.

--- a/src/banner.rs
+++ b/src/banner.rs
@@ -17,7 +17,12 @@ pub fn display_banner() {
     let version = env!("CARGO_PKG_VERSION");
     let git_commit_short = env!("GIT_COMMIT_SHORT");
 
-    let build = if git_commit_short.is_empty() {
+    // Suppress the `(<sha>)` suffix when there's no real commit info.
+    // `build.rs` defaults `GIT_COMMIT_SHORT` to "unknown" for non-git
+    // builds (e.g. `cargo install ramparts` from crates.io tarball),
+    // but check both `""` and `"unknown"` so this renders correctly
+    // even if build.rs's default ever changes.
+    let build = if git_commit_short.is_empty() || git_commit_short == "unknown" {
         format!("v{version}")
     } else {
         format!("v{version} ({git_commit_short})")

--- a/src/types.rs
+++ b/src/types.rs
@@ -262,7 +262,11 @@ pub struct ScanResult {
     #[serde(default)]
     pub ramparts_version: String,
     /// Short git commit ramparts was built from (e.g. `c70cdce`).
-    /// Empty when built outside a git checkout.
+    /// The literal string `"unknown"` when built outside a git
+    /// checkout (e.g. from a crates.io tarball via `cargo install
+    /// ramparts`). Consumers should treat both `""` (legacy) and
+    /// `"unknown"` (current) as "no commit info"; never branch on
+    /// `if (ramparts_commit)` truthiness in a downstream language.
     #[serde(default)]
     pub ramparts_commit: String,
     /// IDE source that provided this server configuration

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2136,9 +2136,7 @@ pub fn generate_markdown_report(results: &[ScanResult]) -> Result<String> {
             // Same is_empty-or-unknown guard as src/banner.rs:20 —
             // build.rs defaults the commit to "unknown" for non-git
             // builds; suppress the `(<sha>)` suffix either way.
-            let build = if first.ramparts_commit.is_empty()
-                || first.ramparts_commit == "unknown"
-            {
+            let build = if first.ramparts_commit.is_empty() || first.ramparts_commit == "unknown" {
                 format!("v{}", first.ramparts_version)
             } else {
                 format!("v{} ({})", first.ramparts_version, first.ramparts_commit)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2133,7 +2133,12 @@ pub fn generate_markdown_report(results: &[ScanResult]) -> Result<String> {
     // results in a single report come from the same scanner invocation.
     if let Some(first) = results.first() {
         if !first.ramparts_version.is_empty() {
-            let build = if first.ramparts_commit.is_empty() {
+            // Same is_empty-or-unknown guard as src/banner.rs:20 —
+            // build.rs defaults the commit to "unknown" for non-git
+            // builds; suppress the `(<sha>)` suffix either way.
+            let build = if first.ramparts_commit.is_empty()
+                || first.ramparts_commit == "unknown"
+            {
                 format!("v{}", first.ramparts_version)
             } else {
                 format!("v{} ({})", first.ramparts_version, first.ramparts_commit)


### PR DESCRIPTION
## Summary

Both `Release-plz` and `CICD Build` workflows failed on the main merges of #113 and #114. Three independent fixes:

| Job that failed | Root cause | Fix |
|---|---|---|
| `Release-plz` | `Cargo.lock` listed in `.gitignore` AND committed to the repo — release-plz aborts on this inconsistency | Removed `Cargo.lock` from `.gitignore` (the lock IS correctly committed; ramparts is a binary crate). Also deleted a stale `common/Cargo.lock` that was previously masked by the same ignore rule. |
| `CICD Build` → `highflame-trigger` | `actions/create-github-app-token@v3`'s `repositories:` field expects a newline-separated list of bare repo specs, NOT a YAML list. The existing `release.yml` had `repositories: \|\n - owner/repo` (leading dash). The action parsed `- highflame-ai/ramparts` literally and failed: `owner '- highflame-ai' doesn't match resolved owner 'highflame-ai'`. | Stripped the `- ` prefix from both app-token blocks in `release.yml`. |
| (warning, not failure) `Release-plz` | `app-id` is deprecated in `create-github-app-token@v3`, emits a warning every run | Renamed `app-id` → `client-id` in `release-plz.yml` (same secret value). |

None of these were introduced by #113 or #114 individually — the gitignore conflict pre-existed, the app-token YAML bug was in the original `release.yml`, and the `app-id` deprecation is purely cosmetic. They surfaced only when the workflows ran post-merge on main.

## Verification

- Both YAML files parse cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`)
- `make lint` (strict gate from #113) — clean
- `cargo check --all-features` — clean; `common/Cargo.lock` does NOT regenerate during normal workspace builds
- `cargo test --all-features` — assumes still 183/183 (no source changes; YAML + .gitignore only)

## Expected effect after merge

1. Next push to main triggers `Release-plz`. Without the `Cargo.lock` complaint, release-plz will compute the bump from commits since `0.8.0` and either open a release PR (likely `0.9.0` given the `feat:` commits in the agentskills stack) or no-op if nothing version-affecting landed.
2. When a release is published from that PR, `release.yml` runs and the `highflame-trigger` job will successfully mint the app token + fire the downstream workflow in `highflame-cloud`.

No `release.yml` test in this PR (the only way to fully validate is to actually publish a release). Comment on the PR if anything else regresses.