### PR TITLE
devops: split release pipeline into dual mode (release-plz PR + manual UI publish)

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,34 +1,35 @@
-name: Release-plz (auto-bump + draft release)
+name: Release-plz (open release PR on bumpable commits)
 
-# Runs on every push to main. Two phases run sequentially:
+# Mode 1 of the dual-mode release pipeline.
 #
-# 1. `release-pr` — opens / updates a "feat: release X.Y.Z" PR that
-#    bumps both workspace Cargo.toml files when there are `feat:` /
-#    `fix:` / `feat!:` commits since the last tag.
+# Fires on every push to main. Runs ONLY release-plz's `release-pr`
+# command, which:
+#   - reads commits since the last git tag
+#   - if any are `feat:` / `fix:` / `feat!:` / `BREAKING CHANGE:`,
+#     computes the semver bump
+#   - opens (or updates) a "feat: release X.Y.Z" PR that bumps
+#     `Cargo.toml`, `common/Cargo.toml`, and `Cargo.lock`
 #
-# 2. `release` — when a previous release PR has just been merged
-#    (release-plz detects this via the Cargo.toml version diff
-#    between HEAD and the previous tag), release-plz:
-#    a. publishes the `ramparts` crate to crates.io
-#    b. creates the git tag
-#    c. creates a DRAFT GitHub release with auto-generated bullets
-#       (sourced from commits since the last tag) in the body
+# This workflow does NOT publish to crates.io. It does NOT create
+# git tags. It does NOT create GitHub releases. Those happen in
+# Mode 2: the maintainer goes to the GitHub UI, drafts a new
+# release at the merged-release-PR's commit, picks the matching
+# tag name, and publishes — which fires `release.yml` (the binary
+# build + cargo publish + downstream deploy trigger).
 #
-#    The release lands as a draft so the maintainer can polish the
-#    notes — add narrative themes, migration guidance, what's-next
-#    — before publishing. When the maintainer clicks "Publish
-#    release", the GitHub `release: published` event fires and the
-#    `release.yml` workflow runs the multi-arch binary builds +
-#    downstream deploy trigger. crate publish itself has moved here
-#    (release-plz handles it during step a above).
+# Manual trigger: `workflow_dispatch` lets you fire this workflow
+# from the Actions tab in the GitHub UI if you ever want to nudge
+# release-plz to re-check. It's idempotent — running it when
+# there's nothing bumpable is a no-op.
 #
-# Concurrency: only one release-plz run at a time on main; in-flight
-# runs cancel when a newer commit lands so the open release PR
-# always reflects the tip of main.
+# Concurrency: only one release-plz run at a time per branch.
+# `cancel-in-progress: false` so in-flight PR updates don't get
+# stomped by newer pushes; the next run picks up the latest commit.
 
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: release-plz-${{ github.ref }}
@@ -38,69 +39,58 @@ jobs:
   release-plz:
     runs-on: ubuntu-24.04
     permissions:
-      # release-plz needs to push commits onto the release branch
-      # (to update the open PR when new commits land on main),
-      # open / update PRs, AND create git tags + GitHub releases
-      # (the `release` command requires `contents: write`).
+      # release-plz needs to push commits onto its release branch
+      # and open / update the release PR. Does NOT need to create
+      # tags or releases (those happen in Mode 2 via release.yml).
       contents: write
       pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          # release-plz needs the full commit history + tag history
-          # to compute the bump, detect when the last release
-          # happened, and walk commits since that tag for the
-          # auto-generated release body bullets.
+          # Full history so release-plz can walk commits back to the
+          # last tag and compute the bump.
           fetch-depth: 0
-          # The PR-opening step uses a Highflame GitHub App token
-          # (next step). Don't persist the default GITHUB_TOKEN since
-          # that token can't trigger CI on the auto-opened PR.
+          # Don't persist the default GITHUB_TOKEN; the next step
+          # mints a Highflame App token because PRs opened by the
+          # default token don't trigger `on: pull_request` workflows.
           persist-credentials: false
 
       - name: Create Highflame GitHub App token
-        # release-plz must open the release PR using a token that
-        # CAN trigger CI workflows on the auto-opened PR. The default
-        # GITHUB_TOKEN can't — PRs opened with it don't trigger
-        # `on: pull_request` workflows. Same app-token pattern the
-        # existing release.yml uses for its private-repo trigger.
+        # Required so the auto-opened release PR actually triggers
+        # CI when you go to merge it. The default GITHUB_TOKEN's
+        # PRs do NOT trigger `on: pull_request` workflows by design.
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          # `app-id` is the deprecated alias for `client-id` in
-          # `create-github-app-token@v3`. Kept here because the
-          # existing `HIGHFLAME_GITHUB_APP_ID` secret holds the
-          # numeric App ID, not the alphanumeric Client ID — those
-          # are different identifiers on GitHub Apps. Using
-          # `client-id:` with the numeric value would fail JWT auth
-          # at runtime. Eat the deprecation warning until the
-          # secret is split (add `HIGHFLAME_GITHUB_APP_CLIENT_ID`)
-          # and the cutover is intentional. Same pattern used in
-          # release.yml.
+          # `app-id` (deprecated alias) kept on purpose —
+          # `HIGHFLAME_GITHUB_APP_ID` holds the numeric App ID, not
+          # the alphanumeric Client ID. Switching to `client-id:`
+          # would fail JWT auth. See release.yml for the full
+          # rationale.
           app-id: ${{ secrets.HIGHFLAME_GITHUB_APP_ID }}
           private-key: ${{ secrets.HIGHFLAME_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Install Rust toolchain
-        # release-plz depends on cargo for reading workspace
-        # metadata + running `cargo publish` when the `release`
-        # command fires. Pinning to `stable` matches the
-        # `rust-toolchain.toml` we added in this PR.
+        # release-plz uses cargo to read workspace metadata. Stable
+        # channel matches `rust-toolchain.toml`.
         uses: dtolnay/rust-toolchain@stable
 
-      - name: "Run release-plz (full mode: PR + release)"
-        # No `command:` specified — the action runs BOTH `release-pr`
-        # and `release` in one go. `release-pr` is idempotent (opens
-        # / updates the release PR as needed); `release` is a no-op
-        # unless the workspace Cargo.toml is at a version that
-        # doesn't yet have a corresponding git tag (which happens
-        # right after a release PR is merged).
+      - name: Run release-plz (release-pr only)
+        # PR-only mode. Does NOT publish to crates.io or create git
+        # tags / GitHub releases — those are Mode 2's responsibility
+        # (release.yml on `release: published`). This keeps the
+        # workflow scope clean: release-plz proposes; the maintainer
+        # disposes via the GitHub UI.
+        #
+        # The action's `command:` input takes one of `release-pr`,
+        # `release`, or (default = both). We pin to `release-pr`.
         uses: MarcoIeni/release-plz-action@v0.5
         with:
+          command: release-pr
           config: release-plz.toml
         env:
-          # PRs + tag pushes + draft GitHub release creation: app token.
+          # The PR-opening step uses this token; no
+          # CARGO_REGISTRY_TOKEN here because PR-only mode never
+          # touches the registry.
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          # crates.io publish: same secret the old `cargo publish` step
-          # in `release.yml` was reading. Moved here because release-plz
-          # is the new publisher.
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -353,30 +353,109 @@ jobs:
           asset_name: ${{ matrix.target }}-${{ matrix.arch }}_checksums.txt
           asset_content_type: text/plain
 
-  # NOTE: the cargo-publish job that used to live here has been
-  # removed. release-plz now publishes to crates.io as part of its
-  # full-mode flow — when a release-plz PR is merged, release-plz
-  # tags + publishes the crate + creates the GitHub release (as a
-  # draft, see release-plz.toml). The maintainer polishes the draft
-  # release notes and clicks "Publish release", which fires this
-  # workflow on `release: published` and builds the multi-arch
-  # binaries that get attached.
+  # Publish both workspace members to crates.io. Runs as part of
+  # Mode 2 (release-published → release.yml). `ramparts-common`
+  # publishes first because the root `ramparts` crate has it as a
+  # path-and-version dependency — crates.io rejects a `ramparts`
+  # publish that references an unpublished `ramparts-common`.
   #
-  # If you need to bypass release-plz and publish a release
-  # manually (e.g., release-plz workflow is broken), do it from a
-  # checkout of the release tag:
-  #
-  #   git checkout 0.X.0
-  #   cargo publish --allow-dirty
-  #
-  # The sed step above (`Stamp release version into Cargo.toml
-  # files`) is the safety net that bridges manual tags whose
-  # Cargo.toml wasn't pre-bumped by release-plz.
+  # `cargo publish --allow-dirty` because the validate step above
+  # seds Cargo.toml in the runner workspace; cargo treats that as
+  # a dirty tree even though the only edit is the version bump.
+  highflame-crate:
+    needs:
+      - highflame-validate
+      - highflame-artifact
+    permissions:
+      contents: 'read'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Download version-stamped Cargo.toml files
+        # Picks up both `Cargo.toml` AND `common/Cargo.toml`
+        # produced by the validate job's sed step. Preserves the
+        # `common/` path because the upload-artifact step bundles
+        # them with paths.
+        uses: actions/download-artifact@v7
+        with:
+          name: cargo-toml
+
+      - name: Check Cargo.toml files
+        shell: bash
+        run: |-
+          echo "---root Cargo.toml---"
+          cat Cargo.toml
+          echo "---common/Cargo.toml---"
+          cat common/Cargo.toml
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install YARA (Ubuntu)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y yara libyara-dev
+
+      - name: Cache dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-publish-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-publish-
+
+      - name: Publish ramparts-common to crates.io
+        # MUST run before the ramparts publish: the root crate's
+        # `Cargo.toml` declares `ramparts-common = { path = "common",
+        # version = "X.Y.Z" }`. `cargo publish` strips the `path`
+        # and ships only the `version` constraint, so when the
+        # `ramparts` publish hits crates.io's resolver it expects
+        # `ramparts-common@X.Y.Z` to be available.
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |-
+          cd common
+          cargo publish --allow-dirty
+
+      - name: Wait for ramparts-common to be queryable
+        # crates.io's sparse-index update is usually fast but not
+        # instantaneous after a publish. Poll the package's
+        # `/api/v1/crates/ramparts-common/<version>` endpoint until
+        # it 200s (or fail after a minute). Without this, the
+        # `ramparts` publish below can fail with "could not find
+        # `ramparts-common` in registry" — a race condition.
+        shell: bash
+        run: |-
+          VERSION="$(grep -m 1 '^version' common/Cargo.toml | cut -d'"' -f2)"
+          echo "waiting for ramparts-common@${VERSION} to appear on crates.io..."
+          for i in $(seq 1 30); do
+            if curl -fsS "https://crates.io/api/v1/crates/ramparts-common/${VERSION}" >/dev/null 2>&1; then
+              echo "ramparts-common@${VERSION} is queryable after ${i} attempt(s)."
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::ramparts-common@${VERSION} did not appear on crates.io after 60s."
+          exit 1
+
+      - name: Publish ramparts to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |-
+          cargo publish --allow-dirty
 
   highflame-trigger:
     needs:
       - reusable-vars
       - highflame-artifact
+      - highflame-crate
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,55 +1,56 @@
 # release-plz configuration.
 #
-# We use release-plz in **full mode**: on every push to main, it
-# (a) opens / updates a release PR that bumps the workspace
-# Cargo.toml versions, and (b) when that PR has been merged, tags
-# the release, publishes the `ramparts` crate to crates.io, and
-# creates a DRAFT GitHub release with auto-generated commit-bullet
-# notes in the body.
+# **PR-only mode** (Mode 1 of the dual-mode release pipeline). On
+# every push to main, release-plz reads commits since the last
+# tag and, if any are `feat:` / `fix:` / `feat!:` /
+# `BREAKING CHANGE:`, opens (or updates) a release PR that bumps
+# `Cargo.toml`, `common/Cargo.toml`, and `Cargo.lock`. That's all
+# it does.
 #
-# The maintainer then polishes the draft release body — adding the
-# narrative themes, migration guide, what's-next — and clicks
-# "Publish release". That fires the GitHub `release: published`
-# event, which triggers `release.yml` to build the multi-arch
-# binaries + attach them + run the private downstream deploy
-# trigger.
+# release-plz does NOT:
+#   - publish to crates.io
+#   - create git tags
+#   - create GitHub releases
 #
-# Why drafts: hand-authored narrative beats commit-list bullets for
-# release notes, but it's nice to start from a complete bullet list
-# (so you don't accidentally forget a feature). Draft mode gives
-# the maintainer that starting point and a hold-and-edit window.
+# All of those belong to Mode 2: the maintainer creates a GitHub
+# release manually (typically at the merged-release-PR's commit,
+# matching the version release-plz proposed), which fires
+# `release.yml` — that workflow builds multi-arch binaries,
+# publishes ramparts-common + ramparts to crates.io, and triggers
+# the downstream private-repo deploy.
+#
+# Why split: hand-authored release notes beat commit-list bullets,
+# and the maintainer wants the discretion to ship a tagged release
+# at a time of their choosing (not the moment a release PR lands).
+# release-plz proposes; the maintainer disposes.
 
 [workspace]
 # Don't auto-open a release PR if there are no version-bumping
-# commits since the last tag.
+# commits since the last tag. Default behavior; explicit here for
+# clarity.
 release_always = false
 
 # Strip the `v` prefix from git tags — ramparts uses bare semver
-# (`0.8.0`, not `v0.8.0`) per the existing release.yml regex.
+# (`0.8.1`, not `v0.8.1`). `release.yml`'s regex enforces this
+# (`^[0-9]+\.[0-9]+\.[0-9]+$`).
 git_tag_name = "{{ version }}"
 
-# The release-PR title that shows up in the GitHub UI. Default would
-# read "chore: release v0.9.0" which doesn't pass Highflame's
-# commit-prefix check (only feat:/fix:/devops:/Merge/Revert are
-# allowed). Use `feat:` so the PR's merge commit passes CI.
+# The release-PR title that shows up in the GitHub UI. Highflame's
+# commit-prefix check only allows feat:/fix:/devops:/Merge/Revert,
+# so the default "chore: release v0.9.0" would fail CI on merge.
+# Use `feat:` so the PR's squash-merge commit passes the gate.
 pr_name = "feat: release {{ version }}"
 
-# Workspace-level changelog template. Even though we set
-# `changelog_update = false` per package (no `CHANGELOG.md` written
-# to disk), the same template populates the auto-generated release
-# body that lands in the draft GitHub release. Keeping it minimal:
-# group by Conventional Commits type, link each entry to its
-# commit. Maintainer adds narrative on top of these bullets when
-# polishing the draft.
+# Workspace-level changelog template. Used to populate the body of
+# the release PR (the bullet list of "what's in this release").
+# `changelog_update = false` per-package below keeps `CHANGELOG.md`
+# out of the repo — the same template content lives only in the
+# release PR description.
 [changelog]
 header = """# Changelog\n\n"""
 # Each bullet links to the commit via a literal
 # `https://github.com/<owner>/<repo>/commit/<sha>` URL — simpler
-# than defining a Tera macro for it. (An earlier draft of this
-# template used `{{ self::commit_link(commit=commit) }}` but the
-# `commit_link` macro was never defined — git-cliff has no such
-# built-in — so release-plz would have failed at render time the
-# first time a release PR tried to fire.)
+# than defining a Tera macro for it.
 body = """
 ## What changed in {{ version }}
 {% for group, commits in commits | group_by(attribute="group") %}
@@ -61,7 +62,7 @@ body = """
 """
 trim = true
 
-# Map Conventional Commits types -> sections in the release body.
+# Map Conventional Commits types -> sections in the release PR body.
 # Order matters: features first, then fixes, then everything else.
 # `devops:`, `Merge`, `Revert`, `build(deps)`, `[Snyk]`, `Bump`
 # (Highflame-conventional non-CC prefixes) get classified by their
@@ -78,40 +79,31 @@ commit_parsers = [
 
 [[package]]
 name = "ramparts"
-# The published crate. release-plz updates the version in
-# `Cargo.toml` AND publishes to crates.io as part of its `release`
-# command (full-mode flow).
+# `publish = true` tells release-plz "this is a publishable crate"
+# (i.e. include it in the release PR's version bump). It does NOT
+# trigger an actual `cargo publish` — release-plz's `release-pr`
+# command never touches the registry. crates.io publish happens
+# in `release.yml` (Mode 2) when the maintainer creates a release
+# in the GitHub UI.
 publish = true
 
-# Don't write a CHANGELOG.md file. The same changelog template
-# above still populates the auto-generated draft release body —
-# that's the user-facing surface we actually want.
+# Don't write a CHANGELOG.md file. The bullet content from the
+# `[changelog]` template above lives only in the release PR's
+# body — and from there the maintainer copies whatever they want
+# into the GitHub release notes when they cut the release.
 changelog_update = false
 
-# Create the GitHub release as a DRAFT. The maintainer polishes
-# the auto-generated bullet body (adds narrative themes, migration
-# guidance, what's-next) before publishing. Publishing fires
-# `release.yml` which builds + attaches the multi-arch binaries.
-git_release_draft = true
+# `git_release_*` settings are no-ops in PR-only mode (release-plz
+# doesn't create GitHub releases). Omitted for clarity.
 
 [[package]]
 name = "ramparts-common"
-# Published to crates.io alongside `ramparts` so downstream
-# `cargo install ramparts` can resolve the dependency. The root
-# crate's `[dependencies] ramparts-common = { path = "common",
-# version = "..." }` declares the required version; `cargo
-# publish` strips the `path` and ships only the `version`
-# constraint, which then must be findable on crates.io. Without
-# this, the next `ramparts` publish fails with
-# "dependency `ramparts-common` does not specify a version" (when
-# `version` is missing) or "could not find `ramparts-common` in
-# registry `crates.io`" (when `version` is set but the crate
-# isn't published). release-plz handles dependency ordering and
-# publishes `ramparts-common` first, then `ramparts`.
+# Workspace member that ships alongside `ramparts` (the root crate
+# depends on it via path + version). Marked `publish = true` so
+# release-plz bumps its version in the release PR — `cargo
+# publish` of either crate would fail if their versions diverge.
+# The actual crates.io publish happens in `release.yml`'s
+# highflame-crate job, which publishes ramparts-common BEFORE
+# ramparts (dep order).
 publish = true
 changelog_update = false
-
-# No GitHub release for the `common` package — the maintainer
-# polishes ONE release body (on the root crate) per cycle. Two
-# parallel drafts per release-plz PR would just be noise.
-git_release_enable = false


### PR DESCRIPTION
## The dual-mode design

```
Mode 1 — release-plz opens a release PR (auto, on every push to main)
═══════════════════════════════════════════════════════════════════
PR with feat:/fix:    →  release-plz.yml fires
merges to main           →  reads commits since last tag
                         →  computes bump (e.g. 0.8.1 → 0.8.2)
                         →  opens "feat: release 0.8.2" PR
                            (bumps Cargo.toml + common/Cargo.toml + Cargo.lock)

You merge the PR.        Main now has Cargo.toml = 0.8.2. No tag yet.


Mode 2 — you ship it (manual via GitHub UI)
═══════════════════════════════════════════════════════════════════
GitHub → Releases →      →  release.yml fires on release: published
Draft a new release →    →  validates tag = bare semver
pick tag 0.8.2 →         →  builds multi-arch binaries → attaches them
write notes → Publish    →  cargo publish ramparts-common (first)
                         →  cargo publish ramparts
                         →  triggers downstream highflame-cloud deploy
```

## Changes

| File | Change |
|---|---|
| `release-plz.yml` | Pinned to `command: release-pr`. Added `workflow_dispatch:`. Removed `CARGO_REGISTRY_TOKEN` (no registry interaction in PR-only mode). |
| `release-plz.toml` | Dropped `git_release_draft = true` (no-op without `release` command). Per-package `publish = true` stays — that's a "this crate exists in the workspace" hint, not a publish trigger. |
| `release.yml` | Restored `highflame-crate` job. Two `cargo publish` calls (ramparts-common first, then ramparts) + a 60-second poll between them so the sparse-index update doesn't race the second publish. |

## ONE-TIME ACTION YOU NEED TO DO

`release-plz` won't open new PRs until `ramparts-common@0.8.1` lands on crates.io — it sees the `0.8.1` git tag (which you created manually for the GitHub release) but can't find the crate in the registry. That's a state mismatch, not a code bug.

**From your local checkout (the secret is in your cargo credentials):**

```bash
git checkout main
git pull
cd common
cargo publish    # publishes ramparts-common@0.8.1
cd ..
cargo publish --allow-dirty   # publishes ramparts@0.8.1
```

You need a `CARGO_REGISTRY_TOKEN` in `~/.cargo/credentials.toml` (or `cargo login` once with your crates.io API token).

After that one-time publish, the cycle for **0.8.2 and onward** is fully automatic:

1. Land normal `feat:` / `fix:` PRs to main
2. release-plz opens "feat: release 0.8.2" PR with the bump → review → merge
3. Go to GitHub UI, create a 0.8.2 release at that commit → publish
4. release.yml does the rest (binaries + crates.io + downstream)

## Local dry-run before pushing (this time)

| Gate | Result |
|---|---|
| `cargo fmt --check` | ✅ |
| `cargo clippy -D warnings -D unused` | ✅ |
| `cargo audit` | ✅ exit 0 |
| YAML parse for all 6 workflows | ✅ |
| `git ls-files -ci --exclude-standard` | ✅ empty |
| `cargo publish --dry-run -p ramparts-common` | ✅ uploads-mock |
| `cargo test --all-features -- --test-threads=1` | ✅ 183/183 |
| `release-plz update` | ❌ orphan-tag block (documented above; one-time manual publish resolves) |

## Test plan

- [ ] Merge this PR (no orphan-tag check on a config-only change — should be green)
- [ ] Run the manual `cargo publish` from your machine for 0.8.1 (ramparts-common then ramparts)
- [ ] Verify on crates.io: `ramparts@0.8.1` and `ramparts-common@0.8.1` both exist
- [ ] Land any `fix:` PR (e.g., #117's cicd/cron fix re-prefixed as `fix(devops):`)
- [ ] Confirm release-plz opens a "feat: release 0.8.2" PR automatically
- [ ] Merge release-plz PR → create 0.8.2 release in UI → confirm release.yml publishes to crates.io