### PR TITLE
devops: add linux-arm64 and win32-arm64 to the release build matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,6 +199,13 @@ jobs:
             arch: x86_64
           - target: macOS-15
             arch: aarch64
+          # GitHub-hosted native arm64 runners (free for public repos).
+          # Building natively avoids cross-compiling the YARA C dep for
+          # aarch64 — the OS-keyed YARA/build steps below work unchanged.
+          - target: ubuntu-24.04-arm
+            arch: aarch64
+          - target: windows-11-arm
+            arch: aarch64
     runs-on: ${{ matrix.target }}
     steps:
       - name: Checkout code
@@ -236,6 +243,14 @@ jobs:
             echo "crate_target=aarch64-apple-darwin" >> ${GITHUB_OUTPUT}
             echo "crate_release=ramparts-macos-aarch64" >> ${GITHUB_OUTPUT}
             echo "crate_ext=" >> ${GITHUB_OUTPUT}
+          elif [[ ${{ matrix.target }} == "ubuntu-24.04-arm" && ${{ matrix.arch }} == "aarch64" ]] ; then
+            echo "crate_target=aarch64-unknown-linux-gnu" >> ${GITHUB_OUTPUT}
+            echo "crate_release=ramparts-linux-aarch64" >> ${GITHUB_OUTPUT}
+            echo "crate_ext=" >> ${GITHUB_OUTPUT}
+          elif [[ ${{ matrix.target }} == "windows-11-arm" && ${{ matrix.arch }} == "aarch64" ]] ; then
+            echo "crate_target=aarch64-pc-windows-msvc" >> ${GITHUB_OUTPUT}
+            echo "crate_release=ramparts-windows-aarch64.exe" >> ${GITHUB_OUTPUT}
+            echo "crate_ext=.exe" >> ${GITHUB_OUTPUT}
           else
             echo "Not matching the target...!"
             exit 1


### PR DESCRIPTION
## What

Adds `aarch64-unknown-linux-gnu` and `aarch64-pc-windows-msvc` to the release build matrix, so a published release also ships arm64 Linux and arm64 Windows binaries.

## Why

Unblocks aarch64 platform support in Overwatch (highflame-ai/highflame-overwatch#675), which consumes the prebuilt ramparts release binaries. Those two targets were deferred because upstream didn't publish them; this is the prerequisite.

## How

Native GitHub-hosted arm64 runners (`ubuntu-24.04-arm`, `windows-11-arm`, free for public repos), not cross-compilation. The YARA install, build, and checksum steps key on `runner.os`, so they run unchanged:

- Linux arm64: apt installs `libyara-dev` for the runner arch.
- Windows arm64: builds `--no-default-features` (no YARA), same as Windows x64 already does.

Diff is two matrix entries plus two `Setting up Envs` branches.

## New release assets

| Platform | Binary | Checksums |
|---|---|---|
| linux-arm64 | `ramparts-linux-aarch64` | `ubuntu-24.04-arm-aarch64_checksums.txt` |
| win32-arm64 | `ramparts-windows-aarch64.exe` | `windows-11-arm-aarch64_checksums.txt` |

## Verification

YAML validated locally. The arm64 build itself is provable only when a release runs this workflow (arm64 MSVC link, arm64 `libyara-dev`). Plan: merge, then cut a release to confirm the binaries publish.
