### PR TITLE
feat: surface installed and fixed versions on OSV findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,7 +1109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2079,9 +2079,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -2653,9 +2653,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -3160,7 +3160,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3217,7 +3217,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3727,7 +3727,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/src/osv.rs
+++ b/src/osv.rs
@@ -163,6 +163,8 @@ struct OsvVulnerability {
     severity: Vec<OsvSeverity>,
     #[serde(default)]
     aliases: Vec<String>,
+    #[serde(default)]
+    affected: Vec<OsvAffected>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -170,6 +172,37 @@ struct OsvSeverity {
     #[serde(rename = "type")]
     severity_type: String,
     score: String,
+}
+
+/// Subset of OSV's `affected[]` we need to surface the fix version. OSV records
+/// the release a vulnerability was fixed in inside `ranges[].events[].fixed`;
+/// a record with no `fixed` event means no fix is available yet.
+#[derive(Debug, Deserialize)]
+struct OsvAffected {
+    #[serde(default)]
+    package: Option<OsvAffectedPackage>,
+    #[serde(default)]
+    ranges: Vec<OsvRange>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OsvAffectedPackage {
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    ecosystem: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct OsvRange {
+    #[serde(default)]
+    events: Vec<OsvRangeEvent>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OsvRangeEvent {
+    #[serde(default)]
+    fixed: Option<String>,
 }
 
 /// Query OSV.dev for vulnerabilities affecting `spec`. Returns an empty
@@ -266,6 +299,7 @@ fn osv_finding_to_yara_result(spec: &PackageSpec, vuln: OsvVulnerability) -> Yar
         spec.version.as_deref().unwrap_or("(any version)"),
         summary
     );
+    let fixed_version = extract_fixed_version(spec, &vuln.affected);
     YaraScanResult {
         target_type: "dependency".to_string(),
         target_name: format!(
@@ -290,6 +324,8 @@ fn osv_finding_to_yara_result(spec: &PackageSpec, vuln: OsvVulnerability) -> Yar
             tags: vec!["dependency".to_string(), "osv".to_string()],
         }),
         owasp_tags: crate::taxonomy::tags_for_yara_rule("VulnerableDependency"),
+        installed_version: spec.version.clone(),
+        fixed_version,
         phase: Some("pre-scan".to_string()),
         rules_executed: None,
         security_issues_detected: None,
@@ -297,6 +333,46 @@ fn osv_finding_to_yara_result(spec: &PackageSpec, vuln: OsvVulnerability) -> Yar
         total_matches: None,
         status: Some("warning".to_string()),
     }
+}
+
+/// Best-effort "the advisory says this is fixed in version X" signal, pulled
+/// from OSV's `affected[].ranges[].events[].fixed`. OSV can list several
+/// affected packages; we only read `fixed` from the package we queried (or an
+/// entry that carries no package object, which OSV occasionally omits), never
+/// from a different package in a multi-package advisory. This is a surfacing
+/// hint for the UI, not a precise range resolution: when a package has several
+/// ranges (e.g. parallel release branches with separate fixes) we surface the
+/// first `fixed` we find rather than resolving which range covers the installed
+/// version, since that needs per-ecosystem version comparison. The result is
+/// always a valid fix, just not necessarily the lowest one for the installed
+/// branch. Returns `None` when OSV lists no fixed version for our package.
+fn extract_fixed_version(spec: &PackageSpec, affected: &[OsvAffected]) -> Option<String> {
+    fn first_fixed(a: &OsvAffected) -> Option<String> {
+        a.ranges
+            .iter()
+            .flat_map(|r| r.events.iter())
+            .find_map(|e| e.fixed.clone())
+    }
+    let names_our_pkg = |a: &OsvAffected| {
+        a.package.as_ref().is_some_and(|p| {
+            p.name.eq_ignore_ascii_case(&spec.name)
+                && p.ecosystem.eq_ignore_ascii_case(spec.ecosystem)
+        })
+    };
+    // If the advisory explicitly names our package, trust only those entries so
+    // a sibling package's fix never leaks in. Only when nothing names our
+    // package do we fall back to entries with no package object, which OSV
+    // occasionally omits.
+    if affected.iter().any(&names_our_pkg) {
+        return affected
+            .iter()
+            .filter(|a| names_our_pkg(a))
+            .find_map(first_fixed);
+    }
+    affected
+        .iter()
+        .filter(|a| a.package.is_none())
+        .find_map(first_fixed)
 }
 
 /// Map a CVSS score string (e.g. "9.8", "CVSS:3.1/AV:N/...") to a coarse
@@ -396,5 +472,141 @@ mod tests {
             "MEDIUM"
         );
         assert_eq!(severity_label_for_cvss(""), "MEDIUM");
+    }
+
+    #[test]
+    fn extracts_fixed_version_from_affected() {
+        let vuln: OsvVulnerability = serde_json::from_value(serde_json::json!({
+            "id": "GHSA-test-fixed",
+            "summary": "bad bug",
+            "affected": [{
+                "package": { "name": "lodash", "ecosystem": "npm" },
+                "ranges": [{
+                    "type": "SEMVER",
+                    "events": [ { "introduced": "0" }, { "fixed": "4.17.21" } ]
+                }]
+            }]
+        }))
+        .expect("valid osv json");
+        let spec = PackageSpec {
+            ecosystem: "npm",
+            name: "lodash".into(),
+            version: Some("4.17.20".into()),
+        };
+        assert_eq!(
+            extract_fixed_version(&spec, &vuln.affected),
+            Some("4.17.21".to_string())
+        );
+    }
+
+    #[test]
+    fn no_fixed_version_when_absent() {
+        // A record whose only event is `introduced` (no fix released yet).
+        let vuln: OsvVulnerability = serde_json::from_value(serde_json::json!({
+            "id": "GHSA-test-nofix",
+            "affected": [{
+                "package": { "name": "lodash", "ecosystem": "npm" },
+                "ranges": [{ "type": "SEMVER", "events": [ { "introduced": "0" } ] }]
+            }]
+        }))
+        .expect("valid osv json");
+        let spec = PackageSpec {
+            ecosystem: "npm",
+            name: "lodash".into(),
+            version: Some("4.17.20".into()),
+        };
+        assert_eq!(extract_fixed_version(&spec, &vuln.affected), None);
+    }
+
+    #[test]
+    fn ignores_fix_from_a_different_package() {
+        // Multi-package advisory: our package has no fix, a sibling does. We
+        // must not borrow the sibling's fixed version.
+        let vuln: OsvVulnerability = serde_json::from_value(serde_json::json!({
+            "id": "GHSA-test-multi",
+            "affected": [
+                {
+                    "package": { "name": "lodash", "ecosystem": "npm" },
+                    "ranges": [{ "type": "SEMVER", "events": [ { "introduced": "0" } ] }]
+                },
+                {
+                    "package": { "name": "other-pkg", "ecosystem": "npm" },
+                    "ranges": [{
+                        "type": "SEMVER",
+                        "events": [ { "introduced": "0" }, { "fixed": "2.0.0" } ]
+                    }]
+                }
+            ]
+        }))
+        .expect("valid osv json");
+        let spec = PackageSpec {
+            ecosystem: "npm",
+            name: "lodash".into(),
+            version: Some("4.17.20".into()),
+        };
+        assert_eq!(extract_fixed_version(&spec, &vuln.affected), None);
+    }
+
+    #[test]
+    fn package_less_fallback_only_when_no_named_match() {
+        let spec = PackageSpec {
+            ecosystem: "npm",
+            name: "lodash".into(),
+            version: Some("4.17.20".into()),
+        };
+
+        // A named entry for our package (no fix) wins over a package-less entry
+        // that does have one: a named-but-unfixed package reports no fix.
+        let with_named: OsvVulnerability = serde_json::from_value(serde_json::json!({
+            "id": "GHSA-test-mixed",
+            "affected": [
+                {
+                    "package": { "name": "lodash", "ecosystem": "npm" },
+                    "ranges": [{ "type": "SEMVER", "events": [ { "introduced": "0" } ] }]
+                },
+                { "ranges": [{ "type": "SEMVER", "events": [ { "fixed": "9.9.9" } ] }] }
+            ]
+        }))
+        .expect("valid osv json");
+        assert_eq!(extract_fixed_version(&spec, &with_named.affected), None);
+
+        // With no named entry at all, the package-less fix is used.
+        let unlabeled: OsvVulnerability = serde_json::from_value(serde_json::json!({
+            "id": "GHSA-test-unlabeled",
+            "affected": [
+                { "ranges": [{ "type": "SEMVER", "events": [ { "fixed": "9.9.9" } ] }] }
+            ]
+        }))
+        .expect("valid osv json");
+        assert_eq!(
+            extract_fixed_version(&spec, &unlabeled.affected),
+            Some("9.9.9".to_string())
+        );
+    }
+
+    #[test]
+    fn osv_finding_populates_installed_and_fixed() {
+        let vuln: OsvVulnerability = serde_json::from_value(serde_json::json!({
+            "id": "GHSA-test-full",
+            "summary": "bug",
+            "severity": [{ "type": "CVSS_V3", "score": "9.8" }],
+            "affected": [{
+                "package": { "name": "lodash", "ecosystem": "npm" },
+                "ranges": [{
+                    "type": "SEMVER",
+                    "events": [ { "introduced": "0" }, { "fixed": "4.17.21" } ]
+                }]
+            }]
+        }))
+        .expect("valid osv json");
+        let spec = PackageSpec {
+            ecosystem: "npm",
+            name: "lodash".into(),
+            version: Some("4.17.20".into()),
+        };
+        let result = osv_finding_to_yara_result(&spec, vuln);
+        assert_eq!(result.installed_version, Some("4.17.20".to_string()));
+        assert_eq!(result.fixed_version, Some("4.17.21".to_string()));
+        assert_eq!(result.target_type, "dependency");
     }
 }

--- a/src/osv.rs
+++ b/src/osv.rs
@@ -335,6 +335,38 @@ fn osv_finding_to_yara_result(spec: &PackageSpec, vuln: OsvVulnerability) -> Yar
     }
 }
 
+/// Compare two package names within an ecosystem. PyPI treats runs of `-`,
+/// `_`, and `.` as equivalent and is case-insensitive (PEP 503), so
+/// `pip_install_test` and `pip-install-test` are the same project; OSV returns
+/// the canonical name while our spec carries the name as typed on the command
+/// line. Other ecosystems compare case-insensitively as-is.
+fn pkg_names_match(ecosystem: &str, a: &str, b: &str) -> bool {
+    if ecosystem.eq_ignore_ascii_case("PyPI") {
+        normalize_pypi_name(a) == normalize_pypi_name(b)
+    } else {
+        a.eq_ignore_ascii_case(b)
+    }
+}
+
+/// PEP 503 name normalization: lowercase and collapse any run of `-`, `_`, or
+/// `.` into a single `-`. PyPI names are ASCII, so ASCII lowercasing suffices.
+fn normalize_pypi_name(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    let mut prev_sep = false;
+    for c in name.chars() {
+        if matches!(c, '-' | '_' | '.') {
+            if !prev_sep {
+                out.push('-');
+            }
+            prev_sep = true;
+        } else {
+            out.push(c.to_ascii_lowercase());
+            prev_sep = false;
+        }
+    }
+    out
+}
+
 /// Best-effort "the advisory says this is fixed in version X" signal, pulled
 /// from OSV's `affected[].ranges[].events[].fixed`. OSV can list several
 /// affected packages; we only read `fixed` from the package we queried (or an
@@ -355,8 +387,8 @@ fn extract_fixed_version(spec: &PackageSpec, affected: &[OsvAffected]) -> Option
     }
     let names_our_pkg = |a: &OsvAffected| {
         a.package.as_ref().is_some_and(|p| {
-            p.name.eq_ignore_ascii_case(&spec.name)
-                && p.ecosystem.eq_ignore_ascii_case(spec.ecosystem)
+            p.ecosystem.eq_ignore_ascii_case(spec.ecosystem)
+                && pkg_names_match(spec.ecosystem, &p.name, &spec.name)
         })
     };
     // If the advisory explicitly names our package, trust only those entries so
@@ -581,6 +613,32 @@ mod tests {
         assert_eq!(
             extract_fixed_version(&spec, &unlabeled.affected),
             Some("9.9.9".to_string())
+        );
+    }
+
+    #[test]
+    fn matches_pypi_names_up_to_normalization() {
+        // PyPI treats pip_install_test and pip-install-test as one project; the
+        // OSV record's canonical name must still match our as-typed spec name.
+        let vuln: OsvVulnerability = serde_json::from_value(serde_json::json!({
+            "id": "GHSA-test-pypi",
+            "affected": [{
+                "package": { "name": "pip_install_test", "ecosystem": "PyPI" },
+                "ranges": [{
+                    "type": "ECOSYSTEM",
+                    "events": [ { "introduced": "0" }, { "fixed": "1.2.0" } ]
+                }]
+            }]
+        }))
+        .expect("valid osv json");
+        let spec = PackageSpec {
+            ecosystem: "PyPI",
+            name: "pip-install-test".into(),
+            version: Some("1.1.0".into()),
+        };
+        assert_eq!(
+            extract_fixed_version(&spec, &vuln.affected),
+            Some("1.2.0".to_string())
         );
     }
 

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -689,6 +689,8 @@ impl YaraScanner {
             context: generate_context_message(T::item_type(), &match_info.rule_name),
             rule_metadata: match_info.metadata.clone(),
             owasp_tags: crate::taxonomy::tags_for_yara_rule(&match_info.rule_name),
+            installed_version: None,
+            fixed_version: None,
             phase: None,
             rules_executed: None,
             security_issues_detected: None,
@@ -777,6 +779,8 @@ impl Scanner for YaraScanner {
                     ),
                     rule_metadata: None,
                     owasp_tags: Vec::new(),
+                    installed_version: None,
+                    fixed_version: None,
                     phase: Some("pre-scan".to_string()),
                     rules_executed: if stats.pre_scan_rules.is_empty() {
                         None
@@ -881,6 +885,8 @@ impl Scanner for YaraScanner {
                     ),
                     rule_metadata: None,
                     owasp_tags: Vec::new(),
+                    installed_version: None,
+                    fixed_version: None,
                     phase: Some("post-scan".to_string()),
                     rules_executed: if stats.post_scan_rules.is_empty() {
                         None
@@ -1782,6 +1788,8 @@ impl MCPScanner {
                             context: generate_context_message("server", &m.rule_name),
                             rule_metadata: m.metadata.clone(),
                             owasp_tags: crate::taxonomy::tags_for_yara_rule(&m.rule_name),
+                            installed_version: None,
+                            fixed_version: None,
                             phase: Some("pre-config".to_string()),
                             rules_executed: None,
                             security_issues_detected: None,
@@ -1823,6 +1831,8 @@ impl MCPScanner {
                                 tags: vec!["baseline".to_string()],
                             }),
                             owasp_tags: crate::taxonomy::tags_for_yara_rule("MCPConfigChanged"),
+                            installed_version: None,
+                            fixed_version: None,
                             phase: Some("pre-config".to_string()),
                             rules_executed: None,
                             security_issues_detected: None,

--- a/src/security/cross_origin_scanner.rs
+++ b/src/security/cross_origin_scanner.rs
@@ -284,6 +284,8 @@ impl CrossOriginScanner {
                 ),
                 rule_metadata: Some(metadata.clone()),
                 owasp_tags: crate::taxonomy::tags_for_yara_rule("CrossDomainContamination"),
+                installed_version: None,
+                fixed_version: None,
                 phase: Some(match self.phase {
                     ScanPhase::PreScan => "pre-scan".to_string(),
                     ScanPhase::PostScan => "post-scan".to_string(),
@@ -308,6 +310,8 @@ impl CrossOriginScanner {
                     context: "Tool or resource using different domain than majority".to_string(),
                     rule_metadata: Some(metadata.clone()),
                     owasp_tags: crate::taxonomy::tags_for_yara_rule("DomainOutlier"),
+                    installed_version: None,
+                    fixed_version: None,
                     phase: Some(match self.phase {
                         ScanPhase::PreScan => "pre-scan".to_string(),
                         ScanPhase::PostScan => "post-scan".to_string(),
@@ -349,6 +353,8 @@ impl CrossOriginScanner {
                         .to_string(),
                 rule_metadata: Some(metadata.clone()),
                 owasp_tags: crate::taxonomy::tags_for_yara_rule("MixedSecuritySchemes"),
+                installed_version: None,
+                fixed_version: None,
                 phase: Some(match self.phase {
                     ScanPhase::PreScan => "pre-scan".to_string(),
                     ScanPhase::PostScan => "post-scan".to_string(),

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -1552,6 +1552,8 @@ fn make_heuristic_finding(
             tags: Vec::new(),
         }),
         owasp_tags: crate::taxonomy::tags_for_yara_rule(rule),
+        installed_version: None,
+        fixed_version: None,
         phase: None,
         rules_executed: None,
         security_issues_detected: None,

--- a/src/types.rs
+++ b/src/types.rs
@@ -49,6 +49,15 @@ pub struct YaraScanResult {
     /// exists yet for the rule — the finding is still reported.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub owasp_tags: Vec<OwaspTag>,
+    // OSV dependency findings only: the installed package version that was
+    // matched and the version the advisory says the fix landed in (absent when
+    // OSV lists no fixed version). `default` + `skip_serializing_if` keep these
+    // omitted for every non-dependency finding and back-compatible with
+    // `replay` reading older JSON.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installed_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fixed_version: Option<String>,
     // Execution summary fields (when target_type is "summary")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub phase: Option<String>,
@@ -591,6 +600,8 @@ mod tests {
             context: "test context".to_string(),
             rule_metadata: None,
             owasp_tags: Vec::new(),
+            installed_version: None,
+            fixed_version: None,
             phase: Some("pre-scan".to_string()),
             rules_executed: Some(vec![
                 "secrets_leakage:SecretsLeakage".to_string(),


### PR DESCRIPTION
## Problem
OSV dependency findings carried the package name and advisory id but not the installed version or the version a fix landed in, so Studio can't show "installed X, fixed in Y" for supply-chain vulns (highflame-ai/highflame-overwatch#609).

## Root cause
`OsvVulnerability` never deserialized OSV's `affected[]`, where the fix version lives (`ranges[].events[].fixed`); the installed version was only embedded inside the `target_name` string.

## Fix
- Parse `affected[].ranges[].events[].fixed`, reading the fix only from the queried package (or an unlabeled entry), never a sibling in a multi-package advisory.
- Add optional `installed_version` / `fixed_version` to `YaraScanResult`, serde-skipped when empty so non-dependency findings and `replay` of older JSON stay unchanged.

These ride the `--format json` serde output the Overwatch daemon already invokes, so they reach cerberus/Studio with no renderer change.

## Verification
- `cargo test` 190 passed; `cargo clippy --all-targets` and `cargo fmt --check` clean.
- 7 OSV unit tests: fix present/absent, multi-package isolation, package-less fallback, full finding population.
- codex review: no P1. Follow-ups (P2): exact multi-range resolution against the installed version (needs per-ecosystem version comparison), and surfacing these fields in the hand-built raw/markdown/SARIF renderers.