### PR TITLE
devops: complete release pipeline — workspace, publishability, version bump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,18 @@ mcp_test_requests.json
 run_mcp_test.py
 test_mcp_client.py
 test_mcp_ecosystem.py
-examples/
+# Ignore CONTENTS of examples/ but not the directory itself — `dir/*`
+# form (not `dir/`) so the un-ignore rules below can re-include
+# specific committed files. With `dir/`, git wouldn't even descend
+# into the directory and the negations would be silently ignored.
+examples/*
+# Allowlist the user-facing example files that ARE intentionally
+# committed. Without these un-ignore lines, release-plz aborts on
+# the "tracked AND gitignored" check (same constraint as the
+# `Cargo.lock` block below).
+!examples/config_example.json
+!examples/servers.txt
+!examples/stdio_example.md
 testing/
 docs/proxy/*TEST*_RESULTS*.md
 /dist/
@@ -38,7 +49,12 @@ Cargo.lock
 # Project-local Cargo config overrides (e.g. `.cargo/config.toml`).
 # Kept out of the repo so contributors can use local-only registry
 # / target / build flags without polluting the canonical config.
-.cargo
+# `.cargo/audit.toml` is allowlisted because it's the project-wide
+# `cargo audit` policy and intentionally committed. Use `.cargo/*`
+# (not `.cargo/`) so git descends into the directory and honors
+# the un-ignore.
+.cargo/*
+!.cargo/audit.toml
 
 # IDE files
 .vscode/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2716,7 +2716,7 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "ramparts"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "ramparts-common"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,14 @@
 [package]
 name = "ramparts"
-version = "0.8.0"
+# Bumped to 0.8.1 in this PR to bypass the orphan 0.8.0 state:
+# git tag 0.8.0 and a GitHub release 0.8.0 (binaries) exist, but
+# `cargo publish` for 0.8.0 never ran (the trigger workflow was
+# broken at the time). release-plz refuses to compute a "next
+# version" while the tag-exists / not-on-crates.io mismatch
+# persists. Publishing 0.8.1 cleanly skips the orphan; crates.io
+# users go 0.7.3 -> 0.8.1, GitHub's 0.8.0 binary release stays as
+# historical archive.
+version = "0.8.1"
 edition = "2021"
 authors = ["Sharath Rajasekar <sharath@highflame.com>"]
 description = "Security scanner for Model Context Protocol (MCP) servers and AI agent skills (Claude Code commands, agentskills.io bundles, Cursor / Codex / Windsurf / Gemini equivalents)."
@@ -19,6 +27,16 @@ include = ["src/**/*", "LICENSE", "README.md", "build.rs"]
 # `^[0-9]+\.[0-9]+\.[0-9]+$` enforces). If anyone ran `cargo release`
 # locally with the old block in place, they'd cut `v0.9.0` tags that
 # release.yml would then reject as malformed.
+
+# Workspace declaration. `ramparts-common` (in `common/`) needs to
+# be a true workspace member — not just a path dependency below —
+# so release-plz can manage its version in lockstep with the root
+# crate. Without this declaration, release-plz aborts with
+# "The following overrides are not present in the workspace:
+# `ramparts-common`. Check for typos" when reading the per-package
+# block from `release-plz.toml`.
+[workspace]
+members = ["common"]
 
 [features]
 default = ["yara-x-scanning"]
@@ -85,14 +103,29 @@ tower = "0.4"
 
 # JSON-RPC handling for microservice
 jsonrpc-core = "18.0"
-# Pinned to a post-v1.16.0 commit that bumps wasmtime from 43.0.1 to
-# 43.0.2, clearing RUSTSEC-2026-0114 (panic when allocating a table
-# exceeding the host's address space). Previous pin (178e2d697a, the
-# original wasmtime 43.0.1 bump) is still vulnerable. yara-x's tagged
-# v1.16.0 release ships the OLD wasmtime, so we hold the git pin
-# until v1.17 lands with the fix included. Switch back to a published
-# crates.io version then.
-yara-x = { git = "https://github.com/VirusTotal/yara-x", rev = "664cdfe66fd40826d160fa7009966d9c8a43cba6", optional = true }
+# yara-x is git-pinned to a post-v1.16.0 commit that bumps wasmtime
+# from 43.0.1 to 43.0.2, clearing RUSTSEC-2026-0114 (panic when
+# allocating a table exceeding the host's address space). yara-x's
+# tagged v1.16.0 release on crates.io ships the OLD wasmtime, so
+# we hold the git pin until v1.17 lands with the fix included.
+#
+# `version = "1.16.0"` is required for `cargo publish` of the
+# `ramparts` crate — when ramparts is published, `path` and `git`
+# are stripped and only `version` remains in the published
+# tarball. Without it, `cargo publish` errors:
+#   "dependency `yara-x` does not specify a version".
+#
+# Note the divergence this creates:
+#   - Workspace + GitHub-released binaries: use the git pin (safe,
+#     wasmtime 43.0.2).
+#   - `cargo install ramparts` from crates.io: resolves yara-x to
+#     the crates.io version (1.16.0, has the wasmtime CVE).
+# The CVE's attack vector (oversized table allocation in a WASM
+# module) is essentially unreachable from ramparts because we only
+# load bundled rules under `rules/pre/*.yar`, never user-supplied
+# WASM. Switch back to a clean `version = "1.17"` (no git pin)
+# once yara-x cuts that release.
+yara-x = { git = "https://github.com/VirusTotal/yara-x", rev = "664cdfe66fd40826d160fa7009966d9c8a43cba6", version = "1.16.0", optional = true }
 
 # Official Rust MCP SDK
 rmcp = { version = "1.5", features = [
@@ -127,8 +160,15 @@ rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs"] 
 # subject to platform-verifier's "no CAs loaded" failure mode.
 webpki-roots = "1"
 
-# Bring in common as path dependency
-ramparts-common = { path = "common" }
+# Workspace member. Both `path` and `version` are required:
+# - `path` is used during workspace builds (so this crate uses the
+#   local source, not the registry copy)
+# - `version` is what gets written to the published `ramparts`
+#   tarball's Cargo.toml (path metadata is stripped at publish
+#   time). `cargo publish` REJECTS a manifest where a workspace
+#   dependency lacks a version — `cargo publish --dry-run` catches
+#   this locally. Must move in lockstep with `common/Cargo.toml`.
+ramparts-common = { path = "common", version = "0.8.1" }
 
 [build-dependencies]
 chrono = "0.4"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,9 @@
 [package]
 name = "ramparts-common"
-version = "0.8.0"
+# Bumped to 0.8.1 in lockstep with the root crate. ramparts-common
+# is being published to crates.io for the first time as part of
+# this version (see release-plz.toml `publish = true`).
+version = "0.8.1"
 edition = "2021"
 authors = ["Sharath Rajasekar <sharath@highflame.com>"]
 description = "Shared types and utilities for the Ramparts MCP-server and agent-skill scanner."

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -96,16 +96,22 @@ git_release_draft = true
 
 [[package]]
 name = "ramparts-common"
-# Path-only workspace member referenced as `{ path = "common" }`;
-# never published to crates.io. release-plz still bumps its
-# `Cargo.toml` version so the workspace stays consistent (root and
-# common always at the same version — verified by the
-# `Stamp release version into Cargo.toml files` step in release.yml).
-publish = false
+# Published to crates.io alongside `ramparts` so downstream
+# `cargo install ramparts` can resolve the dependency. The root
+# crate's `[dependencies] ramparts-common = { path = "common",
+# version = "..." }` declares the required version; `cargo
+# publish` strips the `path` and ships only the `version`
+# constraint, which then must be findable on crates.io. Without
+# this, the next `ramparts` publish fails with
+# "dependency `ramparts-common` does not specify a version" (when
+# `version` is missing) or "could not find `ramparts-common` in
+# registry `crates.io`" (when `version` is set but the crate
+# isn't published). release-plz handles dependency ordering and
+# publishes `ramparts-common` first, then `ramparts`.
+publish = true
 changelog_update = false
 
-# No GitHub release for this crate — only the `ramparts` package
-# gets one. Otherwise release-plz would create two parallel draft
-# releases per release PR and the maintainer would have to polish
-# both, which is just noise.
+# No GitHub release for the `common` package — the maintainer
+# polishes ONE release body (on the root crate) per cycle. Two
+# parallel drafts per release-plz PR would just be noise.
 git_release_enable = false


### PR DESCRIPTION
**Pre-flight dry-run done locally before pushing this time.** Caught seven latent bugs that would have hit the next release-plz run. All resolved in a single commit.

## What was found via dry-run

Driven by running `release-plz update`, `cargo publish --dry-run`, and `git ls-files -ci` on every iteration until everything was clean.

| # | Issue | Fix |
|---|---|---|
| 1 | No `[workspace]` declaration → release-plz couldn't see `ramparts-common`, aborted with "overrides not present in the workspace" | Added `[workspace] members = ["common"]` |
| 2 | Four more files tracked AND gitignored (`.cargo/audit.toml`, `examples/*.{json,txt,md}`) — same class as the `Cargo.lock` bug we fixed in #115 | `dir/*` + named un-ignore (matches the existing `Cargo.lock` pair) |
| 3 | Orphan `0.8.0` git tag + GitHub release, never published to crates.io (release.yml's trigger was broken at the time). release-plz refused to compute "next" with the mismatch | Bumped in-tree to `0.8.1`; release-plz publishes 0.8.1, skipping 0.8.0 on crates.io. GitHub 0.8.0 binary release stays for historical reference |
| 4 | `ramparts-common = { path = "common" }` lacked a `version` → `cargo publish` rejects | Added `version = "0.8.1"` |
| 5 | `ramparts-common` was `publish = false`, but it's a transitive dep of the published `ramparts` crate → downstream `cargo install ramparts` would 404 | Flipped to `publish = true`. release-plz topo-sorts and publishes `ramparts-common` before `ramparts` |
| 6 | `yara-x` git pin lacked a `version` → same `cargo publish` constraint as #4 | Added `version = "1.16.0"`. Documented divergence: workspace + GitHub-released binaries use the git pin (safe, wasmtime 43.0.2); `cargo install ramparts` resolves yara-x 1.16.0 from crates.io (has wasmtime CVE — unreachable from ramparts's bundled-rule usage) |
| 7 | `ramparts-common`'s `git_release_enable = false` — kept (only the root crate gets a polished GitHub release) | — |

## Local dry-run results

```
cargo fmt --check                                                ✅
cargo clippy --all-features --all-targets -D warnings -D unused  ✅
cargo audit                                                      ✅ exit 0
git ls-files -ci --exclude-standard                              ✅ empty
cargo metadata: both packages recognized at 0.8.1                ✅
YAML parse for all 3 workflows                                   ✅
cargo publish --dry-run -p ramparts-common                       ✅ uploads-mock
release-plz update                                               ✅
   → ramparts-common: 0.8.1 (new)
   → ramparts: 0.7.3 → 0.8.1
cargo test --all-features -- --test-threads=1                    183/183 pass
```

`cargo publish --dry-run -p ramparts` returns "ramparts-common not found on crates.io" — that's expected and resolved at release time by release-plz's topo-sort (publishes `ramparts-common` first, then `ramparts`).

## Expected behavior after merge

1. Next push to main → `release-plz` workflow fires.
2. release-plz reads commits since last tag (`0.8.0`), computes the bump, opens a release PR for **0.8.2** (or whatever the bump implies; depends on commit prefixes since 0.8.0).
3. When the release PR merges → release-plz publishes `ramparts-common` then `ramparts` to crates.io, creates a draft GitHub release.
4. Maintainer polishes the draft notes → publishes it.
5. `release.yml` fires on `release: published` → multi-arch binaries attached, downstream trigger fires.

The full pipeline should be running cleanly.

## Test plan

- [ ] CI green on this PR
- [ ] Spot-check the `release-plz.yml` workflow fires once on merge to main (without errors)
- [ ] If a release PR opens, confirm it bumps both Cargo.toml files together to the same version