### PR TITLE
devops: extend app-token fix to cicd.yml + cron.yml

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -50,12 +50,21 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: token
         with:
-          client-id: ${{ secrets.HIGHFLAME_GITHUB_APP_ID }}
+          # `app-id` (deprecated) kept on purpose — `HIGHFLAME_GITHUB_APP_ID`
+          # holds the numeric App ID, not the alphanumeric Client ID.
+          # See release.yml for the full rationale.
+          app-id: ${{ secrets.HIGHFLAME_GITHUB_APP_ID }}
           private-key: ${{ secrets.HIGHFLAME_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          # Newline-separated BARE repo names (no `owner/` prefix, no
+          # `- ` list dash). `${{ github.repository }}` would be
+          # `owner/repo` form which the action rejects with the
+          # "owner '- ...' doesn't match" error. Use
+          # `github.event.repository.name` for the current repo's
+          # bare name. `DEVOPS_REPO` is already bare.
           repositories: |
-            - ${{ github.repository }}
-            - ${{ env.DEVOPS_REPO }}
+            ${{ github.event.repository.name }}
+            ${{ env.DEVOPS_REPO }}
 
       - name: Trigger private repo workflow
         env:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -47,12 +47,17 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: token
         with:
-          client-id: ${{ secrets.HIGHFLAME_GITHUB_APP_ID }}
+          # `app-id` (deprecated) kept on purpose — `HIGHFLAME_GITHUB_APP_ID`
+          # holds the numeric App ID, not the alphanumeric Client ID.
+          # See release.yml for the full rationale.
+          app-id: ${{ secrets.HIGHFLAME_GITHUB_APP_ID }}
           private-key: ${{ secrets.HIGHFLAME_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          # Newline-separated BARE repo names (no `owner/` prefix, no
+          # `- ` list dash). See release.yml for the full rationale.
           repositories: |
-            - ${{ github.repository }}
-            - ${{ env.DEVOPS_REPO }}
+            ${{ github.event.repository.name }}
+            ${{ env.DEVOPS_REPO }}
 
       - name: Trigger private repo workflow
         env:


### PR DESCRIPTION
## What

Two workflow files I overlooked in PR #115 / #116 have the SAME `actions/create-github-app-token@v3` bugs we already fixed in `release.yml`:

| File | Trigger | Was failing? |
|---|---|---|
| `.github/workflows/cicd.yml` | Every push to main | **Yes** — every merge to main since #113 |
| `.github/workflows/cron.yml` | Weekly schedule + workflow_dispatch | Would fail Friday 2:30 AM UTC |

Both had:

```yaml
client-id: ${{ secrets.HIGHFLAME_GITHUB_APP_ID }}   # wrong field — secret is numeric App ID
repositories: |
  - ${{ github.repository }}                        # `-` prefix + owner/repo form
  - ${{ env.DEVOPS_REPO }}
```

Failed with: `Repository '- highflame-ai/ramparts' includes owner '- highflame-ai', which does not match the resolved owner 'highflame-ai'`.

## Fix

Same pattern release.yml already uses:

```yaml
app-id: ${{ secrets.HIGHFLAME_GITHUB_APP_ID }}      # deprecated alias OK
repositories: |
  ${{ github.event.repository.name }}               # bare name
  ${{ env.DEVOPS_REPO }}                            # already bare
```

## How I missed this earlier

Every prior review (PRs #113 / #115 / #116, three sub-agent code reviews) scoped to `release.yml` + `release-plz.yml` and didn't grep the rest of `.github/workflows/` for the same `actions/create-github-app-token@v3` pattern. Sub-agent review on #115 was explicitly scoped to release.yml only.

**Lesson learned:** when a bug is found in one workflow file, grep all workflows for the same `uses:` action + config pattern. Future workflow audits will start with `grep -rn 'actions/create-github-app-token' .github/workflows/` and check each block.

## Pre-flight dry-run before pushing

- YAML parse for all 6 workflows  ✅
- `grep` across workflows: NO remaining `- ${{ github.repository }}` and NO remaining `client-id:` for any `create-github-app-token` block

This is the same pre-flight checklist I should have run BEFORE pushing #115 (then I would have found these two files immediately by searching for the same pattern).

## Test plan

- [ ] CI green on the PR
- [ ] After merge, confirm the next push to main runs `cicd.yml` successfully (the `highflame-trigger` job hits the downstream workflow without the app-token error)
- [ ] Spot-check the next cron run (or trigger manually via `workflow_dispatch`)