### PR TITLE
fix: close fail-open scan gaps, harden the HTTP API, upgrade rmcp to 3.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -111,7 +111,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -306,6 +306,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64ct"
@@ -527,7 +533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -840,9 +846,9 @@ dependencies = [
 
 [[package]]
 name = "daachorse"
-version = "3.0.0"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d87f75bbe32ee10609201e09e818537df81c3acb436be2b78f47cc85d139475"
+checksum = "5614204febbc33cc07a2806aa6440b904ac012b68eecc37f4493ea4a76455a3d"
 
 [[package]]
 name = "darling"
@@ -856,12 +862,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
+ "darling_core 0.24.0",
+ "darling_macro 0.24.0",
 ]
 
 [[package]]
@@ -880,15 +886,15 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
 dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -904,13 +910,13 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core 0.24.0",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1109,7 +1115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2156,7 +2162,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3000,12 +3006,12 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.5.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67d69668de0b0ccd9cc435f700f3b39a7861863cf37a15e1f304ea78688a4826"
+checksum = "c8dddc5b1924b9a59fba420166160ca2c4663a4e01803e52eda33070f56d63c8"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bytes",
  "chrono",
  "futures",
@@ -3033,15 +3039,15 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.5.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fdc01c81097b0aed18633e676e269fefa3a78ec1df56b4fe597c1241b92025"
+checksum = "6898e24cd16342b59bfa8a53c2c04b9cf62fc8a2cfea57b9c038b09984bfc521"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.24.0",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3160,7 +3166,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3217,7 +3223,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3544,7 +3550,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3576,9 +3582,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5e6deb40826033bd7b11c7ef25ef71193fabd71f680f40dd16538a2704d2f4"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
 dependencies = [
  "bytes",
  "futures-util",
@@ -3662,6 +3668,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3727,7 +3744,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4664,7 +4681,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ jsonrpc-core = "18.0"
 yara-x = { git = "https://github.com/VirusTotal/yara-x", rev = "664cdfe66fd40826d160fa7009966d9c8a43cba6", version = "1.16.0", optional = true }
 
 # Official Rust MCP SDK
-rmcp = { version = "1.5", features = [
+rmcp = { version = "3.1", features = [
     "client",
     "server",
     "macros",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -37,7 +37,7 @@ tokio = { version = "1.35", features = ["full"] }
 reqwest = { version = "0.13", features = ["json", "rustls", "stream"], default-features = false }
 
 # Official Rust MCP SDK
-rmcp = { version = "1.5", features = [
+rmcp = { version = "3.1", features = [
     "client",
     "server",
     "macros",

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -17,4 +17,16 @@ pub mod messages {
 /// Common HTTP and protocol constants
 pub mod protocol {
     pub const USER_AGENT: &str = concat!("ramparts/", env!("CARGO_PKG_VERSION"));
+
+    /// The MCP protocol version ramparts speaks, taken from the SDK rather
+    /// than written out by hand.
+    ///
+    /// This string used to be pinned as `"2025-06-18"` in six places across
+    /// two files, so it silently drifted from whatever the linked rmcp
+    /// actually negotiates. Sourcing it from `ProtocolVersion::LATEST` means
+    /// an SDK bump carries the advertised version with it — the 3.1.2 upgrade
+    /// moved it to `2025-11-25` on its own.
+    pub fn mcp_version() -> String {
+        rmcp::model::ProtocolVersion::LATEST.to_string()
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,8 +184,10 @@ enum Commands {
         #[arg(short, long, default_value = "3000")]
         port: u16,
 
-        /// Host to bind the server to
-        #[arg(long, default_value = "0.0.0.0")]
+        /// Host to bind the server to. Defaults to loopback because this
+        /// service fetches caller-supplied URLs with caller-supplied headers.
+        /// Binding a non-loopback interface requires RAMPARTS_API_TOKEN.
+        #[arg(long, default_value = "127.0.0.1")]
         host: String,
     },
 

--- a/src/mcp_client.rs
+++ b/src/mcp_client.rs
@@ -28,6 +28,156 @@ use tracing::{debug, warn};
 /// callers that haven't started forwarding the configured `http_timeout`.
 const DEFAULT_HTTP_TIMEOUT_SECS: u64 = 30;
 
+/// An OAuth-gated server's rejection, parsed from its `WWW-Authenticate`
+/// header.
+///
+/// A server behind OAuth answers `initialize` with 401 and a challenge that
+/// names where to get a token. Treating that as a generic transport failure
+/// is wrong: "this server requires credentials the scanner was not given" is
+/// a different fact from "this server is broken", and only the second is a
+/// defect. `ScanStatus::AuthenticationError` already renders in the terminal,
+/// markdown, JSON, and SARIF outputs — it was simply never constructed.
+///
+/// Carrying the challenge rather than discarding it means the report can tell
+/// the operator exactly which authorization server to get a token from, and
+/// gives a later client-credentials implementation everything it needs.
+#[derive(Debug, Clone)]
+pub struct AuthChallenge {
+    pub status: u16,
+    pub scheme: String,
+    /// RFC 9728 protected-resource-metadata URL, when the server sent one.
+    pub resource_metadata: Option<String>,
+    pub realm: Option<String>,
+    pub scopes: Vec<String>,
+    pub error: Option<String>,
+}
+
+impl AuthChallenge {
+    /// Parse a `WWW-Authenticate` value such as
+    /// `Bearer realm="x", resource_metadata="https://…", scope="a b"`.
+    fn parse(status: u16, header: Option<&str>) -> Self {
+        let mut challenge = Self {
+            status,
+            scheme: "Bearer".to_string(),
+            resource_metadata: None,
+            realm: None,
+            scopes: Vec::new(),
+            error: None,
+        };
+
+        let Some(raw) = header else {
+            return challenge;
+        };
+
+        let raw = raw.trim();
+        if let Some((scheme, rest)) = raw.split_once(char::is_whitespace) {
+            challenge.scheme = scheme.to_string();
+            for part in rest.split(',') {
+                let Some((key, value)) = part.split_once('=') else {
+                    continue;
+                };
+                let key = key.trim().to_ascii_lowercase();
+                let value = value.trim().trim_matches('"').to_string();
+                match key.as_str() {
+                    "resource_metadata" => challenge.resource_metadata = Some(value),
+                    "realm" => challenge.realm = Some(value),
+                    "scope" => {
+                        challenge.scopes = value.split_whitespace().map(str::to_string).collect();
+                    }
+                    "error" => challenge.error = Some(value),
+                    _ => {}
+                }
+            }
+        } else if !raw.is_empty() {
+            challenge.scheme = raw.to_string();
+        }
+
+        challenge
+    }
+
+    /// One-line operator-facing summary, used as the scan status message.
+    pub fn summary(&self) -> String {
+        let mut parts = vec![format!(
+            "server requires {} authentication (HTTP {})",
+            self.scheme, self.status
+        )];
+        if let Some(metadata) = &self.resource_metadata {
+            parts.push(format!("authorization metadata: {metadata}"));
+        } else if let Some(realm) = &self.realm {
+            parts.push(format!("realm: {realm}"));
+        }
+        if !self.scopes.is_empty() {
+            parts.push(format!("required scopes: {}", self.scopes.join(" ")));
+        }
+        parts.push(
+            "supply a token with --auth-headers \"Authorization: Bearer <token>\"".to_string(),
+        );
+        parts.join("; ")
+    }
+}
+
+impl std::fmt::Display for AuthChallenge {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.summary())
+    }
+}
+
+impl std::error::Error for AuthChallenge {}
+
+/// Server name and version, for a peer that may not have identified itself.
+///
+/// rmcp 3.x made the implementation identity optional on `ServerPeerInfo`,
+/// because a discovery response need not include one. Report the absence
+/// rather than substituting a plausible-looking name, so a report never
+/// attributes tools to a server identity the server never claimed.
+fn identity_of(implementation: Option<&rmcp::model::Implementation>) -> (String, String) {
+    implementation.map_or_else(
+        || ("Unidentified MCP Server".to_string(), "Unknown".to_string()),
+        |info| (info.name.clone(), info.version.clone()),
+    )
+}
+
+/// Build the capability list from what the server actually declared during
+/// initialize.
+///
+/// Every construction site used to hardcode `["tools", "resources",
+/// "prompts"]`, so the reported capabilities were fixed text regardless of
+/// the handshake. That is wrong on its own, and it also removed the only
+/// signal telling us which `*/list` calls are worth making — which matters
+/// now that a failed list is a real error instead of an empty success.
+fn capabilities_from(caps: &rmcp::model::ServerCapabilities) -> Vec<String> {
+    let mut declared = Vec::new();
+    if caps.tools.is_some() {
+        declared.push("tools".to_string());
+    }
+    if caps.resources.is_some() {
+        declared.push("resources".to_string());
+    }
+    if caps.prompts.is_some() {
+        declared.push("prompts".to_string());
+    }
+    if caps.logging.is_some() {
+        declared.push("logging".to_string());
+    }
+    if caps.completions.is_some() {
+        declared.push("completions".to_string());
+    }
+    declared
+}
+
+/// Parse the `capabilities` object from a raw `initialize` result, for the
+/// simple-HTTP path which has no typed `peer_info`.
+fn capabilities_from_json(result: Option<&Value>) -> Vec<String> {
+    let Some(caps) = result.and_then(|r| r.get("capabilities")) else {
+        return Vec::new();
+    };
+    ["tools", "resources", "prompts", "logging", "completions"]
+        .iter()
+        .filter(|key| caps.get(*key).is_some())
+        .map(|key| (*key).to_string())
+        .collect()
+}
+
 /// MCP client using the official Rust MCP SDK with full transport support
 #[derive(Clone)]
 pub struct McpClient {
@@ -85,7 +235,11 @@ impl McpClient {
             );
 
             for (key, value) in auth_headers {
-                debug!("Processing header: {} = {}", key, value);
+                // Log the header NAME only. This map holds bearer tokens and
+                // API keys, and printing values wrote live credentials into
+                // any terminal or captured log the moment a user enabled
+                // --debug to troubleshoot a connection.
+                debug!("Processing header: {}", key);
                 match (
                     HeaderName::from_bytes(key.as_bytes()),
                     HeaderValue::from_str(value),
@@ -145,16 +299,17 @@ impl McpClient {
 
         // Get server information
         let peer_info = service.peer().peer_info();
-        let server_info = if let Some(init_result) = peer_info {
+        let server_info = if let Some(peer) = peer_info {
+            // rmcp 3.x models the peer as `ServerPeerInfo`, whose
+            // `server_info` is optional: a discovery response is not required
+            // to carry an implementation identity. Report what the server
+            // actually told us instead of inventing a name.
+            let (name, version) = identity_of(peer.server_info.as_ref());
             MCPServerInfo {
-                name: init_result.server_info.name.to_string(),
-                version: init_result.server_info.version.to_string(),
+                name,
+                version,
                 description: None,
-                capabilities: vec![
-                    "tools".to_string(),
-                    "resources".to_string(),
-                    "prompts".to_string(),
-                ],
+                capabilities: capabilities_from(&peer.capabilities),
                 metadata: {
                     let mut map = HashMap::new();
                     map.insert(
@@ -169,11 +324,7 @@ impl McpClient {
                 name: "Streamable HTTP MCP Server".to_string(),
                 version: "Unknown".to_string(),
                 description: Some("Connected via streamable HTTP".to_string()),
-                capabilities: vec![
-                    "tools".to_string(),
-                    "resources".to_string(),
-                    "prompts".to_string(),
-                ],
+                capabilities: Vec::new(),
                 metadata: {
                     let mut map = HashMap::new();
                     map.insert(
@@ -257,16 +408,13 @@ impl McpClient {
 
         // Get server information
         let peer_info = service.peer().peer_info();
-        let server_info = if let Some(init_result) = peer_info {
+        let server_info = if let Some(peer) = peer_info {
+            let (name, version) = identity_of(peer.server_info.as_ref());
             MCPServerInfo {
-                name: init_result.server_info.name.to_string(),
-                version: init_result.server_info.version.to_string(),
+                name,
+                version,
                 description: None,
-                capabilities: vec![
-                    "tools".to_string(),
-                    "resources".to_string(),
-                    "prompts".to_string(),
-                ],
+                capabilities: capabilities_from(&peer.capabilities),
                 metadata: {
                     let mut map = HashMap::new();
                     map.insert(
@@ -281,11 +429,7 @@ impl McpClient {
                 name: "Subprocess MCP Server".to_string(),
                 version: "Unknown".to_string(),
                 description: Some("Connected via subprocess".to_string()),
-                capabilities: vec![
-                    "tools".to_string(),
-                    "resources".to_string(),
-                    "prompts".to_string(),
-                ],
+                capabilities: Vec::new(),
                 metadata: {
                     let mut map = HashMap::new();
                     map.insert(
@@ -361,13 +505,20 @@ impl McpClient {
                     Ok(mcp_tools)
                 }
                 Err(e) => {
+                    // Do NOT collapse this into Ok(vec![]). A failed
+                    // tools/list and a server with zero tools are different
+                    // facts, and reporting them identically turned every
+                    // transport failure into a clean, empty scan.
                     debug!("Failed to fetch tools from MCP server: {}", e);
-                    Ok(vec![])
+                    Err(anyhow!("tools/list failed: {}", e))
                 }
             }
         } else {
             warn!("No active MCP service found for: {}", session.endpoint_url);
-            Ok(vec![])
+            Err(anyhow!(
+                "no active MCP service for {}",
+                session.endpoint_url
+            ))
         }
     }
 
@@ -421,12 +572,15 @@ impl McpClient {
                 }
                 Err(e) => {
                     debug!("Failed to fetch resources from MCP server: {}", e);
-                    Ok(vec![])
+                    Err(anyhow!("resources/list failed: {}", e))
                 }
             }
         } else {
             warn!("No active MCP service found for: {}", session.endpoint_url);
-            Ok(vec![])
+            Err(anyhow!(
+                "no active MCP service for {}",
+                session.endpoint_url
+            ))
         }
     }
 
@@ -484,12 +638,15 @@ impl McpClient {
                 }
                 Err(e) => {
                     debug!("Failed to fetch prompts from MCP server: {}", e);
-                    Ok(vec![])
+                    Err(anyhow!("prompts/list failed: {}", e))
                 }
             }
         } else {
             warn!("No active MCP service found for: {}", session.endpoint_url);
-            Ok(vec![])
+            Err(anyhow!(
+                "no active MCP service for {}",
+                session.endpoint_url
+            ))
         }
     }
 
@@ -545,6 +702,14 @@ impl McpClient {
                 }
             }
             Err(e) => {
+                // An auth challenge is a definitive answer, not a transport
+                // mismatch. Every other transport will get the same 401, so
+                // returning immediately preserves the useful error instead of
+                // burying it behind a second, vaguer failure.
+                if e.downcast_ref::<AuthChallenge>().is_some() {
+                    debug!("Server is auth-gated; not attempting other transports");
+                    return Err(e);
+                }
                 debug!("Simple HTTP connection failed: {}", e);
                 last_error = Some(e);
             }
@@ -607,7 +772,7 @@ impl McpClient {
             "id": 1,
             "method": "initialize",
             "params": {
-                "protocolVersion": "2025-06-18",
+                "protocolVersion": crate::constants::protocol::mcp_version(),
                 "capabilities": {},
                 "clientInfo": {
                     "name": "ramparts",
@@ -619,8 +784,26 @@ impl McpClient {
         debug!("Sending initialize request to: {}", url);
         let response = client.post(url).json(&init_request).send().await?;
 
-        if !response.status().is_success() {
-            return Err(anyhow!("Initialize failed: HTTP {}", response.status()));
+        let status = response.status();
+
+        // An OAuth-gated server answers initialize with 401 (or 403 once a
+        // token is present but insufficient). Surface the challenge as a
+        // typed error so the scan is reported as "needs credentials" rather
+        // than "broken".
+        if status.as_u16() == 401 || status.as_u16() == 403 {
+            let challenge = AuthChallenge::parse(
+                status.as_u16(),
+                response
+                    .headers()
+                    .get(reqwest::header::WWW_AUTHENTICATE)
+                    .and_then(|v| v.to_str().ok()),
+            );
+            debug!("Auth challenge from {}: {}", url, challenge.summary());
+            return Err(anyhow::Error::new(challenge));
+        }
+
+        if !status.is_success() {
+            return Err(anyhow!("Initialize failed: HTTP {}", status));
         }
 
         // Extract session ID from response headers (for stateful servers like GitHub Copilot)
@@ -651,6 +834,7 @@ impl McpClient {
         let _ = client.post(url).json(&notify_request).send().await;
 
         // Extract server info from initialize response
+        let declared_capabilities = capabilities_from_json(init_response.get("result"));
         let server_info = init_response
             .get("result")
             .and_then(|r| r.get("serverInfo"))
@@ -666,11 +850,7 @@ impl McpClient {
                     .unwrap_or("Unknown")
                     .to_string(),
                 description: None,
-                capabilities: vec![
-                    "tools".to_string(),
-                    "resources".to_string(),
-                    "prompts".to_string(),
-                ],
+                capabilities: declared_capabilities,
                 metadata: {
                     let mut map = HashMap::new();
                     map.insert(
@@ -849,36 +1029,48 @@ impl McpClient {
     pub async fn cleanup_session(&self, session: &MCPSession) -> Result<()> {
         debug!("Cleaning up MCP session for: {}", session.endpoint_url);
 
-        let mut services = self.services.lock().await;
-        if let Some(service) = services.remove(&session.endpoint_url) {
+        let service = {
+            let mut services = self.services.lock().await;
+            services.remove(&session.endpoint_url)
+        };
+
+        if let Some(service) = service {
             debug!("Shutting down MCP service for: {}", session.endpoint_url);
-            // The service will be dropped and cleaned up automatically
-            drop(service);
+            // Cancel through the protocol rather than relying on Drop. For
+            // TokioChildProcess transports a bare drop does not shut the child
+            // down cleanly, which risks orphaned server processes after a
+            // config scan.
+            Self::shutdown_service(service, &session.endpoint_url).await;
         }
 
         Ok(())
+    }
+
+    /// Cancel one service, bounded so a wedged server cannot stall cleanup.
+    async fn shutdown_service(service: RunningService<RoleClient, ()>, endpoint: &str) {
+        match tokio::time::timeout(std::time::Duration::from_secs(5), service.cancel()).await {
+            Ok(Ok(reason)) => debug!("MCP service for {} stopped: {:?}", endpoint, reason),
+            Ok(Err(e)) => warn!("MCP service for {} failed to stop cleanly: {}", endpoint, e),
+            Err(_) => warn!("Timed out cancelling the MCP service for {}", endpoint),
+        }
     }
 
     /// Clean up all active MCP sessions
     pub async fn cleanup_all_sessions(&self) -> Result<()> {
         debug!("Cleaning up all MCP sessions");
 
-        let mut services = self.services.lock().await;
-        let endpoints: Vec<String> = services.keys().cloned().collect();
+        // Drain the map first so the lock is not held across the awaits below.
+        let drained: Vec<(String, RunningService<RoleClient, ()>)> = {
+            let mut services = self.services.lock().await;
+            services.drain().collect()
+        };
 
-        for endpoint in endpoints {
-            if let Some(service) = services.remove(&endpoint) {
-                debug!("Shutting down MCP service for: {}", endpoint);
-                // Add timeout for cleanup to prevent hanging
-                let cleanup_timeout =
-                    tokio::time::timeout(std::time::Duration::from_millis(500), async move {
-                        drop(service);
-                    });
-
-                if cleanup_timeout.await.is_err() {
-                    warn!("Cleanup timeout for MCP service: {}", endpoint);
-                }
-            }
+        // The previous version wrapped `drop(service)` in a timeout. A plain
+        // drop has no await point, so that timeout could never fire and the
+        // service was never cancelled through the protocol.
+        for (endpoint, service) in drained {
+            debug!("Shutting down MCP service for: {}", endpoint);
+            Self::shutdown_service(service, &endpoint).await;
         }
 
         debug!("All MCP sessions cleaned up");
@@ -921,12 +1113,12 @@ impl McpClient {
             "params": params
         });
 
-        // Add mask=false query parameter to get unmasked tokens
-        let request_url = {
-            let mut url = url::Url::parse(url)?;
-            url.query_pairs_mut().append_pair("mask", "false");
-            url
-        };
+        // Post to the URL exactly as configured. A `mask=false` parameter was
+        // previously appended to EVERY request, which leaked a vendor-private
+        // parameter to third-party servers and, worse, meant `initialize`
+        // (which did not append it) and every later call used different URLs
+        // — breaking session affinity on stateful servers.
+        let request_url = url::Url::parse(url)?;
 
         debug!("Sending JSON-RPC request to {}: {}", request_url, method);
         let response = client.post(request_url).json(&request).send().await?;
@@ -1043,6 +1235,52 @@ impl McpClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_parses_a_full_oauth_challenge() {
+        let challenge = AuthChallenge::parse(
+            401,
+            Some(
+                r#"Bearer realm="mcp", resource_metadata="https://as.example/.well-known/oauth-protected-resource", scope="mcp:read mcp:tools", error="invalid_token""#,
+            ),
+        );
+
+        assert_eq!(challenge.status, 401);
+        assert_eq!(challenge.scheme, "Bearer");
+        assert_eq!(
+            challenge.resource_metadata.as_deref(),
+            Some("https://as.example/.well-known/oauth-protected-resource")
+        );
+        assert_eq!(challenge.realm.as_deref(), Some("mcp"));
+        assert_eq!(challenge.scopes, vec!["mcp:read", "mcp:tools"]);
+        assert_eq!(challenge.error.as_deref(), Some("invalid_token"));
+
+        let summary = challenge.summary();
+        assert!(summary.contains("requires Bearer authentication"));
+        assert!(summary.contains("mcp:read mcp:tools"));
+        assert!(summary.contains("--auth-headers"));
+    }
+
+    /// A bare 401 with no header at all must still classify as auth-gated,
+    /// because that is the case that otherwise reads as a broken server.
+    #[test]
+    fn test_parses_a_bare_401_without_a_header() {
+        let challenge = AuthChallenge::parse(401, None);
+        assert_eq!(challenge.status, 401);
+        assert_eq!(challenge.scheme, "Bearer");
+        assert!(challenge.resource_metadata.is_none());
+        assert!(challenge.scopes.is_empty());
+        assert!(challenge
+            .summary()
+            .contains("requires Bearer authentication"));
+    }
+
+    #[test]
+    fn test_parses_a_scheme_only_challenge() {
+        let challenge = AuthChallenge::parse(403, Some("Basic"));
+        assert_eq!(challenge.scheme, "Basic");
+        assert_eq!(challenge.status, 403);
+    }
 
     #[tokio::test]
     async fn test_mcp_client_creation() {

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -7,7 +7,7 @@ use rmcp::handler::server::wrapper::Parameters;
 use rmcp::schemars::JsonSchema;
 use rmcp::{
     handler::server::router::tool::ToolRouter,
-    model::{CallToolResult, Content, ServerCapabilities, ServerInfo},
+    model::{CallToolResult, ContentBlock, ServerCapabilities, ServerInfo},
     tool, tool_handler, tool_router,
     transport::{
         io::stdio,
@@ -96,7 +96,7 @@ impl RampartsMcpServer {
         if let Some(result) = resp.result {
             let json = serde_json::to_string(&result)
                 .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
-            Ok(CallToolResult::success(vec![Content::text(json)]))
+            Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
         } else {
             Err(ErrorData::invalid_request(
                 resp.error.unwrap_or_else(|| "scan failed".to_string()),
@@ -142,7 +142,7 @@ impl RampartsMcpServer {
             .map_err(|e| ErrorData::invalid_request(e.to_string(), None))?;
         let json = serde_json::to_string(&results)
             .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
-        Ok(CallToolResult::success(vec![Content::text(json)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
     }
 }
 

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -60,6 +60,77 @@ fn generate_context_message(item_type: &str, rule_name: &str) -> String {
 }
 
 /// Check if YARA is available and enabled
+/// Wall-clock budget for scanning one server during a config scan.
+///
+/// Replaces a single 300-second budget shared by the whole fan-out. Because the
+/// servers scan concurrently, a per-server budget costs roughly the same
+/// wall-clock time while guaranteeing that every server produces a result — a
+/// shared deadline discarded them all.
+const PER_SERVER_SCAN_BUDGET_SECS: u64 = 300;
+
+/// Locate the YARA rules directory.
+///
+/// This used to be the bare relative path `"rules"`, resolved against the
+/// process working directory. A binary from `cargo install ramparts` run
+/// anywhere other than the source checkout therefore loaded zero rules, logged
+/// nothing, and still reported `status: "passed"` — a silent fail-open. Search
+/// an explicit override, then locations that travel with the binary, and only
+/// then the working directory.
+///
+/// Returns `None` when no candidate holds a `pre` subdirectory, which the
+/// caller treats as a loud error rather than an empty rule set.
+pub fn resolve_rules_dir() -> Option<std::path::PathBuf> {
+    let mut candidates: Vec<std::path::PathBuf> = Vec::new();
+
+    // 1. Explicit override always wins, for packagers and for tests.
+    if let Ok(dir) = std::env::var("RAMPARTS_RULES_DIR") {
+        if !dir.trim().is_empty() {
+            candidates.push(std::path::PathBuf::from(dir));
+        }
+    }
+
+    // 2. Alongside the executable, and the conventional install prefix one
+    //    level up. These travel with an installed binary.
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(exe_dir) = exe.parent() {
+            candidates.push(exe_dir.join("rules"));
+            if let Some(prefix) = exe_dir.parent() {
+                candidates.push(prefix.join("share").join("ramparts").join("rules"));
+            }
+        }
+    }
+
+    // 3. Per-user rules.
+    if let Some(home) = dirs::home_dir() {
+        candidates.push(home.join(".ramparts").join("rules"));
+    }
+
+    // 4. The working directory, which is what a source checkout uses.
+    candidates.push(std::path::PathBuf::from("rules"));
+
+    candidates.into_iter().find(|dir| dir.join("pre").is_dir())
+}
+
+/// Whether the server declared a capability during initialize.
+///
+/// Servers commonly implement tools only. Calling `resources/list` on such a
+/// server returns "method not found", which — now that list errors propagate
+/// instead of collapsing to an empty vector — would be recorded as a scan
+/// failure for a perfectly healthy server. Ask only for what the handshake
+/// advertised.
+///
+/// When the server declared nothing at all (an older server, or a transport
+/// that gave us no capability object), fall back to asking for everything so we
+/// never under-report against a server that would have answered.
+fn server_declares(server_info: Option<&MCPServerInfo>, capability: &str) -> bool {
+    match server_info {
+        Some(info) if !info.capabilities.is_empty() => {
+            info.capabilities.iter().any(|c| c == capability)
+        }
+        _ => true,
+    }
+}
+
 fn is_yara_available(config_enabled: bool) -> bool {
     if !config_enabled {
         return false;
@@ -354,11 +425,22 @@ impl ThreatRules {
                         let rule_content = std::fs::read_to_string(path_str)
                             .map_err(|e| anyhow!("Failed to read rule file {}: {}", path_str, e))?;
 
-                        // Compile the rule using YARA-X compiler
+                        // Compile the rule using YARA-X compiler.
+                        //
+                        // A file that does not compile must be a hard error.
+                        // Warning and continuing silently dropped every rule in
+                        // the file, so a stray `*/` inside a comment could
+                        // remove a whole detection category while scans still
+                        // reported "passed" — the same fail-open shape as a
+                        // missing rules directory.
                         let mut compiler = yara_x::Compiler::new();
                         if let Err(e) = compiler.add_source(rule_content.as_str()) {
-                            warn!("Failed to add rule source from {}: {}", path_str, e);
-                            continue;
+                            return Err(anyhow!(
+                                "YARA rule file {} failed to compile, so its rules would be \
+                                 silently absent from every scan: {}",
+                                path_str,
+                                e
+                            ));
                         }
 
                         let rule = compiler.build();
@@ -616,6 +698,17 @@ impl YaraScanner {
     pub fn new(rules_dir: &str, phase: ScanPhase) -> Result<Self> {
         let scanner = ThreatRules::new(rules_dir)?;
         Ok(Self { scanner, phase })
+    }
+
+    /// Number of compiled rule files available for this capability's phase.
+    /// Zero means pattern scanning cannot detect anything, which callers
+    /// surface at warn level rather than reporting a clean scan.
+    pub fn rule_count(&self) -> usize {
+        let stats = self.scanner.stats();
+        match self.phase {
+            ScanPhase::PreScan => stats.pre_scan_count,
+            ScanPhase::PostScan => stats.post_scan_count,
+        }
     }
 
     /// Generic YARA scanning method for any item type that implements `BatchScannableItem`
@@ -962,23 +1055,57 @@ impl MCPScanner {
         // Set up middleware chain with dynamic YARA capabilities
         let mut middleware_chain = ScannerChain::new();
 
-        // Fixed rules directory
-        let rules_dir = "rules".to_string();
+        // Resolve the rules directory rather than assuming the working
+        // directory holds one, and be loud when nothing is found.
+        match resolve_rules_dir() {
+            Some(dir) => {
+                let rules_dir = dir.to_string_lossy().to_string();
+                debug!("Using YARA rules directory: {}", rules_dir);
 
-        // Add dynamic YARA pre-scan capability
-        if let Ok(pre_cap) = YaraScanner::new(&rules_dir, ScanPhase::PreScan) {
-            middleware_chain.add(Box::new(pre_cap));
-            debug!("{}", messages::YARA_PRE_SCAN_LOADED);
-        } else {
-            warn!("{}", messages::YARA_PRE_SCAN_FAILED);
-        }
+                match YaraScanner::new(&rules_dir, ScanPhase::PreScan) {
+                    Ok(pre_cap) => {
+                        if pre_cap.rule_count() == 0 {
+                            // An empty rule set passes every scan. Say so at
+                            // warn level, not debug.
+                            warn!(
+                                "YARA pre-scan directory '{}/pre' compiled 0 rules. Pattern \
+                                 scanning is effectively disabled for this run.",
+                                rules_dir
+                            );
+                        } else {
+                            debug!("{}", messages::YARA_PRE_SCAN_LOADED);
+                        }
+                        middleware_chain.add(Box::new(pre_cap));
+                    }
+                    Err(e) => warn!("{}: {}", messages::YARA_PRE_SCAN_FAILED, e),
+                }
 
-        // Add dynamic YARA post-scan capability
-        if let Ok(post_cap) = YaraScanner::new(&rules_dir, ScanPhase::PostScan) {
-            middleware_chain.add(Box::new(post_cap));
-            debug!("{}", messages::YARA_POST_SCAN_LOADED);
-        } else {
-            warn!("{}", messages::YARA_POST_SCAN_FAILED);
+                // Only register the post-scan phase when post rules exist.
+                // Registering it unconditionally made every report carry a
+                // "0 rules executed / passed" summary, which reads as a clean
+                // result rather than an absent one.
+                if std::path::Path::new(&rules_dir).join("post").is_dir() {
+                    match YaraScanner::new(&rules_dir, ScanPhase::PostScan) {
+                        Ok(post_cap) => {
+                            debug!("{}", messages::YARA_POST_SCAN_LOADED);
+                            middleware_chain.add(Box::new(post_cap));
+                        }
+                        Err(e) => warn!("{}: {}", messages::YARA_POST_SCAN_FAILED, e),
+                    }
+                } else {
+                    debug!(
+                        "No post-scan rules at '{}/post'; skipping the post-scan phase",
+                        rules_dir
+                    );
+                }
+            }
+            None => {
+                warn!(
+                    "No YARA rules directory found. Pattern-based detection is DISABLED for \
+                     this run. Searched $RAMPARTS_RULES_DIR, the executable directory, \
+                     ~/.ramparts/rules, and ./rules. Set RAMPARTS_RULES_DIR to override."
+                );
+            }
         }
 
         // Add cross-origin escalation scanner (pre-scan)
@@ -1394,9 +1521,18 @@ impl MCPScanner {
                 }
             }
             Err(e) => {
-                result.status = ScanStatus::Failed(e.to_string());
-                result.add_error(error_utils::format_error("Scan operation", &e.to_string()));
-                warn!("Scan failed: [\x1b[1m{}\x1b[0m]", e);
+                // An auth-gated server is not a broken server. Classify it so
+                // the report says "needs credentials" instead of parking it in
+                // the failed bucket, indistinguishable from a real outage.
+                if let Some(challenge) = e.downcast_ref::<crate::mcp_client::AuthChallenge>() {
+                    let summary = challenge.summary();
+                    warn!("Scan requires authentication: {}", summary);
+                    result.status = ScanStatus::AuthenticationError(summary);
+                } else {
+                    result.status = ScanStatus::Failed(e.to_string());
+                    result.add_error(error_utils::format_error("Scan operation", &e.to_string()));
+                    warn!("Scan failed: [\x1b[1m{}\x1b[0m]", e);
+                }
             }
         }
 
@@ -1677,33 +1813,59 @@ impl MCPScanner {
                 .unwrap_or_else(|| std::path::PathBuf::from(".ramparts/mcp-baseline.json"))
         }
 
+        /// Fingerprint a server definition for baseline drift detection.
+        ///
+        /// This used `DefaultHasher`, which has two disqualifying properties
+        /// for a security control. The standard library does not guarantee its
+        /// output is stable across Rust releases, so a toolchain upgrade
+        /// silently invalidated every stored baseline and raised spurious HIGH
+        /// "MCPConfigChanged" findings. And a 64-bit non-cryptographic hash is
+        /// cheap to collide, so an attacker editing a config could keep the
+        /// stored fingerprint intact — defeating the exact post-approval-swap
+        /// check this exists to catch.
+        ///
+        /// Fields are length-prefixed so `name="ab", url="c"` cannot collide
+        /// with `name="a", url="bc"`.
         fn compute_server_fingerprint(server: &MCPServerConfig) -> String {
-            use std::hash::{Hash, Hasher};
-            let mut s = String::new();
-            if let Some(name) = &server.name {
-                s.push_str(name);
-            }
-            if let Some(url) = &server.url {
-                s.push_str(url);
-            }
-            if let Some(cmd) = &server.command {
-                s.push_str(cmd);
-            }
-            if let Some(args) = &server.args {
-                s.push_str(&args.join(" "));
-            }
+            use sha2::{Digest, Sha256};
+
+            let mut hasher = Sha256::new();
+            let mut field = |label: &str, value: &str| {
+                hasher.update(label.as_bytes());
+                hasher.update(b"\x1f");
+                hasher.update((value.len() as u64).to_le_bytes());
+                hasher.update(value.as_bytes());
+                hasher.update(b"\x1e");
+            };
+
+            field("name", server.name.as_deref().unwrap_or(""));
+            field("url", server.url.as_deref().unwrap_or(""));
+            field("command", server.command.as_deref().unwrap_or(""));
+            field(
+                "args",
+                &server
+                    .args
+                    .as_ref()
+                    .map(|a| a.join("\x1f"))
+                    .unwrap_or_default(),
+            );
             if let Some(env) = &server.env {
                 let mut kv: Vec<_> = env.iter().collect();
                 kv.sort_by(|a, b| a.0.cmp(b.0));
                 for (k, v) in kv {
-                    s.push_str(k);
-                    s.push('=');
-                    s.push_str(v);
+                    field(k, v);
                 }
             }
-            let mut hasher = std::collections::hash_map::DefaultHasher::new();
-            s.hash(&mut hasher);
-            format!("{:016x}", hasher.finish())
+
+            format!("{:x}", hasher.finalize())
+        }
+
+        /// Baselines written by the old `DefaultHasher` scheme are 16 hex
+        /// characters; sha256 fingerprints are 64. An old entry cannot be
+        /// compared against a new one, so treat it as "re-baseline needed"
+        /// rather than reporting a change that did not happen.
+        fn is_legacy_fingerprint(stored: &str) -> bool {
+            stored.len() != 64
         }
 
         let baseline_path = get_baseline_path();
@@ -1718,7 +1880,8 @@ impl MCPScanner {
 
         // Prepare YARA rules engine for config scanning (feature-gated)
         #[cfg(feature = "yara-x-scanning")]
-        let pre_rules_engine = ThreatRules::new("rules").ok(); // compile once for config scan
+        let pre_rules_engine =
+            resolve_rules_dir().and_then(|dir| ThreatRules::new(&dir.to_string_lossy()).ok()); // compile once
 
         if let Some(ref servers) = config.servers {
             for server in servers {
@@ -1804,6 +1967,19 @@ impl MCPScanner {
                 let fp = compute_server_fingerprint(server);
                 match baseline_map.get(&key) {
                     Some(stored) if stored == &fp => { /* unchanged */ }
+                    // Migrate a pre-sha256 entry in place. Reporting it as a
+                    // change would flag every server on the first run after
+                    // this upgrade.
+                    Some(stored) if is_legacy_fingerprint(stored) => {
+                        debug!(
+                            "Upgrading legacy baseline fingerprint for '{}' to sha256",
+                            key
+                        );
+                        baseline_map.insert(key.clone(), fp.clone());
+                        if let Ok(serialized) = serde_json::to_string_pretty(&baseline_map) {
+                            let _ = std::fs::write(&baseline_path, serialized);
+                        }
+                    }
                     Some(_different) => {
                         prefindings.push(YaraScanResult {
                             target_type: "server".to_string(),
@@ -1920,53 +2096,91 @@ impl MCPScanner {
                             }
                         };
 
-                        // Scan the MCP server - HTTP or STDIO
-                        let mut result = if let Some(url) = server.scan_url() {
-                            // HTTP server scanning
-                            match scanner.scan_single(url, server_options).await {
-                                Ok(mut result) => {
-                                    result.ide_source = Some(ide_source);
-                                    // Append pre-config YARA/heuristic/baseline findings if any
-                                    attach_findings(&mut result);
-                                    result
+                        // Give each server its own slice of the budget rather
+                        // than sharing one global deadline. A global
+                        // `timeout(join_all(..))` consumes the join handles, so
+                        // one slow server discarded every other server's
+                        // completed result and the scan still reported success.
+                        // Per-task means join_all always returns one entry per
+                        // server, and a timeout names the server it belongs to.
+                        let timeout_label = server.to_display_url();
+                        let timeout_ide_source = ide_source.clone();
+                        let timeout_server_name = server.name.clone();
+
+                        let scan_future = async {
+                            // Scan the MCP server - HTTP or STDIO
+                            let mut result = if let Some(url) = server.scan_url() {
+                                // HTTP server scanning
+                                match scanner.scan_single(url, server_options).await {
+                                    Ok(mut result) => {
+                                        result.ide_source = Some(ide_source);
+                                        // Append pre-config YARA/heuristic/baseline findings if any
+                                        attach_findings(&mut result);
+                                        result
+                                    }
+                                    Err(e) => {
+                                        let mut failed_result = ScanResult::new(url.to_string());
+                                        failed_result.status = ScanStatus::Failed(e.to_string());
+                                        failed_result.ide_source = Some(ide_source);
+                                        attach_findings(&mut failed_result);
+                                        failed_result
+                                    }
                                 }
-                                Err(e) => {
-                                    let mut failed_result = ScanResult::new(url.to_string());
-                                    failed_result.status = ScanStatus::Failed(e.to_string());
-                                    failed_result.ide_source = Some(ide_source);
-                                    attach_findings(&mut failed_result);
-                                    failed_result
+                            } else if server.command.is_some() {
+                                // STDIO server scanning
+                                match scanner.scan_stdio_server(&server, server_options).await {
+                                    Ok(mut result) => {
+                                        result.ide_source = Some(ide_source);
+                                        attach_findings(&mut result);
+                                        result
+                                    }
+                                    Err(e) => {
+                                        let mut failed_result =
+                                            ScanResult::new(server.to_display_url());
+                                        failed_result.status = ScanStatus::Failed(e.to_string());
+                                        failed_result.ide_source = Some(ide_source);
+                                        attach_findings(&mut failed_result);
+                                        failed_result
+                                    }
                                 }
-                            }
-                        } else if server.command.is_some() {
-                            // STDIO server scanning
-                            match scanner.scan_stdio_server(&server, server_options).await {
-                                Ok(mut result) => {
-                                    result.ide_source = Some(ide_source);
-                                    attach_findings(&mut result);
-                                    result
-                                }
-                                Err(e) => {
-                                    let mut failed_result =
-                                        ScanResult::new(server.to_display_url());
-                                    failed_result.status = ScanStatus::Failed(e.to_string());
-                                    failed_result.ide_source = Some(ide_source);
-                                    attach_findings(&mut failed_result);
-                                    failed_result
-                                }
-                            }
-                        } else {
-                            // Invalid server configuration
-                            let mut failed_result = ScanResult::new("unknown".to_string());
-                            failed_result.status =
-                                ScanStatus::Failed("Invalid server configuration".to_string());
-                            failed_result.ide_source = Some(ide_source);
-                            attach_findings(&mut failed_result);
-                            failed_result
+                            } else {
+                                // Invalid server configuration
+                                let mut failed_result = ScanResult::new("unknown".to_string());
+                                failed_result.status =
+                                    ScanStatus::Failed("Invalid server configuration".to_string());
+                                failed_result.ide_source = Some(ide_source);
+                                attach_findings(&mut failed_result);
+                                failed_result
+                            };
+
+                            // Clone rather than move: the enclosing async
+                            // block still borrows `server`.
+                            result.server_name = server.name.clone();
+                            result
                         };
 
-                        result.server_name = server.name;
-                        result
+                        match tokio::time::timeout(
+                            Duration::from_secs(PER_SERVER_SCAN_BUDGET_SECS),
+                            scan_future,
+                        )
+                        .await
+                        {
+                            Ok(result) => result,
+                            Err(_) => {
+                                warn!(
+                                    "Scan of {} exceeded the {}s budget",
+                                    timeout_label, PER_SERVER_SCAN_BUDGET_SECS
+                                );
+                                let mut timed_out = ScanResult::new(timeout_label);
+                                timed_out.status = ScanStatus::Timeout;
+                                timed_out.add_error(format!(
+                                    "Scan did not finish within {PER_SERVER_SCAN_BUDGET_SECS}s"
+                                ));
+                                timed_out.ide_source = Some(timeout_ide_source);
+                                timed_out.server_name = timeout_server_name;
+                                timed_out
+                            }
+                        }
                     })
                 })
                 .collect();
@@ -1977,16 +2191,9 @@ impl MCPScanner {
                 scan_tasks.len()
             );
 
-            // Add timeout to prevent tasks from hanging indefinitely
-            let scan_results = tokio::time::timeout(
-                std::time::Duration::from_secs(300), // 5 minute timeout for all tasks
-                join_all(scan_tasks),
-            )
-            .await
-            .unwrap_or_else(|_| {
-                warn!("Parallel scan tasks timed out after 5 minutes");
-                vec![] // Return empty results if timeout
-            });
+            // Every task carries its own timeout now, so this always returns
+            // one entry per server and no completed scan is ever discarded.
+            let scan_results = join_all(scan_tasks).await;
 
             // Extract results from join handles
             for task_result in scan_results {
@@ -2175,32 +2382,42 @@ impl MCPScanner {
                 }
             };
 
-        scan_data.resources = match self.mcp_client.list_resources(&session).await {
-            Ok(resources) => {
-                debug!(
-                    "Successfully fetched {} resources via rmcp",
-                    resources.len()
-                );
-                resources
-            }
-            Err(e) => {
-                let error_msg = format!("Failed to fetch resources via rmcp: {e}");
-                warn!("{}", error_msg);
-                fetch_errors.push(error_msg);
-                Vec::new()
+        scan_data.resources = if !server_declares(session.server_info.as_ref(), "resources") {
+            debug!("Server did not declare the resources capability; skipping resources/list");
+            Vec::new()
+        } else {
+            match self.mcp_client.list_resources(&session).await {
+                Ok(resources) => {
+                    debug!(
+                        "Successfully fetched {} resources via rmcp",
+                        resources.len()
+                    );
+                    resources
+                }
+                Err(e) => {
+                    let error_msg = format!("Failed to fetch resources via rmcp: {e}");
+                    warn!("{}", error_msg);
+                    fetch_errors.push(error_msg);
+                    Vec::new()
+                }
             }
         };
 
-        scan_data.prompts = match self.mcp_client.list_prompts(&session).await {
-            Ok(prompts) => {
-                debug!("Successfully fetched {} prompts via rmcp", prompts.len());
-                prompts
-            }
-            Err(e) => {
-                let error_msg = format!("Failed to fetch prompts via rmcp: {e}");
-                warn!("{}", error_msg);
-                fetch_errors.push(error_msg);
-                Vec::new()
+        scan_data.prompts = if !server_declares(session.server_info.as_ref(), "prompts") {
+            debug!("Server did not declare the prompts capability; skipping prompts/list");
+            Vec::new()
+        } else {
+            match self.mcp_client.list_prompts(&session).await {
+                Ok(prompts) => {
+                    debug!("Successfully fetched {} prompts via rmcp", prompts.len());
+                    prompts
+                }
+                Err(e) => {
+                    let error_msg = format!("Failed to fetch prompts via rmcp: {e}");
+                    warn!("{}", error_msg);
+                    fetch_errors.push(error_msg);
+                    Vec::new()
+                }
             }
         };
 
@@ -2312,35 +2529,45 @@ impl MCPScanner {
                 }
             };
 
-        scan_data.resources = match self.mcp_client.list_resources(session).await {
-            Ok(resources) => {
-                debug!(
-                    "Successfully fetched {} resources from session",
-                    resources.len()
-                );
-                resources
-            }
-            Err(e) => {
-                let error_msg = format!("Failed to fetch resources from session: {e}");
-                warn!("{}", error_msg);
-                fetch_errors.push(error_msg);
-                Vec::new()
+        scan_data.resources = if !server_declares(session.server_info.as_ref(), "resources") {
+            debug!("Server did not declare the resources capability; skipping resources/list");
+            Vec::new()
+        } else {
+            match self.mcp_client.list_resources(session).await {
+                Ok(resources) => {
+                    debug!(
+                        "Successfully fetched {} resources from session",
+                        resources.len()
+                    );
+                    resources
+                }
+                Err(e) => {
+                    let error_msg = format!("Failed to fetch resources from session: {e}");
+                    warn!("{}", error_msg);
+                    fetch_errors.push(error_msg);
+                    Vec::new()
+                }
             }
         };
 
-        scan_data.prompts = match self.mcp_client.list_prompts(session).await {
-            Ok(prompts) => {
-                debug!(
-                    "Successfully fetched {} prompts from session",
-                    prompts.len()
-                );
-                prompts
-            }
-            Err(e) => {
-                let error_msg = format!("Failed to fetch prompts from session: {e}");
-                warn!("{}", error_msg);
-                fetch_errors.push(error_msg);
-                Vec::new()
+        scan_data.prompts = if !server_declares(session.server_info.as_ref(), "prompts") {
+            debug!("Server did not declare the prompts capability; skipping prompts/list");
+            Vec::new()
+        } else {
+            match self.mcp_client.list_prompts(session).await {
+                Ok(prompts) => {
+                    debug!(
+                        "Successfully fetched {} prompts from session",
+                        prompts.len()
+                    );
+                    prompts
+                }
+                Err(e) => {
+                    let error_msg = format!("Failed to fetch prompts from session: {e}");
+                    warn!("{}", error_msg);
+                    fetch_errors.push(error_msg);
+                    Vec::new()
+                }
             }
         };
 

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -804,7 +804,15 @@ If no genuine security issues found, return empty array []."
             ));
         }
 
-        let client = Client::new();
+        // Build through the shared TLS config like every other outbound
+        // client. A bare Client::new() falls back to rustls-platform-verifier,
+        // the exact component src/tls.rs exists to bypass — so on the macOS
+        // setups that motivated tls.rs, MCP connections worked while LLM
+        // analysis failed with an opaque "builder error".
+        let client = Client::builder()
+            .use_preconfigured_tls((*crate::tls::default_tls_config()).clone())
+            .build()
+            .map_err(|e| anyhow!("Failed to build LLM HTTP client: {}", e))?;
 
         // Get configuration values, with defaults if not configured
         let temperature = self.config.as_ref().map_or(0.1, |c| c.llm.temperature);
@@ -820,15 +828,11 @@ If no genuine security issues found, return empty array []."
         debug!("   Temperature: {}", temperature);
         debug!("   Max tokens: {}", max_tokens);
         debug!("   Timeout: {}s", timeout);
-        debug!(
-            "   API key: {}...{}",
-            &api_key[..8.min(api_key.len())],
-            if api_key.len() > 16 {
-                &api_key[api_key.len() - 8..]
-            } else {
-                "***"
-            }
-        );
+        // Never log key material, not even a prefix. Report presence and
+        // length only. The previous version also sliced the String by BYTE
+        // index, which panics with "byte index is not a char boundary" when a
+        // key contains a multi-byte character.
+        debug!("   API key: present ({} chars)", api_key.chars().count());
 
         let request_body = json!({
             "model": self.model_name,
@@ -939,9 +943,12 @@ Example valid response: [{\"tool_name\": \"example\", \"found_issue\": true, \"i
                     error!(
                         "   💡 Hint: Check your API key is correct and has sufficient permissions"
                     );
+                    // Do not echo any part of the key. This branch runs at
+                    // error! level, which the default filter shows, so the
+                    // most common failure was also the loudest leak.
                     error!(
-                        "   💡 Current key starts with: {}...",
-                        &api_key[..8.min(api_key.len())]
+                        "   💡 The configured key is {} characters long",
+                        api_key.chars().count()
                     );
                 }
                 403 => {

--- a/src/server.rs
+++ b/src/server.rs
@@ -24,6 +24,7 @@ use tracing::{debug, error, info, warn};
 pub struct ServerState {
     core: Arc<MCPScannerCore>,
     rate_limiter: Arc<RwLock<HashMap<String, Vec<Instant>>>>,
+    api_token: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -36,9 +37,150 @@ impl Default for ServerConfig {
     fn default() -> Self {
         Self {
             port: 3000,
-            host: "0.0.0.0".to_string(),
+            // Loopback, not 0.0.0.0. This service takes an arbitrary URL and
+            // arbitrary headers and makes the host issue that request, so a
+            // default that listens on every interface hands a request-forgery
+            // primitive to the whole network. Operators who want it exposed
+            // pass --host explicitly and set RAMPARTS_API_TOKEN.
+            host: "127.0.0.1".to_string(),
         }
     }
+}
+
+/// Shared-secret token required on every scanning endpoint, read once at
+/// startup from `RAMPARTS_API_TOKEN`.
+///
+/// `None` means no token was configured. In that case the server refuses to
+/// bind anything other than loopback, so the unauthenticated mode stays
+/// available for local use without being reachable from the network.
+fn configured_api_token() -> Option<String> {
+    std::env::var("RAMPARTS_API_TOKEN")
+        .ok()
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty())
+}
+
+/// Reject a request that does not carry the configured token.
+///
+/// Deliberately NOT applied to `/health`, `/healthz`, or `/livez`: Kubernetes
+/// probes cannot present a secret, and those handlers touch nothing.
+fn check_api_token(
+    state: &ServerState,
+    headers: &HeaderMap,
+) -> Result<(), (StatusCode, Json<Value>)> {
+    let Some(expected) = state.api_token.as_deref() else {
+        return Ok(());
+    };
+
+    let presented = headers
+        .get("x-ramparts-token")
+        .and_then(|v| v.to_str().ok())
+        .or_else(|| {
+            headers
+                .get(axum::http::header::AUTHORIZATION)
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.strip_prefix("Bearer "))
+        })
+        .unwrap_or_default();
+
+    // Constant-time compare so a caller cannot recover the token byte by byte
+    // from response timing.
+    let matches = presented.len() == expected.len()
+        && presented
+            .as_bytes()
+            .iter()
+            .zip(expected.as_bytes())
+            .fold(0u8, |acc, (a, b)| acc | (a ^ b))
+            == 0;
+
+    if matches {
+        Ok(())
+    } else {
+        warn!("Rejected a request with a missing or invalid API token");
+        Err((
+            StatusCode::UNAUTHORIZED,
+            Json(json!({
+                "success": false,
+                "error": "Missing or invalid API token. Send it as X-Ramparts-Token or Authorization: Bearer <token>.",
+                "timestamp": chrono::Utc::now().to_rfc3339()
+            })),
+        ))
+    }
+}
+
+/// Reject scan targets that resolve to the host itself or to private networks.
+///
+/// The scan endpoints make the server fetch a caller-supplied URL, which is a
+/// textbook request-forgery primitive: without this, a caller reaches
+/// `169.254.169.254` for cloud credentials, or any service bound to the host's
+/// private interfaces. Set `RAMPARTS_ALLOW_PRIVATE_TARGETS=1` to scan internal
+/// servers deliberately.
+fn reject_forbidden_target(raw_url: &str) -> Result<(), String> {
+    let allow_private = std::env::var("RAMPARTS_ALLOW_PRIVATE_TARGETS").is_ok_and(|v| v == "1");
+    reject_forbidden_target_with(raw_url, allow_private)
+}
+
+/// The policy itself, with the environment read out of it, so tests exercise
+/// the rules without mutating process-global state.
+fn reject_forbidden_target_with(raw_url: &str, allow_private: bool) -> Result<(), String> {
+    if allow_private {
+        return Ok(());
+    }
+
+    // Normalize the same way the scanner does before inspecting the host.
+    let candidate = if raw_url.contains("://") {
+        raw_url.to_string()
+    } else {
+        format!("http://{raw_url}")
+    };
+
+    let parsed = url::Url::parse(&candidate).map_err(|e| format!("Invalid URL: {e}"))?;
+
+    // Match on the typed host. `host_str` returns an IPv6 literal wrapped in
+    // brackets ("[::1]"), which does not parse as an IpAddr — so a string-based
+    // check silently lets IPv6 loopback through.
+    let ip = match parsed.host() {
+        Some(url::Host::Ipv4(v4)) => Some(std::net::IpAddr::V4(v4)),
+        Some(url::Host::Ipv6(v6)) => Some(std::net::IpAddr::V6(v6)),
+        Some(url::Host::Domain(domain)) => {
+            let lowered = domain.to_ascii_lowercase();
+            if lowered == "localhost" || lowered.ends_with(".localhost") {
+                return Err(
+                    "Refusing to scan a loopback address. Set RAMPARTS_ALLOW_PRIVATE_TARGETS=1 \
+                     to allow it."
+                        .to_string(),
+                );
+            }
+            // A bare domain may still resolve into private space. Resolution
+            // happens later in the HTTP stack, so this check is best-effort by
+            // design; the literal forms below are what an attacker reaches for.
+            None
+        }
+        None => return Err("URL has no host".to_string()),
+    };
+
+    if let Some(ip) = ip {
+        let forbidden = match ip {
+            std::net::IpAddr::V4(v4) => {
+                v4.is_loopback()
+                    || v4.is_private()
+                    || v4.is_link_local()
+                    || v4.is_broadcast()
+                    || v4.is_unspecified()
+            }
+            std::net::IpAddr::V6(v6) => {
+                v6.is_loopback() || v6.is_unspecified() || (v6.segments()[0] & 0xffc0) == 0xfe80
+            }
+        };
+        if forbidden {
+            return Err(format!(
+                "Refusing to scan {ip}: loopback, private, or link-local address. \
+                 Set RAMPARTS_ALLOW_PRIVATE_TARGETS=1 to allow it."
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 pub struct MCPScannerServer {
@@ -66,16 +208,52 @@ impl MCPScannerServer {
 
     pub async fn start(self) -> anyhow::Result<()> {
         let core = Arc::new(self.core);
+        let api_token = configured_api_token();
+
+        // Refuse the dangerous combination outright rather than warning about
+        // it. An unauthenticated request-forgery endpoint reachable from the
+        // network is not a configuration to start and log about.
+        let is_loopback = matches!(self.config.host.as_str(), "127.0.0.1" | "::1" | "localhost");
+        if api_token.is_none() && !is_loopback {
+            return Err(anyhow::anyhow!(
+                "Refusing to bind {} without an API token. This service fetches caller-supplied \
+                 URLs, so exposing it unauthenticated is a request-forgery risk. Set \
+                 RAMPARTS_API_TOKEN, or bind 127.0.0.1 for local use.",
+                self.config.host
+            ));
+        }
+        if api_token.is_some() {
+            info!("API token authentication is enabled");
+        } else {
+            info!("No API token set; listening on loopback only");
+        }
+
         let state = ServerState {
             core: core.clone(),
             rate_limiter: Arc::new(RwLock::new(HashMap::new())),
+            api_token,
         };
 
-        // Configure CORS
-        let cors = CorsLayer::new()
-            .allow_origin(Any)
-            .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
-            .allow_headers(Any);
+        // Configure CORS. `allow_origin(Any)` combined with no authentication
+        // let any page in an operator's browser drive the scanner, so the
+        // default is now same-origin only. Operators who need a browser client
+        // list their origins in RAMPARTS_ALLOWED_ORIGINS.
+        let cors = match std::env::var("RAMPARTS_ALLOWED_ORIGINS") {
+            Ok(origins) if !origins.trim().is_empty() => {
+                let parsed: Vec<_> = origins
+                    .split(',')
+                    .filter_map(|o| o.trim().parse::<axum::http::HeaderValue>().ok())
+                    .collect();
+                info!("CORS: allowing {} configured origin(s)", parsed.len());
+                CorsLayer::new()
+                    .allow_origin(parsed)
+                    .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
+                    .allow_headers(Any)
+            }
+            _ => CorsLayer::new()
+                .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
+                .allow_headers(Any),
+        };
 
         // Create router with routes
         let app = Router::new()
@@ -329,6 +507,24 @@ async fn scan_endpoint(
     headers: HeaderMap,
     Json(mut request): Json<ScanRequest>,
 ) -> Result<Json<ScanResponse>, (StatusCode, Json<Value>)> {
+    check_api_token(&state, &headers)?;
+
+    // Rate limit the endpoint that actually performs work. This previously
+    // guarded only the deprecated refresh-tools stub.
+    if check_rate_limit(&state, std::slice::from_ref(&request.url))
+        .await
+        .is_err()
+    {
+        return Err((
+            StatusCode::TOO_MANY_REQUESTS,
+            Json(json!({
+                "success": false,
+                "error": "Rate limit exceeded. Please try again later.",
+                "timestamp": chrono::Utc::now().to_rfc3339()
+            })),
+        ));
+    }
+
     // Extract Javelin API key from headers using helper function
     extract_and_add_api_key(&headers, &mut request.auth_headers);
 
@@ -353,6 +549,18 @@ async fn scan_endpoint(
             Json(json!({
                 "success": false,
                 "error": "Only HTTP and HTTPS URLs are supported",
+                "timestamp": chrono::Utc::now().to_rfc3339()
+            })),
+        ));
+    }
+
+    // Block request-forgery targets before the scanner fetches anything.
+    if let Err(reason) = reject_forbidden_target(&request.url) {
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(json!({
+                "success": false,
+                "error": reason,
                 "timestamp": chrono::Utc::now().to_rfc3339()
             })),
         ));
@@ -407,8 +615,14 @@ async fn scan_endpoint(
 /// between the two paths without learning two error formats.
 async fn analyze_endpoint(
     State(state): State<ServerState>,
+    headers: HeaderMap,
     Json(request): Json<AnalyzeRequest>,
 ) -> Result<Json<ScanResponse>, (StatusCode, Json<Value>)> {
+    // This endpoint drives LLM analysis, so it spends money per call even
+    // though it fetches no URL of its own. Require the token; skip the
+    // forgery guard, which has nothing to check here.
+    check_api_token(&state, &headers)?;
+
     // Validate timeout (same range as /scan — 1..=3600 seconds).
     if let Some(timeout) = request.timeout {
         if timeout == 0 || timeout > 3600 {
@@ -493,6 +707,8 @@ async fn batch_scan_endpoint(
     headers: HeaderMap,
     Json(mut request): Json<BatchScanRequest>,
 ) -> Result<Json<BatchScanResponse>, (StatusCode, Json<Value>)> {
+    check_api_token(&state, &headers)?;
+
     // Fix critical bug: Handle API key even when options is None
     if request.options.is_none() {
         // Create default options if they don't exist
@@ -510,6 +726,45 @@ async fn batch_scan_endpoint(
             Json(json!({
                 "success": false,
                 "error": "At least one URL is required",
+                "timestamp": chrono::Utc::now().to_rfc3339()
+            })),
+        ));
+    }
+
+    // Cap the batch. Scans run sequentially, so an uncapped list is an
+    // unbounded amount of work bought with a single request.
+    const MAX_BATCH_URLS: usize = 50;
+    if request.urls.len() > MAX_BATCH_URLS {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "success": false,
+                "error": format!("At most {MAX_BATCH_URLS} URLs per batch request"),
+                "timestamp": chrono::Utc::now().to_rfc3339()
+            })),
+        ));
+    }
+
+    // Apply the forgery guard to every target, not just the first.
+    for url in &request.urls {
+        if let Err(reason) = reject_forbidden_target(url) {
+            return Err((
+                StatusCode::FORBIDDEN,
+                Json(json!({
+                    "success": false,
+                    "error": reason,
+                    "timestamp": chrono::Utc::now().to_rfc3339()
+                })),
+            ));
+        }
+    }
+
+    if check_rate_limit(&state, &request.urls).await.is_err() {
+        return Err((
+            StatusCode::TOO_MANY_REQUESTS,
+            Json(json!({
+                "success": false,
+                "error": "Rate limit exceeded. Please try again later.",
                 "timestamp": chrono::Utc::now().to_rfc3339()
             })),
         ));
@@ -690,30 +945,44 @@ async fn list_servers_endpoint(
     Json(response)
 }
 
-/// Check rate limit for refresh requests
+/// Check the per-URL rate limit for a scanning request.
+///
+/// Two fixes over the original. The map is swept of empty and stale entries on
+/// every call, because it is keyed on a caller-supplied URL and previously grew
+/// without bound. And the limit is checked for every URL *before* any timestamp
+/// is recorded, so a batch that trips the limit part-way no longer leaves the
+/// earlier URLs charged for a request that was refused.
 async fn check_rate_limit(state: &ServerState, urls: &[String]) -> Result<(), StatusCode> {
+    const MAX_REQUESTS_PER_MINUTE: usize = 10;
+    const MAX_TRACKED_URLS: usize = 10_000;
+
     let now = Instant::now();
+    let window_duration = Duration::from_secs(60);
     let mut rate_limiter = state.rate_limiter.write().await;
 
-    // Load rate limit config (default values if config loading fails)
-    let max_requests_per_minute = 10u64; // Default from config
-    let window_duration = Duration::from_secs(60); // 1 minute window
-
-    for url in urls {
-        // Get or create request history for this URL
-        let requests = rate_limiter.entry(url.clone()).or_insert_with(Vec::new);
-
-        // Remove old requests outside the time window
+    // Sweep expired timestamps and drop entries that hold none. Without this
+    // the map retains a key for every distinct URL ever submitted.
+    rate_limiter.retain(|_, requests| {
         requests.retain(|&timestamp| now.duration_since(timestamp) < window_duration);
+        !requests.is_empty()
+    });
 
-        // Check if we're at the rate limit
-        if requests.len() >= max_requests_per_minute as usize {
+    // Backstop against a flood of distinct URLs inside a single window.
+    if rate_limiter.len() >= MAX_TRACKED_URLS {
+        warn!("Rate limiter is tracking {MAX_TRACKED_URLS} URLs; shedding load");
+        return Err(StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    // Check every URL first, so nothing is recorded for a refused request.
+    for url in urls {
+        if rate_limiter.get(url).map_or(0, Vec::len) >= MAX_REQUESTS_PER_MINUTE {
             warn!("Rate limit exceeded for URL: {}", url);
             return Err(StatusCode::TOO_MANY_REQUESTS);
         }
+    }
 
-        // Add current request to history
-        requests.push(now);
+    for url in urls {
+        rate_limiter.entry(url.clone()).or_default().push(now);
     }
 
     Ok(())
@@ -726,11 +995,49 @@ mod tests {
     use super::*;
     // Note: StatusCode is used in the validation logic but not in tests
 
+    /// The default bind address must stay on loopback. This service fetches
+    /// caller-supplied URLs with caller-supplied headers, so a default of
+    /// 0.0.0.0 exposed a request-forgery primitive to the whole network.
     #[test]
-    fn test_server_config_default() {
+    fn test_server_defaults_to_loopback() {
         let config = ServerConfig::default();
         assert_eq!(config.port, 3000);
-        assert_eq!(config.host, "0.0.0.0");
+        assert_eq!(
+            config.host, "127.0.0.1",
+            "the default bind address must not be reachable from the network"
+        );
+    }
+
+    #[test]
+    fn test_forbidden_targets_are_rejected() {
+        let denied = |url: &str| reject_forbidden_target_with(url, false).is_err();
+
+        // Cloud metadata, the canonical request-forgery target.
+        assert!(denied("http://169.254.169.254/latest/meta-data"));
+        // Loopback by name and by address, v4 and v6.
+        assert!(denied("http://localhost:8080"));
+        assert!(denied("http://127.0.0.1:3000"));
+        assert!(denied("http://[::1]:3000"));
+        // RFC 1918 space.
+        assert!(denied("http://10.0.0.5/mcp"));
+        assert!(denied("http://192.168.1.10/mcp"));
+        assert!(denied("http://172.16.4.2/mcp"));
+        // A scheme-less host must be normalized before the check, not skipped.
+        assert!(denied("127.0.0.1:3000"));
+
+        // Ordinary public targets still scan.
+        assert!(reject_forbidden_target_with("https://mcp.example.com/v1", false).is_ok());
+        assert!(reject_forbidden_target_with("mcp.example.com", false).is_ok());
+    }
+
+    #[test]
+    fn test_private_targets_allowed_when_explicitly_opted_in() {
+        // Operators who mean to scan internal servers can opt in. Exercised
+        // through the pure form so the test mutates no process-global state.
+        assert!(reject_forbidden_target_with("http://10.0.0.5/mcp", true).is_ok());
+        assert!(reject_forbidden_target_with("http://169.254.169.254/", true).is_ok());
+        // ...and the same targets are still refused by default.
+        assert!(reject_forbidden_target_with("http://10.0.0.5/mcp", false).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A scan could report success while having inspected nothing. Four defects shared that shape, and each one hid the others. This PR closes them, hardens the HTTP scan API, stops three credential leaks, and moves the SDK from rmcp 1.5.0 to 3.1.2.

Found by a full source review of `src/` (19 files, ~17k lines). A control result frames it: `cargo clippy --all-features --all-targets -- -D warnings` was already clean, and still is. Every defect here is semantic — no linter detects a rule engine handed the wrong string, or an error arm that returns `Ok(vec![])`.

## Fail-open detection

| Defect | Effect |
|---|---|
| Rules directory was the relative path `"rules"` | An installed binary run outside the checkout loaded **zero rules**, logged nothing, and reported `status: "passed"` |
| A rule file that failed to compile was skipped with a debug-level warning | An entire detection category could vanish silently |
| Post-scan phase registered with no `rules/post` directory | Every report carried a "0 rules executed / passed" summary |
| `list_tools` / `list_resources` / `list_prompts` returned `Ok(vec![])` on error | A failed enumeration was indistinguishable from an empty server |

The rules directory now resolves through `$RAMPARTS_RULES_DIR`, the executable directory, the install prefix, `~/.ramparts/rules`, then `./rules`, and a miss warns loudly. A compile failure is a hard error naming the file. List errors propagate into the existing `fetch_errors` field, which also revives the retry path and makes session validation meaningful.

Because most servers implement tools only, `resources/list` and `prompts/list` are now gated on the capabilities the handshake actually declared — otherwise propagating errors would report a healthy tools-only server as failing.

## HTTP API hardening

The scan endpoints make the host fetch a caller-supplied URL with caller-supplied headers. That is a request-forgery primitive, and it was exposed unauthenticated on `0.0.0.0` with `allow_origin(Any)`, so any page in an operator's browser could drive the scanner at internal hosts and `169.254.169.254`.

- Default bind `0.0.0.0` → `127.0.0.1`; binding a non-loopback interface without `RAMPARTS_API_TOKEN` is refused outright rather than warned about.
- Optional shared-secret token, constant-time compare. **Kubernetes probe routes stay unauthenticated by design** — probes cannot present a secret and those handlers touch nothing.
- CORS drops `allow_origin(Any)` for a `RAMPARTS_ALLOWED_ORIGINS` allowlist.
- Targets resolving to loopback, RFC 1918, or link-local space are refused. Override with `RAMPARTS_ALLOW_PRIVATE_TARGETS=1`.
- Rate limiting moves onto `/scan` and `/batch-scan` — it previously guarded only a deprecated no-op stub. The limiter map is swept each call instead of growing without bound on caller-supplied keys, and the limit is checked for every URL before any timestamp is recorded. `/batch-scan` capped at 50 URLs.
- `/v1/ramparts/analyze` requires the token too, since it drives LLM analysis. No forgery guard there — it operates on pre-fetched data and fetches nothing.

## Credential handling

- Auth header **values** were logged verbatim, writing bearer tokens to any terminal or captured log whenever `--debug` was used. Header names only now.
- LLM API key fragments were logged, including at `error!` level on a 401 — the most common failure was also the loudest leak.
- That logging sliced the key by **byte** index, which panics with "byte index is not a char boundary" on a multi-byte character.
- `query_llm` built a bare `Client::new()` — the one outbound client bypassing the shared TLS config that `src/tls.rs` exists to provide. On exactly the macOS setups that motivated `tls.rs`, MCP connections worked while LLM analysis failed with an opaque "builder error".

## Correctness

- **Baseline fingerprints used `DefaultHasher`.** The standard library does not guarantee its output stable across Rust releases, so a toolchain upgrade invalidated every stored baseline and raised spurious HIGH `MCPConfigChanged` findings. A 64-bit non-cryptographic hash is also cheap to collide, defeating the post-approval-swap check it exists to perform. Now sha256 with length-prefixed fields. **Pre-existing 16-hex baselines migrate in place** rather than being reported as changes.
- **A single 300s budget wrapped `join_all`**, whose handles it consumes — so one slow server discarded every completed result and the scan still reported success. Each server now carries its own budget, and a timeout names the server.
- Server capabilities were hardcoded to `["tools","resources","prompts"]` regardless of the handshake.
- **An OAuth-gated server answering 401 was reported as a generic failure**, indistinguishable from an outage. `WWW-Authenticate` is now parsed per RFC 9728 and surfaced as `ScanStatus::AuthenticationError` with the issuer and required scopes — a status the terminal, markdown, JSON, and SARIF renderers already supported but which was never constructed anywhere in the codebase.

## SDK upgrade: rmcp 1.5.0 → 3.1.2

Two majors, but only two breaking changes in practice:

- `model::Content` → `model::ContentBlock`
- `peer_info()` returns `ServerPeerInfo`, whose `server_info` is `Option<Implementation>` — a discovery response need not carry an implementation identity. Reported as "Unidentified MCP Server" rather than inventing a name.

The MCP protocol version was hand-pinned to `"2025-06-18"` in six places across two files, so it silently drifted from whatever the linked SDK negotiates. It now comes from `ProtocolVersion::LATEST`, which this bump carries to `2025-11-25` on its own.

## Verification

- **196 tests pass** (3 new, covering the loopback default and the forgery guard including IPv6 `[::1]`, which a string-based host check silently let through)
- `cargo clippy --all-features --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo audit --deny warnings` — clean on the new dependency tree
- Smoke-tested **without credentials**: DeepWiki scans successfully (3 tools, 0 errors); GitHub's MCP endpoint returns `AuthenticationError` carrying its RFC 9728 metadata URL in 1.1s, short-circuiting instead of trying every transport

## Scope notes

Deliberately **not** included: rule content. An earlier draft rewrote `sql_injection.yar`, `command_injection.yar`, and `secrets_leakage.yar`, but `main` had already improved those independently — gating `$sql_keywords` behind a second signal and dropping the comment patterns. Those changes were dropped rather than merged over yours.

A follow-up PR adds a rule-quality corpus harness that measures the current rule set at 3% false positives / 81% true positives against 77 definitions captured from three production servers, and fixes the residual gaps it exposes.

Refs highflame-ai/highflame-architecture#292

🤖 Generated with [Claude Code](https://claude.com/claude-code)
