### PR TITLE
fix: add server_name to scan output

### DIFF
--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1910,8 +1910,6 @@ impl MCPScanner {
                             }
                         };
 
-                        let server_name = server.name.clone();
-
                         // Scan the MCP server - HTTP or STDIO
                         let mut result = if let Some(url) = server.scan_url() {
                             // HTTP server scanning
@@ -1957,7 +1955,7 @@ impl MCPScanner {
                             failed_result
                         };
 
-                        result.server_name = server_name;
+                        result.server_name = server.name;
                         result
                     })
                 })

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1910,8 +1910,10 @@ impl MCPScanner {
                             }
                         };
 
+                        let server_name = server.name.clone();
+
                         // Scan the MCP server - HTTP or STDIO
-                        let result = if let Some(url) = server.scan_url() {
+                        let mut result = if let Some(url) = server.scan_url() {
                             // HTTP server scanning
                             match scanner.scan_single(url, server_options).await {
                                 Ok(mut result) => {
@@ -1955,6 +1957,7 @@ impl MCPScanner {
                             failed_result
                         };
 
+                        result.server_name = server_name;
                         result
                     })
                 })

--- a/src/types.rs
+++ b/src/types.rs
@@ -269,6 +269,9 @@ pub struct ScanResult {
     /// `if (ramparts_commit)` truthiness in a downstream language.
     #[serde(default)]
     pub ramparts_commit: String,
+    /// Server name from config file (preserves user's naming, not server's self-reported name)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_name: Option<String>,
     /// IDE source that provided this server configuration
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ide_source: Option<String>,
@@ -322,6 +325,7 @@ impl ScanResult {
             errors: Vec::new(),
             ramparts_version: env!("CARGO_PKG_VERSION").to_string(),
             ramparts_commit: env!("GIT_COMMIT_SHORT").to_string(),
+            server_name: None,
             ide_source: None,
             llm_prompts: None,
         }


### PR DESCRIPTION
## Summary

- **Bug:** `server_name` was missing from ramparts scan JSON output. When `highflame-ramparts` switched to fetching the binary from this upstream repo (v0.8.3), the field was lost — it existed in the old mono-repo Rust source but was never ported here.
- **Impact:** Studio Discovery → MCP Scans sidepanel was broken — clicking a row did nothing because the query filters on `server_name` which was empty. The ClickHouse `overwatch_mcp_server_scans.server_name` column existed but was never populated by recent scans.
- **Fix:** Added `server_name: Option<String>` to `ScanResult` in `types.rs` and set it from `server.name` in `scanner.rs` after all scan paths (success, failure, invalid config) converge.

## Changes

- `src/types.rs` — Added `server_name` field to `ScanResult` struct and initialized it to `None` in `ScanResult::new()`
- `src/scanner.rs` — Captured `server.name` before scan branches and assigned it to `result.server_name` after all paths converge in `scan_config_by_ide_inner`

## Test plan

- [x] `cargo check` — compiles cleanly
- [x] `cargo build --release` — binary builds
- [x] `ramparts scan-config --format json` — verified `server_name` is populated for all servers (filesystem, memory, sequential-thinking)
- [x] Failed scans also get `server_name` populated
- [x] Field uses `skip_serializing_if = "Option::is_none"` — omitted from JSON when no name exists

## Related

- Studio issue: highflame-ai/highflame-studio#941
- ClickHouse column: `overwatch_mcp_server_scans.server_name`
- Cerberus span attribute: `hf.server_name`

🤖 Generated with [Claude Code](https://claude.com/claude-code)